### PR TITLE
Ensure AI doctor report context carries consent data

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -3531,13 +3531,22 @@ function buildIcfSource_(pid, range){
   if (!header) {
     return { patientFound: false };
   }
+  const consentText = (header && typeof header.consentContent === 'string')
+    ? header.consentContent.trim()
+    : getConsentContentForPatient_(pid);
+  const effectiveEndDate = range && range.endDate instanceof Date ? range.endDate : new Date();
+  const frequencyLabel = determineTreatmentFrequencyLabel_(
+    countTreatmentsInRecentMonth_(pid, effectiveEndDate)
+  );
   const notes = getTreatmentNotesInRange_(pid, range.startDate, range.endDate);
   const handovers = getHandoversInRange_(pid, range.startDate, range.endDate);
   return {
     patientFound: true,
     header,
     notes,
-    handovers
+    handovers,
+    consent: consentText || '',
+    frequencyLabel
   };
 }
 


### PR DESCRIPTION
## Summary
- add consent text from the patient sheet to the AI report source payload
- compute and provide the latest visit frequency label so doctor prompts can tie treatment purpose to consent content

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916d02994148321b0cb591a43c49c20)