### PR TITLE
Add employment insurance rate inputs and calculations

### DIFF
--- a/src/payroll.html
+++ b/src/payroll.html
@@ -49,6 +49,7 @@
   .rate-grid{ display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:12px; }
   .rate-grid label{ font-size:0.85rem; color:var(--muted); }
   .rate-grid input{ width:100%; }
+  .rate-grid small{ display:block; font-size:0.75rem; color:var(--muted); margin-top:4px; }
   .table-note{ font-size:0.85rem; color:var(--muted); margin-top:8px; }
   .text-right{ text-align:right; }
   .insurance-summary-name{ display:flex; flex-direction:column; gap:4px; }
@@ -287,8 +288,16 @@
         <label>子ども・子育て拠出金（事業主）
           <input id="insuranceChildEmployer" type="number" step="0.0001" min="0" />
         </label>
+        <label>雇用保険（本人）
+          <input id="insuranceEmploymentEmployee" type="number" step="0.0001" min="0" />
+          <small class="muted">賃金総額 × 料率</small>
+        </label>
+        <label>雇用保険（事業主）
+          <input id="insuranceEmploymentEmployer" type="number" step="0.0001" min="0" />
+          <small class="muted">賃金総額 × 料率</small>
+        </label>
       </div>
-      <p class="table-note">料率は小数（例: 4.95% = 0.0495）で入力してください。</p>
+      <p class="table-note">料率は小数（例: 4.95% = 0.0495）で入力してください。雇用保険は賃金総額に対して自動計算されます。</p>
       <div class="form-actions">
         <button type="submit" class="btn">レートを保存</button>
       </div>
@@ -444,7 +453,9 @@ const SOCIAL_INSURANCE_RATE_DEFAULTS = Object.freeze({
   nursingEmployee: 0.0045,
   nursingEmployer: 0.0045,
   childEmployee: 0.0018,
-  childEmployer: 0.0018
+  childEmployer: 0.0018,
+  employmentEmployee: 0,
+  employmentEmployer: 0
 });
 
 let payrollState = {
@@ -744,7 +755,9 @@ function renderInsuranceRateForm(){
     nursingEmployee: 'insuranceNursingEmployee',
     nursingEmployer: 'insuranceNursingEmployer',
     childEmployee: 'insuranceChildEmployee',
-    childEmployer: 'insuranceChildEmployer'
+    childEmployer: 'insuranceChildEmployer',
+    employmentEmployee: 'insuranceEmploymentEmployee',
+    employmentEmployer: 'insuranceEmploymentEmployer'
   };
   Object.keys(mapping).forEach(key => {
     const el = document.getElementById(mapping[key]);
@@ -774,7 +787,9 @@ function gatherInsuranceRatePayload(){
     nursingEmployee: document.getElementById('insuranceNursingEmployee').value,
     nursingEmployer: document.getElementById('insuranceNursingEmployer').value,
     childEmployee: document.getElementById('insuranceChildEmployee').value,
-    childEmployer: document.getElementById('insuranceChildEmployer').value
+    childEmployer: document.getElementById('insuranceChildEmployer').value,
+    employmentEmployee: document.getElementById('insuranceEmploymentEmployee').value,
+    employmentEmployer: document.getElementById('insuranceEmploymentEmployer').value
   };
 }
 


### PR DESCRIPTION
## Summary
- extend the payroll social insurance rate form/UI with configurable employment insurance rates for employees and employers and document that the rates apply to total wages
- persist and expose the new rate values in the Apps Script backend and include them when computing contributions
- calculate employment insurance premiums automatically from the estimated wage total so they are reflected in the contribution totals

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bfced5d90832191384d63bd0fba56)