### PR TITLE
Improve patient ID loading stability in standalone mode

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -102,7 +102,8 @@
         <label>患者ID（施術録番号）</label>
         <input id="pid" list="pidlist" placeholder="例: 5702" value="<?= patientId ?>"
                onkeydown="handlePatientIdKeydown(event)" oninput="handlePatientIdInput(event)"
-               onchange="handlePatientIdConfirm()" onblur="handlePatientIdBlur()" />
+               onchange="handlePatientIdConfirm()" onblur="handlePatientIdBlur()"
+               onfocus="handlePatientIdFocus()" />
         <datalist id="pidlist"></datalist>
         <div id="pidLoadProgress" class="muted" aria-live="polite" style="margin-top:6px; min-height:1.2em"></div>
       </div>
@@ -312,10 +313,41 @@ function focusPatientIdInput(){
   }
 }
 
+function detectStandaloneDisplayMode(){
+  try {
+    if (typeof window !== 'undefined' && window){
+      if (typeof window.matchMedia === 'function'){
+        try {
+          if (window.matchMedia('(display-mode: standalone)').matches){
+            return true;
+          }
+        } catch (err){
+          console.warn('[detectStandaloneDisplayMode] matchMedia failed', err);
+        }
+      }
+      if (window.navigator && typeof window.navigator.standalone === 'boolean' && window.navigator.standalone){
+        return true;
+      }
+    }
+    if (typeof document !== 'undefined' && document && typeof document.referrer === 'string'){
+      if (document.referrer.startsWith('android-app://')){
+        return true;
+      }
+    }
+  } catch (err){
+    console.warn('[detectStandaloneDisplayMode] detection failed', err);
+  }
+  return false;
+}
+
+const IS_STANDALONE_DISPLAY_MODE = detectStandaloneDisplayMode();
+
 const PATIENT_ID_CACHE_KEY = 'treatmentLogApp.patientIdCache';
 const PATIENT_ID_CHUNK_SIZE_STORAGE_KEY = 'treatmentLogApp.pidChunkSize';
 const PATIENT_ID_RENDER_CHUNK_DEFAULT = 200;
 const PATIENT_ID_RENDER_PAUSE_DEBOUNCE_MS = 180;
+const PATIENT_ID_STANDALONE_CHUNK_SIZE = 100;
+const PATIENT_ID_PROGRESS_UPDATE_INTERVAL = IS_STANDALONE_DISPLAY_MODE ? 2 : 1;
 let _patientIdIndex = {};
 let _patientIdList = [];
 let _patientIdKanaIndex = {};
@@ -324,6 +356,10 @@ const PATIENT_ID_RENDER_CHUNK_SIZE = determinePatientIdRenderChunkSize();
 let _patientIdRenderResumeAt = 0;
 let _pendingPatientIdList = null;
 let _pendingPatientIdListScheduled = false;
+let _patientIdInitialRenderLocked = IS_STANDALONE_DISPLAY_MODE;
+let _patientIdInitialRenderBuffer = null;
+let _patientIdInitialRenderWaiters = [];
+let _patientIdInitialRenderNoticeShown = false;
 
 function parsePatientIdChunkSizeCandidate(candidate){
   if (candidate == null) return NaN;
@@ -367,19 +403,27 @@ function determinePatientIdRenderChunkSize(){
   } catch (err){
     console.warn('[determinePatientIdRenderChunkSize] localStorage read failed', err);
   }
+  let standaloneCandidateIndex = -1;
+  if (IS_STANDALONE_DISPLAY_MODE){
+    standaloneCandidateIndex = candidates.length;
+    candidates.push(PATIENT_ID_STANDALONE_CHUNK_SIZE);
+  }
   let selected = null;
+  let selectedIndex = -1;
   for (let i = 0; i < candidates.length; i++){
     const parsed = parsePatientIdChunkSizeCandidate(candidates[i]);
     if (Number.isFinite(parsed) && parsed > 0){
       selected = clamp(parsed);
+      selectedIndex = i;
       break;
     }
   }
   if (selected == null){
     selected = PATIENT_ID_RENDER_CHUNK_DEFAULT;
   }
+  const selectedFromStandalone = selectedIndex === standaloneCandidateIndex && standaloneCandidateIndex !== -1;
   try {
-    if (typeof localStorage !== 'undefined'){
+    if (!selectedFromStandalone && typeof localStorage !== 'undefined'){
       localStorage.setItem(PATIENT_ID_CHUNK_SIZE_STORAGE_KEY, String(selected));
     }
   } catch (err){
@@ -1463,8 +1507,84 @@ function enqueuePendingPatientIdList(rawList, options){
   });
 }
 
+function shouldDeferInitialPatientIdList(options){
+  if (!_patientIdInitialRenderLocked){
+    return false;
+  }
+  if (options && options.bypassInitialDefer){
+    return false;
+  }
+  return true;
+}
+
+function deferInitialPatientIdList(rawList, options){
+  return new Promise((resolve, reject) => {
+    if (_patientIdInitialRenderBuffer){
+      _patientIdInitialRenderBuffer.rawList = rawList;
+      _patientIdInitialRenderBuffer.options = options ? Object.assign({}, options) : {};
+    } else {
+      _patientIdInitialRenderBuffer = {
+        rawList,
+        options: options ? Object.assign({}, options) : {}
+      };
+    }
+    _patientIdInitialRenderWaiters.push({ resolve, reject });
+    if (!_patientIdInitialRenderNoticeShown){
+      _patientIdInitialRenderNoticeShown = true;
+      renderPatientIdProgress({ message: '候補は入力欄をタップすると読み込みます。' });
+    }
+  });
+}
+
+function unlockInitialPatientIdRender(){
+  if (!_patientIdInitialRenderLocked){
+    return Promise.resolve();
+  }
+  _patientIdInitialRenderLocked = false;
+  const payload = _patientIdInitialRenderBuffer ? Object.assign({}, _patientIdInitialRenderBuffer) : null;
+  const waiters = _patientIdInitialRenderWaiters.slice();
+  _patientIdInitialRenderBuffer = null;
+  _patientIdInitialRenderWaiters = [];
+  if (!payload){
+    if (waiters.length){
+      waiters.forEach(waiter => {
+        try {
+          waiter.resolve();
+        } catch (err){
+          console.error('[unlockInitialPatientIdRender] resolve failed', err);
+        }
+      });
+    }
+    return Promise.resolve();
+  }
+  const flushPromise = applyPatientIdList(payload.rawList, Object.assign({}, payload.options, { bypassInitialDefer: true }));
+  flushPromise
+    .then(result => {
+      waiters.forEach(waiter => {
+        try {
+          waiter.resolve(result);
+        } catch (err){
+          console.error('[unlockInitialPatientIdRender] resolve failed', err);
+        }
+      });
+    })
+    .catch(err => {
+      waiters.forEach(waiter => {
+        try {
+          waiter.reject(err);
+        } catch (resolveErr){
+          console.error('[unlockInitialPatientIdRender] reject failed', resolveErr);
+        }
+      });
+    });
+  return flushPromise;
+}
+
 function applyPatientIdList(rawList, options){
   const opts = options ? Object.assign({}, options) : {};
+  if (shouldDeferInitialPatientIdList(opts)){
+    return deferInitialPatientIdList(rawList, opts);
+  }
   if (opts.deferIfPaused !== false && isPatientIdRenderPaused()){
     return enqueuePendingPatientIdList(rawList, opts);
   }
@@ -1485,6 +1605,8 @@ function performPatientIdListApply(rawList, options){
   }
   const total = rawList.length;
   let index = 0;
+  let chunkCount = 0;
+  const progressInterval = Math.max(1, PATIENT_ID_PROGRESS_UPDATE_INTERVAL);
   renderPatientIdProgress({ source: opts.source || '', total, appended: 0, done: false });
   return new Promise((resolve, reject) => {
     const processChunk = deadline => {
@@ -1519,7 +1641,12 @@ function performPatientIdListApply(rawList, options){
         if (fragment.childNodes.length){
           dl.appendChild(fragment);
         }
-        renderPatientIdProgress({ source: opts.source || '', total, appended: index, done: false });
+        if (processed > 0){
+          chunkCount++;
+          if (chunkCount % progressInterval === 0 || index >= total){
+            renderPatientIdProgress({ source: opts.source || '', total, appended: index, done: false });
+          }
+        }
         if (index >= total){
           renderPatientIdProgress({ source: opts.source || '', total, appended: total, done: true });
           resolve();
@@ -1531,7 +1658,7 @@ function performPatientIdListApply(rawList, options){
         reject(err);
       }
     };
-    processChunk();
+    Promise.resolve().then(() => processChunk());
   });
 }
 
@@ -1654,6 +1781,7 @@ function loadPidList(){
 }
 
 function handlePatientIdKeydown(evt){
+  unlockInitialPatientIdRender();
   if (evt && evt.key !== 'Enter'){
     pausePatientIdRender();
   }
@@ -1664,7 +1792,12 @@ function handlePatientIdKeydown(evt){
 }
 
 function handlePatientIdInput(){
+  unlockInitialPatientIdRender();
   pausePatientIdRender();
+}
+
+function handlePatientIdFocus(){
+  unlockInitialPatientIdRender();
 }
 
 function handlePatientIdConfirm(){
@@ -2276,7 +2409,9 @@ function saveHandoverUI(){
   loadMetricDefinitions();
   ensureMetricEmptyMessage();
   setupIcfSummaryUI();
-  focusPatientIdInput();
+  if (!IS_STANDALONE_DISPLAY_MODE){
+    focusPatientIdInput();
+  }
   const p = "<?= patientId ?>";
   if (p) {
     refresh();


### PR DESCRIPTION
## Summary
- detect standalone/PWA launches and defer patient ID rendering until the input receives focus
- reduce standalone chunk sizes, throttle progress updates, and kick off the first render chunk immediately to avoid throttling stalls
- add runtime messaging and unlock hooks so cached/network lists flush once the user interacts

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6904a73054148321b1ed92a41827e897