### PR TITLE
Fix webhook property lookup and sanitize handover note editing

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -776,7 +776,7 @@ function onOpen(){
 }
 
 function notifyChat_(message){
-  const url = PropertiesService.getScriptProperties().getProperty('');
+  const url = (PropertiesService.getScriptProperties().getProperty('CHAT_WEBHOOK_URL') || '').trim();
   if (!url) { Logger.log('CHAT_WEBHOOK_URL 未設定'); return; }
   const payload = JSON.stringify({ text: message });
   UrlFetchApp.fetch(url, {

--- a/src/app.html
+++ b/src/app.html
@@ -214,6 +214,7 @@
 function q(id){ return document.getElementById(id); }
 function val(id){ return q(id).value.trim(); }
 function setv(id,v){ q(id).value=v; }
+function jsString(s){ return JSON.stringify(String(s == null ? '' : s)); }
 function pid(){ return val('pid'); }
 
 let _flags = { receipt:false, handout:false, consentHandout:false, consentObtained:false };
@@ -510,21 +511,22 @@ function loadHandovers(){
         return;
       }
       box.innerHTML = list.map(h => {
-  const imgs = (h.files || []).map(u =>
-    `<img src="${u}" style="max-width:120px;max-height:120px;border-radius:8px;margin:4px;border:1px solid #e5e7eb">`
-  ).join('');
+        const imgs = (h.files || []).map(u =>
+          `<img src="${u}" style="max-width:120px;max-height:120px;border-radius:8px;margin:4px;border:1px solid #e5e7eb">`
+        ).join('');
+        const noteArg = jsString(h.note || '');
 
-  return `<div class="news-item">
-    <div class="muted">${h.when} ／ ${escapeHtml(h.user||'')}</div>
-    <div>${escapeHtml(h.note||'').replace(/\n/g,'<br>')}</div>
-    <div style="margin-top:4px">${imgs}</div>
-    <div class="btnrow" style="margin-top:6px">
-      <button class="btn ghost" onclick="editHandover(${h.row}, \`${h.note||''}\`)">編集</button>
-      <button class="btn warn" onclick="deleteHandover(${h.row})">削除</button>
-    </div>
-  </div>`;
-}).join('');
-
+        return `
+        <div class="news-item">
+          <div class="muted">${h.when} ／ ${escapeHtml(h.user||'')}</div>
+          <div>${escapeHtml(h.note||'').replace(/\n/g,'<br>')}</div>
+          <div style="margin-top:4px">${imgs}</div>
+          <div class="btnrow" style="margin-top:6px">
+            <button class="btn ghost" onclick='editHandover(${h.row}, ${noteArg})'>編集</button>
+            <button class="btn warn" onclick="deleteHandover(${h.row})">削除</button>
+          </div>
+        </div>`;
+      }).join('');
 
     })
     .withFailureHandler(e=>{


### PR DESCRIPTION
## Summary
- trim and read the chat webhook URL from the proper script property before posting notifications
- escape handover notes when wiring edit buttons so inline handlers cannot break on template markers

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d14ba8170083218a9d6afe9abdb4e2