### PR TITLE
Move clinical metrics UI and add daily chat notifications

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -120,14 +120,6 @@
           </div>
         </div>
 
-        <div class="section-title" style="margin-top:12px">臨床指標（任意入力）</div>
-        <div class="muted" style="font-size:0.9rem">痛みVASや可動域など数値化した情報を記録すると、自動で経過グラフを作成します。</div>
-        <div id="metricInputs" class="metric-rows"></div>
-        <div class="btnrow" style="margin-top:6px">
-          <button class="btn ghost" onclick="addMetricRow()">指標を追加</button>
-          <button class="btn ghost" onclick="clearMetricRows()">指標クリア</button>
-        </div>
-
         <!-- 保存行＋外部向けレポート -->
         <div class="btnrow" style="margin-top:8px">
           <button class="btn ok" onclick="save()">保存（施術録）</button>
@@ -139,12 +131,6 @@
               <button class="btn ghost" onclick="chooseReport('family')">家族向け</button>
               <button class="btn ghost" onclick="chooseReport('physician')">同意医師向け</button>
             </div>
-          </div>
-
-          <div style="flex:1"></div>
-          <div class="btnrow">
-            <button class="btn warn" onclick="setSuspend()">施術 休止</button>
-            <button class="btn warn" onclick="setStop()">施術 中止</button>
           </div>
         </div>
       </div>
@@ -159,21 +145,6 @@
       <div class="card">
         <div class="section-title">当月の施術記録（この患者）</div>
         <div id="list"></div>
-      </div>
-
-      <div class="card">
-        <div class="section-title">臨床・ケア連携（β）</div>
-        <div class="muted" style="font-size:0.9rem">ICFサマリと臨床指標のグラフをワンクリックで表示します。</div>
-        <div class="btnrow" style="margin:8px 0">
-          <button class="btn ghost" onclick="generateIcfSummary()">ICFサマリを生成</button>
-          <button class="btn ghost" onclick="loadClinicalTrends(true)">グラフを再読込</button>
-        </div>
-        <div id="icfSummaryBox" class="icf-summary">
-          <div class="muted">ICFサマリを生成するとここに表示されます。</div>
-        </div>
-        <div id="clinicalTrendBox" class="trend-container">
-          <div class="muted">臨床指標の記録がまだありません。</div>
-        </div>
       </div>
 
       <!-- レポート下書き（4問ガイド） -->
@@ -225,6 +196,30 @@
           <div class="btnrow" style="margin-top:8px">
             <button class="btn ok" onclick="saveHandoverUI()">申し送りを保存</button>
           </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="section-title">臨床・ケア連携（β）</div>
+        <div class="muted" style="font-size:0.9rem">ICFサマリと臨床指標を申し送りと合わせて活用できます。</div>
+
+        <div class="section-title" style="margin-top:12px">臨床指標（任意入力）</div>
+        <div class="muted" style="font-size:0.9rem">痛みVASや可動域など数値化した情報を記録すると、自動で経過グラフを作成します。</div>
+        <div id="metricInputs" class="metric-rows"></div>
+        <div class="btnrow" style="margin-top:6px">
+          <button class="btn ghost" onclick="addMetricRow()">指標を追加</button>
+          <button class="btn ghost" onclick="clearMetricRows()">指標クリア</button>
+        </div>
+
+        <div class="btnrow" style="margin:12px 0 8px">
+          <button class="btn ghost" onclick="generateIcfSummary()">ICFサマリを生成</button>
+          <button class="btn ghost" onclick="loadClinicalTrends(true)">グラフを再読込</button>
+        </div>
+        <div id="icfSummaryBox" class="icf-summary">
+          <div class="muted">ICFサマリを生成するとここに表示されます。</div>
+        </div>
+        <div id="clinicalTrendBox" class="trend-container">
+          <div class="muted">臨床指標の記録がまだありません。</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- move the clinical metrics input and visualization card from the treatment form to the handover column and remove the suspend/stop buttons
- add `sendDailySummaryToChat` and helpers to post per-staff daily summaries to Google Chat using Script Properties managed webhooks

## Testing
- not run (Apps Script project)


------
https://chatgpt.com/codex/tasks/task_e_68d3737ae83c8321909f8b5a7d5de90b