### PR TITLE
Update doctor report AI prompt for compliance

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -197,7 +197,7 @@
 
       <div class="card">
         <div class="section-title">報告書AI生成</div>
-        <div class="muted" style="font-size:0.9rem">申し送りの内容からAIが自動生成します。</div>
+        <div class="muted" style="font-size:0.9rem">施術報告書を自動生成します。『治療』等の医行為表現は使用されません。</div>
 
         <div id="icfSummaryBox" class="icf-summary">
           <div class="muted" style="font-size:0.9rem">申し送りの内容をもとにAIが用途別のサマリを生成します。</div>


### PR DESCRIPTION
## Summary
- add a dedicated doctor-report system prompt that enforces legally compliant terminology, tone, and output structure
- reshape the doctor report prompt payload to surface recent notes and handovers while wiring the new system instructions into the OpenAI call
- clarify the AI generation helper text in the UI to explain that prohibited medical terms are excluded

## Testing
- not run (Google Apps Script project without automated tests)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69105216168c83219e67e42173af0580)