### PR TITLE
Ensure clinical metrics persistence and stabilize chat summary trigger

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -513,6 +513,13 @@ function renderIcfSummary(res){
   meta.textContent = `${res.generatedAt || ''}  /  メモ件数:${res.noteCount || 0}  /  方式:${res.usedAi ? 'AI整形' : 'ローカル整形'}`;
   box.innerHTML = '';
   box.appendChild(meta);
+  if (res && res.patientFound === false) {
+    const warn = document.createElement('div');
+    warn.className = 'icf-meta';
+    warn.style.color = '#b91c1c';
+    warn.textContent = '患者情報が見つからなかったため、ID未指定としてサマリを作成しました。';
+    box.appendChild(warn);
+  }
   res.sections.forEach(sec => {
     const wrap = document.createElement('div');
     wrap.className = 'icf-section';


### PR DESCRIPTION
## Summary
- harden the clinical metric sheet helper, normalize timestamps, and always persist metrics with the correct patient ID
- allow ICF summaries to fall back to a placeholder header when patient info is missing and surface that state in the UI
- rework chat webhook configuration, improve the daily summary message, and add a locked trigger-friendly entry point with installer

## Testing
- not run (Apps Script project)


------
https://chatgpt.com/codex/tasks/task_e_68d5f35dd46c83218135e1b10fde36ab