### PR TITLE
Improve albyte monthly summary presentation

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -9713,6 +9713,15 @@ function getVisitAttendancePortalData(options){
       record.request = req;
     }
   });
+  attendance.forEach(record => {
+    if (!record) return;
+    const hasWeekday = record.weekday && String(record.weekday).trim();
+    if (hasWeekday) return;
+    const resolvedDate = record.date ? createDateFromKey_(record.date) : null;
+    if (resolvedDate) {
+      record.weekday = getWeekdaySymbol_(resolvedDate, tz) || '';
+    }
+  });
   const totalWork = attendance.reduce((sum, r) => sum + (Number.isFinite(r.workMinutes) ? r.workMinutes : 0), 0);
   const totalBreak = attendance.reduce((sum, r) => sum + (Number.isFinite(r.breakMinutes) ? r.breakMinutes : 0), 0);
   const firstOfCurrent = new Date(now.getFullYear(), now.getMonth(), 1);

--- a/src/albyte.html
+++ b/src/albyte.html
@@ -68,10 +68,25 @@
   .monthly-totals .metric{ background:#f1f5f9; border-radius:12px; padding:10px 14px; display:flex; flex-direction:column; gap:6px; min-width:120px; }
   .monthly-totals .metric span{ color:var(--muted); font-size:0.8rem; }
   .monthly-totals .metric strong{ font-size:1.05rem; }
-  .table-scroll{ overflow-x:auto; }
-  .monthly-table{ width:100%; border-collapse:collapse; font-size:0.85rem; }
-  .monthly-table th, .monthly-table td{ border:1px solid #e5e7eb; padding:8px 10px; text-align:left; white-space:nowrap; }
+  .table-scroll{ overflow-x:auto; margin:0 -16px -8px; padding:0 16px 16px; }
+  .table-scroll::-webkit-scrollbar{ height:6px; }
+  .table-scroll::-webkit-scrollbar-track{ background:transparent; }
+  .table-scroll::-webkit-scrollbar-thumb{ background:rgba(15,23,42,0.28); border-radius:999px; }
+  .monthly-table{ width:100%; border-collapse:separate; border-spacing:0; font-size:0.85rem; table-layout:fixed; min-width:640px; }
+  .monthly-table col.col-date{ width:132px; }
+  .monthly-table col.col-clock{ width:92px; }
+  .monthly-table col.col-break{ width:72px; }
+  .monthly-table col.col-work{ width:120px; }
+  .monthly-table col.col-note{ width:220px; }
+  .monthly-table col.col-auto{ width:72px; }
+  .monthly-table thead th{ font-size:0.78rem; text-transform:uppercase; letter-spacing:0.04em; color:#475569; background:#f8fafc; border-bottom:1px solid #e2e8f0; }
+  .monthly-table th, .monthly-table td{ border:1px solid #e5e7eb; padding:10px 12px; text-align:left; white-space:nowrap; }
   .monthly-table tbody tr:nth-child(even){ background:#f9fafb; }
+  .monthly-table tbody tr:hover{ background:#eef2ff; }
+  .monthly-table .cell-note, .monthly-table .cell-auto{ white-space:normal; word-break:break-word; }
+  .monthly-table .cell-date{ font-weight:600; }
+  .monthly-table .cell-break{ text-align:center; font-variant-numeric:tabular-nums; }
+  .monthly-table .cell-clock, .monthly-table .cell-work{ font-variant-numeric:tabular-nums; }
   .loading{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; background:rgba(255,255,255,0.78); z-index:1500; }
   .loading.hidden{ display:none; }
   .loading-box{ display:flex; align-items:center; gap:12px; background:#fff; padding:14px 18px; border-radius:14px; box-shadow:0 18px 40px rgba(15,23,42,0.2); font-weight:600; }
@@ -84,6 +99,12 @@
     .action-row .btn{ width:100%; }
     .custom-input-row{ flex-direction:column; }
     .custom-input-row button{ width:100%; }
+    .card{ padding:20px; }
+    .wrap{ padding:24px 12px 56px; }
+    .monthly-table{ font-size:0.78rem; min-width:560px; }
+    .monthly-table th, .monthly-table td{ padding:8px 10px; }
+    .table-scroll{ margin:0 -12px -6px; padding:0 12px 12px; }
+    .monthly-table col.col-note{ width:180px; }
   }
 </style>
 </head>
@@ -176,6 +197,15 @@
     <div id="monthlyTotals" class="monthly-totals"></div>
     <div class="table-scroll">
       <table class="monthly-table">
+        <colgroup>
+          <col class="col-date" />
+          <col class="col-clock" />
+          <col class="col-clock" />
+          <col class="col-break" />
+          <col class="col-work" />
+          <col class="col-note" />
+          <col class="col-auto" />
+        </colgroup>
         <thead>
           <tr>
             <th>日付</th>
@@ -312,6 +342,21 @@ function getPortalMonthTarget(){
   return { year: now.getFullYear(), month: now.getMonth() + 1 };
 }
 
+function formatBreakValue(minutes, text){
+  const numeric = Number(minutes);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return '–';
+  }
+  return escapeHtml(text || '–');
+}
+
+function formatBreakCellValue(row){
+  if (!row || row.isDailyStaff) {
+    return '--';
+  }
+  return formatBreakValue(row.breakMinutes, row.breakText);
+}
+
 function renderMonthlySummary(){
   if (!monthlyCard) return;
   if (!monthlyState) {
@@ -328,7 +373,7 @@ function renderMonthlySummary(){
   if (monthlyTotals) {
     const metrics = [];
     const workText = escapeHtml(totals.durationText || totals.workText || '--');
-    const breakText = isDailySummary ? '--' : escapeHtml(totals.breakText || '--');
+    const breakText = isDailySummary ? '--' : formatBreakValue(totals.breakMinutes, totals.breakText);
     const workingDays = totals.workingDays != null ? escapeHtml(totals.workingDays) : escapeHtml('--');
     metrics.push(`<div class="metric"><span>${isDailySummary ? '延長時間' : '勤務時間'}</span><strong>${workText}</strong></div>`);
     metrics.push(`<div class="metric"><span>休憩</span><strong>${breakText}</strong></div>`);
@@ -349,18 +394,18 @@ function renderMonthlySummary(){
         const date = escapeHtml(row.date || '');
         const clockIn = escapeHtml(row.clockIn || '');
         const clockOut = escapeHtml(row.clockOut || '');
-        const breakText = row.isDailyStaff ? '--' : escapeHtml(row.breakText || '');
+        const breakText = formatBreakCellValue(row);
         const workText = row.isDailyStaff
           ? `延長 ${escapeHtml(row.overtimeText || row.workText || '')}`
           : escapeHtml(row.workText || '');
         return `<tr>
-          <td>${date}</td>
-          <td>${clockIn}</td>
-          <td>${clockOut}</td>
-          <td>${breakText}</td>
-          <td>${workText}</td>
-          <td>${note}</td>
-          <td>${auto}</td>
+          <td class="cell-date">${date}</td>
+          <td class="cell-clock">${clockIn}</td>
+          <td class="cell-clock">${clockOut}</td>
+          <td class="cell-break">${breakText}</td>
+          <td class="cell-work">${workText}</td>
+          <td class="cell-note">${note}</td>
+          <td class="cell-auto">${auto}</td>
         </tr>`;
       }).join('');
     }

--- a/src/attendance.html
+++ b/src/attendance.html
@@ -40,12 +40,15 @@
   .card-header{ display:flex; flex-wrap:wrap; justify-content:space-between; gap:12px; align-items:center; margin-bottom:12px; }
   .muted{ color:var(--muted); font-size:0.9rem; }
   table{ width:100%; border-collapse:collapse; }
-  .table-wrapper{ width:100%; overflow-x:auto; }
+  .table-wrapper{ width:100%; overflow-x:auto; -webkit-overflow-scrolling:touch; scrollbar-width:thin; scrollbar-color:#94a3b8 transparent; }
+  .table-wrapper::-webkit-scrollbar{ height:6px; }
+  .table-wrapper::-webkit-scrollbar-track{ background:transparent; }
+  .table-wrapper::-webkit-scrollbar-thumb{ background:#94a3b8; border-radius:4px; }
   .attendance-table{ width:100%; border-collapse:collapse; table-layout:fixed; }
   th,td{ text-align:left; padding:10px 8px; border-bottom:1px solid var(--border); font-size:0.95rem; vertical-align:top; }
   .attendance-table th{ font-weight:600; color:#111827; }
   .attendance-table th.col-date,
-  .attendance-table td.col-date{ width:132px; }
+  .attendance-table td.col-date{ width:122px; }
   .attendance-table th.col-time,
   .attendance-table td.col-time,
   .attendance-table th.col-work,
@@ -53,14 +56,14 @@
   .attendance-table th.col-break,
   .attendance-table td.col-break{ width:86px; white-space:nowrap; font-variant-numeric:tabular-nums; }
   .attendance-table th.col-breakdown,
-  .attendance-table td.col-breakdown{ width:18%; }
+  .attendance-table td.col-breakdown{ width:16%; white-space:normal; word-break:break-word; overflow-wrap:anywhere; line-height:1.35; }
   .attendance-table th.col-source,
-  .attendance-table td.col-source{ width:16%; }
+  .attendance-table td.col-source{ width:13%; white-space:normal; word-break:break-word; line-height:1.35; }
   .attendance-table th.col-request,
-  .attendance-table td.col-request{ width:150px; }
+  .attendance-table td.col-request{ width:150px; white-space:normal; }
   .attendance-table th.col-actions,
-  .attendance-table td.col-actions{ width:90px; text-align:center; }
-  .attendance-table td.col-actions .btn{ width:100%; padding:6px 0; }
+  .attendance-table td.col-actions{ width:110px; text-align:center; white-space:nowrap; }
+  .attendance-table td.col-actions .btn{ width:100%; }
   .attendance-table tbody tr:hover{ background:#f1f5f9; }
   .date-cell{ font-variant-numeric:tabular-nums; }
   .date-primary{ font-weight:600; }
@@ -76,6 +79,7 @@
   .btn:hover{ transform:translateY(-1px); box-shadow:0 10px 20px rgba(37,99,235,0.15); }
   .btn:disabled{ opacity:.45; cursor:not-allowed; box-shadow:none; transform:none; }
   .btn.ghost{ background:#e5e7eb; color:#1f2937; }
+  .btn-sm{ padding:6px 12px; font-size:0.82rem; }
   .table-note{ margin-top:12px; font-size:0.9rem; color:var(--muted); }
   .history-list{ display:flex; flex-direction:column; gap:12px; }
   .history-item{ border:1px solid var(--border); border-radius:12px; padding:12px 14px; background:#fff; }
@@ -104,12 +108,35 @@
   .toast{ position:fixed; left:50%; bottom:32px; transform:translateX(-50%); background:#1f2937; color:#fff; padding:10px 18px; border-radius:999px; font-size:0.9rem; box-shadow:0 12px 30px rgba(15,23,42,0.25); opacity:0; pointer-events:none; transition:opacity .3s ease; z-index:1600; }
   .toast.show{ opacity:1; }
   .auto-adjust-note{ margin-top:4px; font-size:0.8rem; color:#b91c1c; }
+  @media (max-width:768px){
+    .attendance-table th.col-date,
+    .attendance-table td.col-date{ width:110px; }
+    .attendance-table th.col-time,
+    .attendance-table td.col-time{ width:78px; }
+    .attendance-table th.col-work,
+    .attendance-table td.col-work,
+    .attendance-table th.col-break,
+    .attendance-table td.col-break{ width:74px; }
+    .attendance-table th.col-breakdown,
+    .attendance-table td.col-breakdown{ width:14%; }
+    .attendance-table th.col-source,
+    .attendance-table td.col-source{ width:12%; }
+    .attendance-table th.col-request,
+    .attendance-table td.col-request{ width:130px; }
+    .attendance-table th.col-actions,
+    .attendance-table td.col-actions{ width:120px; }
+    .attendance-table td.col-actions .btn{ min-width:110px; }
+  }
   @media (max-width:640px){
     th,td{ font-size:0.85rem; padding:8px 6px; }
     .btn{ padding:7px 12px; font-size:0.85rem; }
     .header-controls{ flex-direction:column; align-items:flex-start; }
     .header-actions{ width:100%; justify-content:flex-start; }
     .paid-leave-widget{ width:100%; }
+    .dialog{ padding:16px; }
+    select,input,textarea{ font-size:0.9rem; padding:8px; }
+    .modal-actions{ flex-direction:column; }
+    .modal-actions .btn{ width:100%; }
   }
 </style>
 </head>
@@ -471,7 +498,9 @@ function renderAttendance(){
       const requestCell = req
         ? `<div class="badge ${statusClass}">${escapeHtml(statusLabel)}</div>${statusNote}`
         : '<span class="muted">-</span>';
-      const button = month.canRequest ? `<button class="btn" ${status === 'pending' ? 'disabled' : ''} data-date="${record.date}">申請</button>` : '';
+      const button = month.canRequest
+        ? `<button class="btn btn-sm" ${status === 'pending' ? 'disabled' : ''} data-date="${record.date}">申請</button>`
+        : '';
       const sourceLabel = escapeHtml(record.sourceLabel || '');
       const autoNote = record.autoAdjustmentMessage ? `<div class="auto-adjust-note">${escapeHtml(record.autoAdjustmentMessage)}</div>` : '';
       const sourceCell = sourceLabel + autoNote;
@@ -479,7 +508,7 @@ function renderAttendance(){
       const startLabel = formatTimeDisplay(record.start);
       const endLabel = formatTimeDisplay(record.end);
       const workLabel = formatTimeDisplay(record.work);
-      const breakLabel = formatTimeDisplay(record.break);
+      const breakLabel = formatBreakDisplay(record);
       const dateCell = `
         <div class="date-primary">${escapeHtml(datePrimary || record.displayDate || record.date || '')}</div>
         ${dateSecondary ? `<div class="date-sub muted">${escapeHtml(dateSecondary)}</div>` : (record.weekday ? `<div class="date-sub muted">（${escapeHtml(record.weekday)}）</div>` : '')}
@@ -1040,6 +1069,25 @@ function formatAttendanceDateParts(record){
     primary: iso,
     secondary: weekdayText ? `${short}（${weekdayText}）` : short
   };
+}
+
+function formatBreakDisplay(record){
+  if (!record) return '';
+  const minutes = Number(record.breakMinutes);
+  if (Number.isFinite(minutes) && minutes === 0){
+    return '–';
+  }
+  const label = formatTimeDisplay(record.break);
+  if (!label){
+    if (Number.isFinite(minutes)){
+      return minutes === 0 ? '–' : formatMinutesAsClock(minutes);
+    }
+    return '';
+  }
+  if ((label === '00:00' || label === '0:00') && Number.isFinite(minutes) && minutes === 0){
+    return '–';
+  }
+  return label;
 }
 
 function parseDateValue(value){


### PR DESCRIPTION
## Summary
- restyle the albyte monthly summary table with fixed column widths, hover styles, styled scrollbars, and mobile padding tweaks so the view stays legible on narrow screens
- add a colgroup and semantic cell classes to the table so notes and correction columns can wrap naturally instead of forcing every cell to stay on a single line
- show an en dash when break minutes are zero (while daily staff keep `--`) and reuse that helper for the monthly totals

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691aa2d5b4608321990c25cb83d816fc)