### PR TITLE
Allow part-time attendance without shifts

### DIFF
--- a/src/albyte.html
+++ b/src/albyte.html
@@ -77,6 +77,7 @@
   .monthly-table col.col-clock{ width:92px; }
   .monthly-table col.col-break{ width:72px; }
   .monthly-table col.col-work{ width:120px; }
+  .monthly-table col.col-category{ width:100px; }
   .monthly-table col.col-note{ width:220px; }
   .monthly-table col.col-auto{ width:72px; }
   .monthly-table thead th{ font-size:0.78rem; text-transform:uppercase; letter-spacing:0.04em; color:#475569; background:#f8fafc; border-bottom:1px solid #e2e8f0; }
@@ -84,6 +85,7 @@
   .monthly-table tbody tr:nth-child(even){ background:#f9fafb; }
   .monthly-table tbody tr:hover{ background:#eef2ff; }
   .monthly-table .cell-note, .monthly-table .cell-auto{ white-space:normal; word-break:break-word; }
+  .monthly-table .cell-category{ text-align:center; font-size:0.82rem; white-space:nowrap; }
   .monthly-table .cell-date{ font-weight:600; }
   .monthly-table .cell-break{ text-align:center; font-variant-numeric:tabular-nums; }
   .monthly-table .cell-clock, .monthly-table .cell-work{ font-variant-numeric:tabular-nums; }
@@ -105,6 +107,7 @@
     .monthly-table th, .monthly-table td{ padding:8px 10px; }
     .table-scroll{ margin:0 -12px -6px; padding:0 12px 12px; }
     .monthly-table col.col-note{ width:180px; }
+    .monthly-table col.col-category{ width:90px; }
   }
 </style>
 </head>
@@ -203,6 +206,7 @@
           <col class="col-clock" />
           <col class="col-break" />
           <col class="col-work" />
+          <col class="col-category" />
           <col class="col-note" />
           <col class="col-auto" />
         </colgroup>
@@ -213,6 +217,7 @@
             <th>退勤</th>
             <th>休憩</th>
             <th>勤務/延長</th>
+            <th>区分</th>
             <th>備考</th>
             <th>補正</th>
           </tr>
@@ -407,9 +412,9 @@ function renderMonthlySummary(){
   }
   if (monthlyTableBody) {
     const rows = Array.isArray(summary.records) ? summary.records : [];
-    if (!rows.length) {
-      monthlyTableBody.innerHTML = '<tr><td colspan="7">データがありません</td></tr>';
-    } else {
+      if (!rows.length) {
+        monthlyTableBody.innerHTML = '<tr><td colspan="8">データがありません</td></tr>';
+      } else {
       monthlyTableBody.innerHTML = rows.map(row => {
         const note = escapeHtml(row.note || '');
         const auto = escapeHtml(row.autoFlag || '');
@@ -417,6 +422,7 @@ function renderMonthlySummary(){
         const clockIn = escapeHtml(row.clockIn || '');
         const clockOut = escapeHtml(row.clockOut || '');
         const breakText = formatBreakCellValue(row);
+        const category = escapeHtml(row.sourceLabel || '通常勤務');
         const workText = row.isDailyStaff
           ? `延長 ${escapeHtml(row.overtimeText || row.workText || '')}`
           : escapeHtml(row.workText || '');
@@ -426,6 +432,7 @@ function renderMonthlySummary(){
           <td class="cell-clock">${clockOut}</td>
           <td class="cell-break">${breakText}</td>
           <td class="cell-work">${workText}</td>
+          <td class="cell-category">${category}</td>
           <td class="cell-note">${note}</td>
           <td class="cell-auto">${auto}</td>
         </tr>`;


### PR DESCRIPTION
## Summary
- classify part-time attendance directly from recorded punches and expose the label to clients
- allow paid-leave previews to fall back to default working hours when no shift exists and treat missing source labels as 通常勤務
- update theアルバイト勤怠 monthly table to show the new 区分 column and layout tweaks to keep rendering stable

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ad088dbe08321a6119a9111951185)