### PR TITLE
Fix month filter validation in admin panels

### DIFF
--- a/src/albyte_admin.html
+++ b/src/albyte_admin.html
@@ -393,7 +393,11 @@ function fetchAttendance(){
   const { year, month } = parseMonthInput(monthInput);
   const staffId = document.getElementById('attendanceStaffFilter').value;
   state.attendanceFilter = { year, month, staffId };
-  const params = { year, month };
+  const params = {};
+  if (Number.isFinite(year) && Number.isFinite(month)) {
+    params.year = year;
+    params.month = month;
+  }
   if (staffId) params.staffId = staffId;
   const tbody = document.getElementById('attendanceTableBody');
   if (tbody) tbody.innerHTML = '<tr><td colspan="11">読み込み中…</td></tr>';
@@ -455,7 +459,11 @@ function fetchShifts(){
   const { year, month } = parseMonthInput(monthInput);
   const staffId = document.getElementById('shiftStaffFilter').value;
   state.shiftFilter = { year, month, staffId };
-  const params = { year, month };
+  const params = {};
+  if (Number.isFinite(year) && Number.isFinite(month)) {
+    params.year = year;
+    params.month = month;
+  }
   if (staffId) params.staffId = staffId;
   const tbody = document.getElementById('shiftTableBody');
   if (tbody) tbody.innerHTML = '<tr><td colspan="6">読み込み中…</td></tr>';


### PR DESCRIPTION
## Summary
- add helper utilities on the Apps Script side to normalize and default invalid year/month inputs before querying monthly ranges
- update every server handler that accepts a month filter to use the new helper and keep range calculations stable
- stop the admin UI from sending empty month values so clearing the filter no longer produces an invalid request

## Testing
- Not run (GAS environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918f21698d08321abe5ede07173e030)