### PR TITLE
Adjust consent auto updates to record confirmation date separately

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1499,7 +1499,7 @@ function loadHeader(){
             <div class="badge">患者ID ${h.patientId}</div>
             <div style="margin:6px 0 2px">氏名：${h.name||'—'}　（${h.age!=null? h.age+'歳':''} ${h.ageClass||''}）</div>
             <div>病院名：${h.hospital||'—'}　医師：${h.doctor||'—'}</div>
-            <div>同意日：${h.consentDate||'—'}　次回期限：${h.consentExpiry||'—'}　負担割合：${h.burden||'—'}</div>
+            <div>同意書確認日：${h.consentHandoutDate||'—'}　同意日：${h.consentDate||'—'}　次回期限：${h.consentExpiry||'—'}　負担割合：${h.burden||'—'}</div>
           </div>
           <div>
             <div>${status} ${h.pauseUntil? '（ミュート:'+h.pauseUntil+'まで）':''}</div>


### PR DESCRIPTION
## Summary
- write automated consent confirmations from treatment records to the patient info handout column instead of the official consent date
- keep manual consent date edits updating the consent column, unify reminder logging, and expose the confirmation date via the header API
- surface the confirmation date in the app header so staff can distinguish confirmation vs. official consent dates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6901bd9b474c8321a83c0d7e89ddab40