### PR TITLE
Fix albyte attendance refresh and parsing

### DIFF
--- a/src/albyte.html
+++ b/src/albyte.html
@@ -661,9 +661,11 @@ function handlePortalResponse(res, options){
   if (options && options.toast) {
     showToast(options.toast);
   }
-  if (options && options.expectStatus) {
+  const expectStatus = options && options.expectStatus;
+  const forceRefresh = Boolean(options && options.forceRefresh);
+  if (expectStatus || forceRefresh) {
     const currentStatus = portalState && portalState.today ? portalState.today.status : '';
-    if (currentStatus !== options.expectStatus) {
+    if (forceRefresh || currentStatus !== expectStatus) {
       refreshPortalState({ silent: true });
     }
   }
@@ -871,7 +873,8 @@ function clockIn(){
     loadingMessage: '出勤を記録しています…',
     onSuccess: res => handlePortalResponse(res, {
       toast: res && res.ok ? '出勤を記録しました。' : undefined,
-      expectStatus: 'working'
+      expectStatus: 'working',
+      forceRefresh: true
     })
   });
 }
@@ -886,7 +889,8 @@ function clockOut(){
     loadingMessage: '退勤を記録しています…',
     onSuccess: res => handlePortalResponse(res, {
       toast: res && res.ok ? '退勤を記録しました。' : undefined,
-      expectStatus: 'completed'
+      expectStatus: 'completed',
+      forceRefresh: true
     })
   });
 }


### PR DESCRIPTION
## Summary
- normalize attendance rows so empty clock values stay null instead of showing 1899-era timestamps
- fall back to the most recent AlbyteAttendance record so the portal works even without shift rows
- refresh the portal after clock-in/clock-out so the UI immediately reflects the new punch

## Testing
- Not run (not supported)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bf87c53d0832189abb9d1667eb188)