### PR TITLE
Fix incorrect no-candidate message after selecting patient ID

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -894,12 +894,17 @@ function renderPatientIdSearchResults(result){
   const dl = q('pidlist');
   if (!dl) return;
   clearPatientIdOptions();
+  const confirmedId = pid();
+  const confirmedRecord = confirmedId ? _patientIdIndex[confirmedId] : null;
+  const noResultProgressState = confirmedRecord
+    ? null
+    : { message: '候補が見つかりませんでした。' };
   if (!result){
-    renderPatientIdProgress({ message: '候補が見つかりませんでした。' });
+    renderPatientIdProgress(noResultProgressState);
     return;
   }
   if (!Array.isArray(result.records) || !result.records.length){
-    renderPatientIdProgress({ message: '候補が見つかりませんでした。' });
+    renderPatientIdProgress(noResultProgressState);
     return;
   }
   const fragment = document.createDocumentFragment();


### PR DESCRIPTION
## Summary
- suppress the "候補が見つかりませんでした" status when a confirmed patient ID is already selected
- reuse the existing progress renderer so the status area is cleared once a valid record is active

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690963beb5fc832197c9c15f761b190c