### PR TITLE
Add clinical coordination summary and metrics graphs

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -48,7 +48,24 @@
   /* 申し送り（画像プレビュー） */
   .thumbs{ display:flex; flex-wrap:wrap; gap:8px; margin-top:8px }
   .thumbs img{ max-width:120px; max-height:120px; border-radius:8px; border:1px solid #e5e7eb }
+  .metric-rows{ margin-top:6px; display:flex; flex-direction:column; gap:8px }
+  .metric-row{ display:flex; flex-wrap:wrap; gap:8px; align-items:center; background:#f8fafc; padding:8px; border-radius:12px }
+  .metric-row select{ flex:1 1 180px; min-width:140px }
+  .metric-row input[type="number"]{ width:110px }
+  .metric-row .metric-unit{ color:var(--muted); font-size:0.85rem }
+  .metric-row input.metric-note{ flex:1 1 160px; min-width:140px }
+  .metric-row button{ flex:0 0 auto }
+  .metric-empty{ color:var(--muted); font-size:0.85rem }
+  .icf-summary{ margin-top:8px; padding:12px; border-radius:12px; background:#f9fafb; color:var(--fg); }
+  .icf-summary .icf-meta{ font-size:0.85rem; color:var(--muted); margin-bottom:6px }
+  .icf-section{ margin-top:8px; }
+  .icf-section-title{ font-weight:600; margin-bottom:4px }
+  .trend-container{ margin-top:12px; display:flex; flex-direction:column; gap:16px }
+  .trend-item{ padding:12px; border:1px solid #e5e7eb; border-radius:12px; background:#fff; }
+  .trend-item h4{ margin:0 0 6px; font-size:15px }
+  .trend-meta{ font-size:0.85rem; color:var(--muted); margin-top:6px }
 </style>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js"></script>
 </head>
 <body>
 <div class="wrap">
@@ -103,6 +120,14 @@
           </div>
         </div>
 
+        <div class="section-title" style="margin-top:12px">臨床指標（任意入力）</div>
+        <div class="muted" style="font-size:0.9rem">痛みVASや可動域など数値化した情報を記録すると、自動で経過グラフを作成します。</div>
+        <div id="metricInputs" class="metric-rows"></div>
+        <div class="btnrow" style="margin-top:6px">
+          <button class="btn ghost" onclick="addMetricRow()">指標を追加</button>
+          <button class="btn ghost" onclick="clearMetricRows()">指標クリア</button>
+        </div>
+
         <!-- 保存行＋外部向けレポート -->
         <div class="btnrow" style="margin-top:8px">
           <button class="btn ok" onclick="save()">保存（施術録）</button>
@@ -134,6 +159,21 @@
       <div class="card">
         <div class="section-title">当月の施術記録（この患者）</div>
         <div id="list"></div>
+      </div>
+
+      <div class="card">
+        <div class="section-title">臨床・ケア連携（β）</div>
+        <div class="muted" style="font-size:0.9rem">ICFサマリと臨床指標のグラフをワンクリックで表示します。</div>
+        <div class="btnrow" style="margin:8px 0">
+          <button class="btn ghost" onclick="generateIcfSummary()">ICFサマリを生成</button>
+          <button class="btn ghost" onclick="loadClinicalTrends(true)">グラフを再読込</button>
+        </div>
+        <div id="icfSummaryBox" class="icf-summary">
+          <div class="muted">ICFサマリを生成するとここに表示されます。</div>
+        </div>
+        <div id="clinicalTrendBox" class="trend-container">
+          <div class="muted">臨床指標の記録がまだありません。</div>
+        </div>
       </div>
 
       <!-- レポート下書き（4問ガイド） -->
@@ -220,9 +260,291 @@ function pid(){ return val('pid'); }
 let _flags = { receipt:false, handout:false, consentHandout:false, consentObtained:false };
 let _pendingVisitPlanDate = null;
 let _reportType = null;
+let METRIC_DEFS = [];
+let METRIC_DEF_MAP = {};
+let _metricRowSeq = 0;
+let _clinicalCharts = {};
 
 function resetFlags(){ _flags={receipt:false,handout:false,consentHandout:false,consentObtained:false}; _pendingVisitPlanDate=null; }
 
+function loadMetricDefinitions(){
+  google.script.run.withSuccessHandler(defs=>{
+    METRIC_DEFS = Array.isArray(defs) ? defs : [];
+    METRIC_DEF_MAP = {};
+    METRIC_DEFS.forEach(d=>{ METRIC_DEF_MAP[d.id] = d; });
+    clearMetricRows();
+  }).getClinicalMetricDefinitions();
+}
+
+function ensureMetricEmptyMessage(){
+  const box = q('metricInputs');
+  if (!box) return;
+  const hasRow = box.querySelector('[data-metric-row]');
+  let empty = box.querySelector('.metric-empty');
+  if (!hasRow) {
+    if (!empty){
+      empty = document.createElement('div');
+      empty.className = 'metric-empty';
+      empty.textContent = '必要に応じて「指標を追加」から入力してください。';
+      box.appendChild(empty);
+    }
+  } else if (empty) {
+    empty.remove();
+  }
+}
+
+function addMetricRow(prefill){
+  if (!METRIC_DEFS.length){
+    alert('指標マスタが未設定です');
+    return;
+  }
+  const box = q('metricInputs');
+  if (!box) return;
+  ensureMetricEmptyMessage();
+  const row = document.createElement('div');
+  row.className = 'metric-row';
+  const rowId = ++_metricRowSeq;
+  row.dataset.metricRow = String(rowId);
+
+  const sel = document.createElement('select');
+  METRIC_DEFS.forEach(def => {
+    const opt = document.createElement('option');
+    opt.value = def.id;
+    opt.textContent = def.unit ? `${def.label} (${def.unit})` : def.label;
+    sel.appendChild(opt);
+  });
+  row.appendChild(sel);
+
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.step = '0.5';
+  row.appendChild(input);
+
+  const unit = document.createElement('span');
+  unit.className = 'metric-unit';
+  row.appendChild(unit);
+
+  const note = document.createElement('input');
+  note.type = 'text';
+  note.className = 'metric-note';
+  note.placeholder = 'メモ（任意）';
+  row.appendChild(note);
+
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'btn ghost';
+  btn.textContent = '削除';
+  btn.onclick = ()=> removeMetricRow(rowId);
+  row.appendChild(btn);
+
+  box.appendChild(row);
+
+  if (prefill && prefill.metricId) sel.value = prefill.metricId;
+  if (prefill && prefill.value != null) input.value = prefill.value;
+  if (prefill && prefill.note) note.value = prefill.note;
+
+  sel.addEventListener('change', ()=> updateMetricInputAttributes(row));
+  updateMetricInputAttributes(row);
+  ensureMetricEmptyMessage();
+}
+
+function updateMetricInputAttributes(row){
+  if (!row) return;
+  const sel = row.querySelector('select');
+  const input = row.querySelector('input[type="number"]');
+  const unit = row.querySelector('.metric-unit');
+  const def = METRIC_DEF_MAP[sel?.value] || null;
+  if (def){
+    input.min = def.min != null ? def.min : '';
+    input.max = def.max != null ? def.max : '';
+    input.step = def.step != null ? def.step : 1;
+    unit.textContent = def.unit || '';
+    if (def.description){
+      sel.title = def.description;
+    }
+  } else {
+    input.removeAttribute('min');
+    input.removeAttribute('max');
+    input.step = '1';
+    unit.textContent = '';
+    sel.title = '';
+  }
+}
+
+function removeMetricRow(rowId){
+  const box = q('metricInputs');
+  if (!box) return;
+  const row = box.querySelector(`[data-metric-row="${rowId}"]`);
+  if (row) row.remove();
+  ensureMetricEmptyMessage();
+}
+
+function clearMetricRows(){
+  const box = q('metricInputs');
+  if (!box) return;
+  Array.from(box.querySelectorAll('[data-metric-row]')).forEach(el => el.remove());
+  ensureMetricEmptyMessage();
+}
+
+function collectMetricInputs(){
+  const box = q('metricInputs');
+  if (!box) return [];
+  const rows = Array.from(box.querySelectorAll('[data-metric-row]'));
+  const out = [];
+  rows.forEach(row => {
+    const metricId = row.querySelector('select')?.value;
+    const valInput = row.querySelector('input[type="number"]');
+    const noteInput = row.querySelector('.metric-note');
+    if (!metricId) return;
+    if (!valInput) return;
+    const raw = valInput.value;
+    if (raw === '' || raw == null) return;
+    const num = Number(raw);
+    if (!isFinite(num)) return;
+    const note = noteInput ? noteInput.value.trim() : '';
+    out.push({ metricId, value: num, note });
+  });
+  return out;
+}
+
+function destroyClinicalCharts(){
+  Object.keys(_clinicalCharts).forEach(key => {
+    try { _clinicalCharts[key].destroy(); } catch(e){}
+  });
+  _clinicalCharts = {};
+}
+
+function loadClinicalTrends(){
+  const box = q('clinicalTrendBox');
+  if (!box) return;
+  const p = pid();
+  if (!p){
+    destroyClinicalCharts();
+    box.innerHTML = '<div class="muted">患者IDを入力すると臨床指標が表示されます。</div>';
+    return;
+  }
+  box.innerHTML = '<div class="muted">読み込み中…</div>';
+  google.script.run
+    .withSuccessHandler(res=>{
+      const metrics = (res && res.metrics) ? res.metrics : [];
+      renderClinicalCharts(metrics);
+    })
+    .withFailureHandler(e=>{
+      const msg = (e && e.message) ? e.message : String(e);
+      box.innerHTML = `<div class="muted" style="color:#b91c1c">臨床指標の取得に失敗しました：${escapeHtml(msg)}</div>`;
+      destroyClinicalCharts();
+    })
+    .listClinicalMetricSeries(p);
+}
+
+function renderClinicalCharts(metrics){
+  const box = q('clinicalTrendBox');
+  if (!box) return;
+  destroyClinicalCharts();
+  if (!Array.isArray(metrics) || !metrics.length){
+    box.innerHTML = '<div class="muted">臨床指標の記録がまだありません。</div>';
+    return;
+  }
+  if (typeof Chart === 'undefined'){
+    box.innerHTML = '<div class="muted" style="color:#b91c1c">Chart.jsの読み込みに失敗しました</div>';
+    return;
+  }
+  box.innerHTML = '';
+  metrics.forEach(metric => {
+    const wrap = document.createElement('div');
+    wrap.className = 'trend-item';
+    const title = document.createElement('h4');
+    title.textContent = metric.unit ? `${metric.label} (${metric.unit})` : metric.label;
+    wrap.appendChild(title);
+    const canvas = document.createElement('canvas');
+    wrap.appendChild(canvas);
+    const ctx = canvas.getContext('2d');
+    const labels = metric.points.map(p => p.date);
+    const values = metric.points.map(p => p.value);
+    _clinicalCharts[metric.id] = new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels,
+        datasets: [{
+          label: metric.label,
+          data: values,
+          fill: false,
+          borderColor: '#2563eb',
+          backgroundColor: '#60a5fa',
+          tension: 0.25,
+          pointRadius: 4
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          y: {
+            suggestedMin: metric.min != null ? metric.min : undefined,
+            suggestedMax: metric.max != null ? metric.max : undefined
+          }
+        },
+        plugins: {
+          legend: { display: false }
+        }
+      }
+    });
+    canvas.style.maxHeight = '220px';
+    const latest = metric.points[metric.points.length - 1];
+    const meta = document.createElement('div');
+    meta.className = 'trend-meta';
+    meta.textContent = latest ? `最新：${latest.date} / ${latest.value}${metric.unit||''}` : '';
+    wrap.appendChild(meta);
+    box.appendChild(wrap);
+  });
+}
+
+function clearIcfSummary(){
+  const box = q('icfSummaryBox');
+  if (box){
+    box.innerHTML = '<div class="muted">ICFサマリを生成するとここに表示されます。</div>';
+  }
+}
+
+function renderIcfSummary(res){
+  const box = q('icfSummaryBox');
+  if (!box) return;
+  if (!res || !Array.isArray(res.sections) || !res.sections.length){
+    box.innerHTML = '<div class="muted" style="color:#b91c1c">ICFサマリの生成に失敗しました。</div>';
+    return;
+  }
+  const meta = document.createElement('div');
+  meta.className = 'icf-meta';
+  meta.textContent = `${res.generatedAt || ''}  /  メモ件数:${res.noteCount || 0}  /  方式:${res.usedAi ? 'AI整形' : 'ローカル整形'}`;
+  box.innerHTML = '';
+  box.appendChild(meta);
+  res.sections.forEach(sec => {
+    const wrap = document.createElement('div');
+    wrap.className = 'icf-section';
+    const title = document.createElement('div');
+    title.className = 'icf-section-title';
+    title.textContent = sec.title || '';
+    wrap.appendChild(title);
+    const body = document.createElement('div');
+    body.innerHTML = escapeHtml(sec.body || '').replace(/\n/g,'<br>');
+    wrap.appendChild(body);
+    box.appendChild(wrap);
+  });
+}
+
+function generateIcfSummary(){
+  const p = pid();
+  if (!p){ alert('患者IDを入力してください'); return; }
+  const box = q('icfSummaryBox');
+  if (box) box.innerHTML = '<div class="muted">ICFサマリを生成中です…</div>';
+  google.script.run
+    .withSuccessHandler(res => renderIcfSummary(res))
+    .withFailureHandler(e => {
+      const msg = (e && e.message) ? e.message : String(e);
+      if (box) box.innerHTML = `<div class="muted" style="color:#b91c1c">ICFサマリ生成に失敗しました：${escapeHtml(msg)}</div>`;
+    })
+    .generateIcfSummary(p);
+}
 /* 候補/定型文 */
 function loadPidList(){
   google.script.run.withSuccessHandler(list=>{
@@ -326,6 +648,8 @@ function save(){
       notesParts:{ note: val('obs') },
       actions:{}
     };
+    const metrics = collectMetricInputs();
+    if (metrics.length) payload.clinicalMetrics = metrics;
     if(_pendingVisitPlanDate){ payload.actions.visitPlanDate = _pendingVisitPlanDate; }
 
     // ボタン連打防止
@@ -348,6 +672,7 @@ function save(){
         setv('obs','');
         setv('vitals','');
         q('preset').selectedIndex = 0;
+        clearMetricRows();
         refresh();
 
         btns.forEach(b=> b.disabled = false);
@@ -396,7 +721,15 @@ function skipReportPdf(){
 function cancelReport(){ q('reportGuide').style.display='none'; }
 
 /* 画面更新 */
-function refresh(){ loadHeader(); loadNews(); loadThisMonth(); }
+function refresh(){
+  clearIcfSummary();
+  loadHeader();
+  loadNews();
+  loadThisMonth();
+  loadClinicalTrends();
+  clearMetricRows();
+  ensureMetricEmptyMessage();
+}
 function loadHeader(){
   const p=pid(); if(!p) return;
   google.script.run.withSuccessHandler(h=>{
@@ -592,8 +925,15 @@ function saveHandoverUI(){
 (function init(){
   loadPidList();
   loadPresets();
+  loadMetricDefinitions();
+  ensureMetricEmptyMessage();
+  clearIcfSummary();
   const p = "<?= patientId ?>";
-  if (p) refresh();
+  if (p) {
+    refresh();
+  } else {
+    loadClinicalTrends();
+  }
   q('consentModal')?.classList.remove('open');
 })();
 


### PR DESCRIPTION
## Summary
- add Google Apps Script utilities for clinical metric storage, retrieval, and ICF-style summary generation with OpenAI fallback
- persist optional clinical metrics when saving a treatment and expose them with new APIs
- update the treatment log UI to capture metrics, generate ICF summaries, and display trend charts via Chart.js

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d243c509f08321a0864f44da58fdba