### PR TITLE
Fix after-treatment reminders firing after save

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -2520,6 +2520,35 @@ function submitTreatment(payload) {
       recordClinicalMetrics_(pid, payload.clinicalMetrics, now, user);
     }
 
+    const job = { patientId: pid };
+    let hasFollowUp = false;
+
+    const presetLabel = String(payload?.presetLabel || '').trim();
+    if (presetLabel) {
+      job.presetLabel = presetLabel;
+      hasFollowUp = true;
+    }
+
+    const burdenShare = payload?.burdenShare;
+    if (burdenShare != null && String(burdenShare).trim() !== '') {
+      job.burdenShare = String(burdenShare).trim();
+      hasFollowUp = true;
+    }
+
+    const visitPlanDate = payload?.actions?.visitPlanDate;
+    if (visitPlanDate) {
+      job.visitPlanDate = String(visitPlanDate).trim();
+      if (job.visitPlanDate) {
+        hasFollowUp = true;
+      } else {
+        delete job.visitPlanDate;
+      }
+    }
+
+    if (hasFollowUp) {
+      queueAfterTreatmentJob(job);
+    }
+
     return { ok: true, vitals: vit, wroteTo: s.getName(), row };
   } catch (e) {
     throw e;


### PR DESCRIPTION
## Summary
- queue after-treatment jobs from submitTreatment when preset actions are present
- forward visit plan dates from the client payload so reminders are created

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e080dd635c83219337b653d1c134c1