### PR TITLE
Add themed payroll PDF template for Second Family

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -7662,6 +7662,7 @@ function doGet(e) {
     case 'albyte_admin': templateFile = 'albyte_admin'; break;
     case 'albyte_report':templateFile = 'albyte_report'; break;
     case 'payroll':      templateFile = 'payroll'; break;
+    case 'payroll_pdf_family': templateFile = 'payroll_pdf_family'; break;
     case 'record':       templateFile = 'app'; break;   // ★ app.html を record として表示
     case 'report':       templateFile = 'report'; break;
     default:             templateFile = 'welcome'; break;

--- a/src/payroll_pdf_family.html
+++ b/src/payroll_pdf_family.html
@@ -1,0 +1,368 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>PDF給与明細（第二の家族版）</title>
+<style>
+  :root {
+    --bg:#f7f3eb;
+    --card:#fffdf7;
+    --accent:#4d6b3c;
+    --accent-light:#8bb47a;
+    --text:#2f2a26;
+    --muted:#6b6155;
+    --border:rgba(77,107,60,0.2);
+    --shadow:0 20px 50px rgba(54,73,46,0.12);
+  }
+  *, *::before, *::after { box-sizing:border-box; }
+  html, body {
+    margin:0;
+    padding:0;
+    font-family:"Noto Sans JP", "Hiragino Sans", "Yu Gothic", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background:var(--bg);
+    color:var(--text);
+    min-height:100vh;
+  }
+  body {
+    position:relative;
+    padding:32px 16px 48px;
+    display:flex;
+    justify-content:center;
+  }
+  body::before {
+    content:"";
+    position:fixed;
+    inset:0;
+    background:radial-gradient(circle at top, rgba(141,178,122,0.15), transparent 55%),
+               radial-gradient(circle at bottom left, rgba(210,190,150,0.4), transparent 60%);
+    z-index:0;
+  }
+  body::after {
+    content:"";
+    position:fixed;
+    inset:0;
+    background-image:url("data:image/svg+xml,%3Csvg width='360' height='360' viewBox='0 0 360 360' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M10 340c40-60 120-140 170-150s100 30 150-10' fill='none' stroke='rgba(77,107,60,0.15)' stroke-width='3'/%3E%3Cpath d='M30 360c40-55 110-110 150-120s80 10 140-40' fill='none' stroke='rgba(77,107,60,0.08)' stroke-width='2'/%3E%3C/svg%3E");
+    opacity:0.3;
+    mix-blend-mode:multiply;
+    z-index:0;
+    background-size:cover;
+    background-position:center;
+  }
+  .sheet {
+    position:relative;
+    z-index:1;
+    width:100%;
+    max-width:960px;
+    background:var(--card);
+    border-radius:32px;
+    box-shadow:var(--shadow);
+    padding:36px clamp(20px, 4vw, 48px) 48px;
+    overflow:hidden;
+  }
+  .sheet::before {
+    content:"";
+    position:absolute;
+    inset:0;
+    background:linear-gradient(135deg, rgba(141,178,122,0.18), transparent 60%);
+    opacity:0.65;
+    pointer-events:none;
+  }
+  .sheet > * { position:relative; z-index:2; }
+  header {
+    display:flex;
+    flex-direction:column;
+    gap:8px;
+  }
+  .brand {
+    display:flex;
+    align-items:center;
+    gap:12px;
+  }
+  .brand-icon {
+    width:52px;
+    height:52px;
+    border-radius:16px;
+    background:linear-gradient(135deg, var(--accent), var(--accent-light));
+    color:#fff;
+    font-weight:700;
+    font-size:1.4rem;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    box-shadow:0 12px 25px rgba(77,107,60,0.3);
+  }
+  .brand-text h1 {
+    margin:0;
+    font-size:1.4rem;
+    letter-spacing:0.08em;
+  }
+  .brand-text p {
+    margin:4px 0 0;
+    color:var(--muted);
+    font-size:0.92rem;
+  }
+  .period-card {
+    margin-top:18px;
+    border:1px solid var(--border);
+    border-radius:20px;
+    padding:16px 20px;
+    display:flex;
+    flex-wrap:wrap;
+    gap:24px;
+    background:#fff;
+  }
+  .period-card span {
+    font-size:0.85rem;
+    text-transform:uppercase;
+    color:var(--muted);
+  }
+  .period-card strong {
+    display:block;
+    font-size:1.2rem;
+    margin-top:4px;
+  }
+  .summary-grid {
+    display:grid;
+    grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
+    gap:18px;
+    margin:28px 0;
+  }
+  .summary-card {
+    background:rgba(255,255,255,0.9);
+    border-radius:24px;
+    padding:20px;
+    border:1px solid rgba(77,107,60,0.15);
+    box-shadow:0 12px 30px rgba(77,107,60,0.08);
+  }
+  .summary-card h2 {
+    margin:0;
+    font-size:0.95rem;
+    color:var(--muted);
+    letter-spacing:0.05em;
+  }
+  .summary-card .value {
+    font-size:2rem;
+    font-weight:700;
+    color:var(--accent);
+    margin:8px 0 0;
+  }
+  .summary-card p {
+    margin:6px 0 0;
+    color:var(--muted);
+    font-size:0.85rem;
+  }
+  .details {
+    border-radius:24px;
+    border:1px solid rgba(77,107,60,0.2);
+    background:#fff;
+    padding:12px;
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
+    gap:12px;
+  }
+  .detail-table {
+    border-radius:18px;
+    border:1px solid rgba(77,107,60,0.15);
+    padding:16px;
+    background:rgba(247,243,235,0.7);
+  }
+  .detail-table h3 {
+    margin:0 0 12px;
+    font-size:1rem;
+    color:var(--accent);
+    letter-spacing:0.08em;
+  }
+  table {
+    width:100%;
+    border-collapse:collapse;
+    font-size:0.92rem;
+  }
+  th, td {
+    text-align:left;
+    padding:6px 4px;
+  }
+  th { color:var(--muted); font-weight:600; font-size:0.85rem; }
+  td.amount { text-align:right; font-variant-numeric:tabular-nums; }
+  tr + tr td { border-top:1px dashed rgba(77,107,60,0.2); }
+  .note {
+    margin-top:24px;
+    padding:18px 20px;
+    border-radius:20px;
+    background:rgba(77,107,60,0.08);
+    color:var(--muted);
+    font-size:0.9rem;
+  }
+  .message {
+    margin-top:32px;
+    border-radius:28px;
+    padding:28px;
+    background:linear-gradient(120deg, rgba(141,178,122,0.25), rgba(77,107,60,0.4));
+    color:#fffef6;
+    position:relative;
+    overflow:hidden;
+  }
+  .message::after {
+    content:"";
+    position:absolute;
+    inset:auto -40px -50px auto;
+    width:160px;
+    height:160px;
+    background:rgba(255,255,255,0.2);
+    filter:blur(24px);
+    border-radius:50%;
+  }
+  .message h4 {
+    margin:0 0 8px;
+    font-size:1.1rem;
+    letter-spacing:0.08em;
+  }
+  .message p { margin:0; line-height:1.8; }
+  .footer {
+    margin-top:32px;
+    display:flex;
+    flex-wrap:wrap;
+    gap:12px;
+    justify-content:space-between;
+    font-size:0.85rem;
+    color:var(--muted);
+  }
+  .footer strong { color:var(--accent); }
+  @media (max-width:640px) {
+    body { padding:16px 8px 32px; }
+    .sheet { border-radius:24px; padding:28px 20px 40px; }
+    .summary-card .value { font-size:1.6rem; }
+  }
+  @media print {
+    body { background:#fff; padding:0; }
+    body::before, body::after { display:none; }
+    .sheet { box-shadow:none; border-radius:0; padding:32px 40px; }
+    .message { color:#fff; }
+  }
+</style>
+</head>
+<body>
+  <div class="sheet">
+    <header>
+      <div class="brand">
+        <div class="brand-icon">BT</div>
+        <div class="brand-text">
+          <h1>べるつりー第二の家族</h1>
+          <p>PAYROLL STATEMENT</p>
+        </div>
+      </div>
+      <div class="period-card">
+        <div>
+          <span>給与対象期間</span>
+          <strong data-field="pay-period">2024年4月1日 〜 2024年4月30日</strong>
+        </div>
+        <div>
+          <span>支給日</span>
+          <strong data-field="payday">2024年5月25日</strong>
+        </div>
+        <div>
+          <span>従業員</span>
+          <strong data-field="employee-name">山田 太郎 様</strong>
+        </div>
+      </div>
+    </header>
+
+    <section class="summary-grid">
+      <article class="summary-card">
+        <h2>支給総額</h2>
+        <div class="value" data-field="total-gross">¥420,000</div>
+        <p>基本給＋各種手当の合計</p>
+      </article>
+      <article class="summary-card">
+        <h2>控除総額</h2>
+        <div class="value" data-field="total-deduction">¥68,540</div>
+        <p>社会保険・税金などの控除</p>
+      </article>
+      <article class="summary-card">
+        <h2>差引支給額</h2>
+        <div class="value" data-field="net-pay">¥351,460</div>
+        <p>振込予定口座：〇〇銀行 普通 1234567</p>
+      </article>
+    </section>
+
+    <section class="details">
+      <div class="detail-table">
+        <h3>支給内訳</h3>
+        <table>
+          <tbody>
+            <tr>
+              <th>基本給</th>
+              <td class="amount" data-field="pay-basic">¥320,000</td>
+            </tr>
+            <tr>
+              <th>役職手当</th>
+              <td class="amount" data-field="pay-role">¥30,000</td>
+            </tr>
+            <tr>
+              <th>資格手当</th>
+              <td class="amount" data-field="pay-license">¥15,000</td>
+            </tr>
+            <tr>
+              <th>訪問手当</th>
+              <td class="amount" data-field="pay-visit">¥25,000</td>
+            </tr>
+            <tr>
+              <th>交通費</th>
+              <td class="amount" data-field="pay-transport">¥30,000</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="detail-table">
+        <h3>控除内訳</h3>
+        <table>
+          <tbody>
+            <tr>
+              <th>健康保険</th>
+              <td class="amount" data-field="deduction-health">¥19,740</td>
+            </tr>
+            <tr>
+              <th>厚生年金</th>
+              <td class="amount" data-field="deduction-pension">¥37,800</td>
+            </tr>
+            <tr>
+              <th>雇用保険</th>
+              <td class="amount" data-field="deduction-employment">¥1,800</td>
+            </tr>
+            <tr>
+              <th>所得税</th>
+              <td class="amount" data-field="deduction-tax">¥8,200</td>
+            </tr>
+            <tr>
+              <th>住民税</th>
+              <td class="amount" data-field="deduction-resident">¥1,000</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <div class="note" data-field="note">
+      勤怠・控除内容は労働基準法および就業規則に基づき算出しています。内容に相違がある場合は5営業日以内に総務までご連絡ください。
+    </div>
+
+    <section class="message">
+      <h4>Message from BellTree</h4>
+      <p>
+        「あなたの働きが、べるつりーの理念である “関係者に最善を提供する” ことにつながっています。」<br />
+        「いつもありがとうございます。」
+      </p>
+    </section>
+
+    <footer class="footer">
+      <div>
+        <strong>BellTree 第二の家族</strong> ｜ 〒000-0000 東京都〇〇区〇〇 0-0-0<br />
+        代表 03-0000-0000 ｜ payroll@belltree.example
+      </div>
+      <div>
+        発行日：<span data-field="issued">2024年5月10日</span>
+      </div>
+    </footer>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated HTML template for the Second Family payroll PDF with the requested tree motif, warm palette, and gratitude message
- expose the template through a new `view=payroll_pdf_family` route so it can be previewed via the Apps Script web app or exported to PDF

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c02c525e883219b5b1869a1acab77)