### PR TITLE
Fix consent reminder news window

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -688,10 +688,13 @@ function checkConsentExpiration_(){
     if (!expiryStr) continue;
     const expiryDate = parseIsoLocal(expiryStr);
     if (!expiryDate) continue;
+    expiryDate.setHours(0, 0, 0, 0);
     const reminderDate = new Date(expiryDate.getTime() - 30 * dayMs);
     reminderDate.setHours(0, 0, 0, 0);
-    const diffDays = Math.round((reminderDate.getTime() - todayStart.getTime()) / dayMs);
-    if (diffDays !== 0) continue;
+    const daysFromReminder = Math.floor((todayStart.getTime() - reminderDate.getTime()) / dayMs);
+    if (daysFromReminder < 0) continue; // 1か月前より未来の場合はスキップ
+    const daysSinceExpiry = Math.floor((todayStart.getTime() - expiryDate.getTime()) / dayMs);
+    if (daysSinceExpiry > 30) continue; // 期限を30日以上過ぎていたらスキップ
     const key = pidNormalized + '|' + expiryStr;
     if (existingKeys.has(key) || insertedKeys.has(key)) {
       continue;


### PR DESCRIPTION
## Summary
- ensure consent news entries start appearing once the 30-day reminder window begins and continue through the 30-day grace period after expiry
- normalize consent expiry dates to midnight before calculating reminder boundaries

## Testing
- node - <<'NODE' (logic verification)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fcf10b5e48321897a4e449d26d41a)