### PR TITLE
Fix consent news updates and after-treatment queue

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1570,7 +1570,8 @@ function shouldShowConsentEditButton(news){
   const type = String(news.type || '').trim();
   if(type !== '同意') return false;
   const message = String(news.message || '');
-  return message.indexOf('未定') >= 0 || message.indexOf('確認') >= 0;
+  if (message.indexOf('未定') >= 0 || message.indexOf('確認') >= 0) return true;
+  return message.indexOf('同意書受渡。') >= 0;
 }
 
 function openConsentEditModal(){


### PR DESCRIPTION
## Summary
- run after-treatment jobs immediately with locking, logging, and a fallback trigger to prevent delayed News updates
- keep consent News entries when editing from the News panel and register the visit plan alongside the confirmation
- allow the consent edit button to remain visible after recording the handoff so the date can be adjusted again

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901ae1453948321a69c0ed6fae6329c