### PR TITLE
Implement AI report aggregation and UI preview

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -682,6 +682,15 @@ function callGenerateSummary(pidValue, rangeKey, audience){
   });
 }
 
+function callGetReportsForUI(pidValue, rangeLabel){
+  return new Promise((resolve, reject)=>{
+    google.script.run
+      .withSuccessHandler(resolve)
+      .withFailureHandler(err => reject(err))
+      .getReportsForUI(pidValue, rangeLabel);
+  });
+}
+
 function handleIcfSummaryResponse(res, fallbackAudience){
   const key = res && res.audience ? res.audience : fallbackAudience;
   if (!res || !res.ok){
@@ -729,27 +738,28 @@ async function generateAllIcfSummaries(){
   const p = pid();
   if(!p){ alert('患者IDを入力してください'); return; }
   const rangeKey = _icfSummaryState.range || 'all';
-  const audiences = ['doctor','caremanager','family'];
-  let hadError = false;
+  const rangeOption = ICF_RANGE_OPTIONS.find(opt => opt.key === rangeKey);
+  const rangeLabel = rangeOption ? rangeOption.label : rangeKey;
   setIcfButtonsDisabled(true);
   updateIcfSummaryStatus('3種類のサマリを生成しています…');
   try {
-    for (const audience of audiences){
-      try {
-        const res = await callGenerateSummary(p, rangeKey, audience);
-        const ok = handleIcfSummaryResponse(res, audience);
-        if (!ok) hadError = true;
-      } catch (err) {
-        hadError = true;
-        console.error('[generateAllIcfSummaries]', err);
-        const msg = err && err.message ? err.message : String(err);
-        const label = getIcfAudienceLabel(audience);
-        updateIcfSummaryStatus(`${label}の生成に失敗しました：${msg}`);
+    const res = await callGetReportsForUI(p, rangeLabel);
+    const aggregated = res && res.reports ? res.reports : null;
+    if (!res || !res.ok || !aggregated || !aggregated.ok){
+      const message = res && res.rangeLabel ? `${res.rangeLabel}のサマリ生成に失敗しました。` : 'サマリ生成に失敗しました。';
+      updateIcfSummaryStatus(message);
+      alert(message);
+      return;
+    }
+    const results = {};
+    ['doctor','caremanager','family'].forEach(key => {
+      if (aggregated[key]) {
+        results[key] = aggregated[key];
       }
-    }
-    if (!hadError){
-      updateIcfSummaryStatus('3種類のサマリを更新しました。');
-    }
+    });
+    _icfSummaryState.results = results;
+    renderIcfSummaryResults();
+    updateIcfSummaryStatus('3種類のサマリを更新しました。');
   } finally {
     setIcfButtonsDisabled(false);
   }

--- a/src/report.html
+++ b/src/report.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>AI報告書プレビュー</title>
+<style>
+  body{ font-family:system-ui,-apple-system,"Segoe UI",Roboto,"Noto Sans JP",sans-serif; margin:0; padding:24px; background:#f7f7f9; color:#1f2933; }
+  h1{ margin-top:0; font-size:1.5rem; }
+  .card{ background:#fff; border-radius:16px; box-shadow:0 8px 24px rgba(15,23,42,0.08); padding:20px; max-width:960px; margin:0 auto; }
+  .controls{ display:flex; flex-wrap:wrap; gap:12px; margin-bottom:16px; }
+  .controls label{ display:flex; flex-direction:column; font-weight:600; font-size:0.95rem; gap:6px; }
+  .controls input,.controls select{ border:1px solid #d1d5db; border-radius:10px; padding:10px 12px; font-size:0.95rem; }
+  button{ appearance:none; border:none; border-radius:999px; background:#2563eb; color:#fff; padding:10px 18px; font-size:0.95rem; font-weight:600; cursor:pointer; }
+  button:disabled{ background:#9ca3af; cursor:not-allowed; }
+  .status{ margin-bottom:12px; color:#4b5563; font-size:0.9rem; }
+  .report-block{ background:#f8fafc; border:1px solid #e5e7eb; border-radius:12px; padding:12px; margin-top:12px; }
+  .report-block h2{ margin:0 0 6px; font-size:1.1rem; }
+  pre{ white-space:pre-wrap; word-break:break-word; font-family:"Noto Sans JP",system-ui,sans-serif; font-size:0.95rem; margin:0; }
+</style>
+</head>
+<body>
+  <div class="card">
+    <h1>AI報告書プレビュー</h1>
+    <div class="controls">
+      <label>
+        患者ID
+        <input id="reportPid" placeholder="例: 123" value="<?= patientId ?>" />
+      </label>
+      <label>
+        対象期間
+        <select id="reportRange">
+          <option value="直近1か月">直近1か月</option>
+          <option value="直近2か月">直近2か月</option>
+          <option value="直近3か月">直近3か月</option>
+          <option value="全期間">全期間</option>
+        </select>
+      </label>
+      <div style="display:flex; align-items:flex-end;">
+        <button id="reportFetch">報告書を生成</button>
+      </div>
+    </div>
+    <div id="reportStatus" class="status">対象を選んで「報告書を生成」をクリックしてください。</div>
+    <div class="report-block">
+      <h2>医師向け報告書</h2>
+      <pre id="doctor"></pre>
+    </div>
+    <div class="report-block">
+      <h2>ケアマネ向けサマリ</h2>
+      <pre id="caremanager"></pre>
+    </div>
+    <div class="report-block">
+      <h2>家族向けサマリ</h2>
+      <pre id="family"></pre>
+    </div>
+  </div>
+
+<script>
+function setReportStatus(message){
+  document.getElementById('reportStatus').textContent = message || '';
+}
+function setButtonDisabled(disabled){
+  document.getElementById('reportFetch').disabled = !!disabled;
+}
+function renderReports(payload){
+  ['doctor','caremanager','family'].forEach(key => {
+    const el = document.getElementById(key);
+    if (!el) return;
+    const text = payload && payload[key] ? String(payload[key]).trim() : '';
+    el.textContent = text || '生成できませんでした';
+  });
+}
+function fetchReports(){
+  const pid = document.getElementById('reportPid').value.trim();
+  if (!pid){
+    alert('患者IDを入力してください');
+    return;
+  }
+  const range = document.getElementById('reportRange').value;
+  setButtonDisabled(true);
+  setReportStatus('報告書を生成しています…');
+  google.script.run
+    .withSuccessHandler(res => {
+      const reports = res && res.reports ? res.reports : null;
+      if (!res || !res.ok || !reports || !reports.ok){
+        setReportStatus('報告書の生成に失敗しました。');
+        renderReports({});
+        setButtonDisabled(false);
+        return;
+      }
+      renderReports({
+        doctor: reports.doctor?.text || '',
+        caremanager: reports.caremanager?.text || '',
+        family: reports.family?.text || ''
+      });
+      const label = res.rangeLabel || range;
+      setReportStatus(`${label}の報告書を更新しました。`);
+      setButtonDisabled(false);
+    })
+    .withFailureHandler(err => {
+      console.error('[fetchReports]', err);
+      const msg = err && err.message ? err.message : '不明なエラーが発生しました。';
+      setReportStatus(`報告書の生成に失敗しました：${msg}`);
+      renderReports({});
+      setButtonDisabled(false);
+    })
+    .getReportsForUI(pid, range);
+}
+document.getElementById('reportFetch').addEventListener('click', fetchReports);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement OpenAI-backed AI報告書生成ヘルパーと generateAllReports_/getReportsForUI を追加
- アプリ内のサマリ生成UIを新しい一括取得APIに合わせて更新
- AI報告書プレビュー用の report.html ビューと doGet ルーティングを追加

## Testing
- not run (Google Apps Script environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8793febec83218b742ac87902faec