### PR TITLE
Add explicit contractor withholding labels

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -243,8 +243,8 @@ const PAYROLL_COMMISSION_RULES = Object.freeze({
   horiguchi: { weeklyThreshold: 30, amount: 1250 }
 });
 const PAYROLL_WITHHOLDING_LABELS = Object.freeze({
-  required: 'あり',
-  none: 'なし'
+  required: 'あり（10.21%）',
+  none: 'なし（個人事業主扱い）'
 });
 const PAYROLL_WITHHOLDING_TAX_RATE = 0.1021;
 const PAYROLL_GRADE_SHEET_NAME = 'PayrollGrades';
@@ -2794,10 +2794,12 @@ function buildPayrollCommissionBreakdown_(record, countsEntry, options){
 
 function normalizePayrollWithholdingType_(value){
   const text = String(value || '').trim().toLowerCase();
-  if (!text || text === 'none' || text === '0' || text === 'なし' || text === '無' || text === 'off') {
+  const plain = text.replace(/[（(].*?[）)]/g, '').trim();
+  const normalized = plain || text;
+  if (!normalized || normalized === 'none' || normalized === '0' || normalized === 'なし' || normalized === '無' || normalized === 'off') {
     return 'none';
   }
-  if (text === 'required' || text === 'あり' || text === '有' || text === 'true' || text === 'yes' || text === 'on' || text === '1' || text === 'withholding') {
+  if (normalized === 'required' || normalized === 'あり' || normalized === '有' || normalized === 'true' || normalized === 'yes' || normalized === 'on' || normalized === '1' || normalized === 'withholding') {
     return 'required';
   }
   return 'none';

--- a/src/payroll.html
+++ b/src/payroll.html
@@ -472,8 +472,8 @@ const COMMISSION_OPTIONS = [
   { value:'horiguchi', label:'堀口以降' }
 ];
 const WITHHOLDING_OPTIONS = [
-  { value:'none', label:'なし' },
-  { value:'required', label:'あり' }
+  { value:'none', label:'なし（個人事業主扱い）' },
+  { value:'required', label:'あり（10.21%）' }
 ];
 const SOCIAL_INSURANCE_RATE_DEFAULTS = Object.freeze({
   healthEmployee: 0.0495,


### PR DESCRIPTION
## Summary
- update the payroll master UI to show the new contractor withholding options with the requested wording
- align the Apps Script labels and normalization logic so the new labels round-trip correctly and still apply the 10.21% rate when enabled

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c01f5aab083219184afacf51d51dc)