### PR TITLE
Add payroll access roles and payslip portal

### DIFF
--- a/src/attendance.html
+++ b/src/attendance.html
@@ -23,6 +23,10 @@
   .header-main{ display:flex; flex-direction:column; gap:4px; }
   .header-controls{ display:flex; flex-wrap:wrap; gap:12px; align-items:flex-end; }
   .header-actions{ display:flex; align-items:center; gap:12px; margin-left:auto; flex-wrap:wrap; }
+  .tab-nav{ display:flex; gap:8px; margin:8px 0 0; }
+  .tab-button{ border:0; border-radius:999px; padding:6px 16px; background:rgba(37,99,235,0.12); color:#1f2937; font-weight:600; cursor:pointer; }
+  .tab-button.active{ background:var(--brand); color:#fff; }
+  .tab-panel--hidden{ display:none; }
   .paid-leave-widget{ background:rgba(37,99,235,0.08); border-radius:12px; padding:8px 12px; font-size:0.9rem; color:#1f2937; display:flex; flex-direction:column; gap:2px; min-width:160px; }
   .paid-leave-widget strong{ color:#2563eb; font-size:1.05rem; }
   .paid-leave-widget-meta{ font-size:0.8rem; color:var(--muted); }
@@ -108,6 +112,11 @@
   .toast{ position:fixed; left:50%; bottom:32px; transform:translateX(-50%); background:#1f2937; color:#fff; padding:10px 18px; border-radius:999px; font-size:0.9rem; box-shadow:0 12px 30px rgba(15,23,42,0.25); opacity:0; pointer-events:none; transition:opacity .3s ease; z-index:1600; }
   .toast.show{ opacity:1; }
   .auto-adjust-note{ margin-top:4px; font-size:0.8rem; color:#b91c1c; }
+  .payslip-list{ display:flex; flex-direction:column; gap:12px; }
+  .payslip-item{ display:flex; justify-content:space-between; align-items:center; gap:16px; padding:12px 16px; border:1px solid var(--border); border-radius:12px; background:#fff; }
+  .payslip-info{ display:flex; flex-direction:column; gap:4px; }
+  .payslip-title{ font-weight:600; }
+  .payslip-meta{ font-size:0.85rem; color:var(--muted); }
   @media (max-width:768px){
     .attendance-table th.col-date,
     .attendance-table td.col-date{ width:110px; }
@@ -160,7 +169,12 @@
     </div>
   </header>
 
-  <section class="card">
+  <div class="tab-nav" role="tablist">
+    <button class="tab-button active" type="button" data-tab-target="attendance">勤怠</button>
+    <button class="tab-button" type="button" data-tab-target="payslip">給与明細を見る</button>
+  </div>
+
+  <section class="card tab-panel" data-tab-panel="attendance">
     <div class="card-header">
       <h2>勤怠一覧</h2>
       <div id="monthNotice" class="muted"></div>
@@ -169,12 +183,12 @@
     <div class="table-note">退勤は18:00まで・15分単位。休憩時間も15分単位で申請してください。</div>
   </section>
 
-  <section class="card">
+  <section class="card tab-panel" data-tab-panel="attendance">
     <h2>申請履歴</h2>
     <div id="requestHistory" class="muted">読み込み中…</div>
   </section>
 
-  <section class="card" id="adminPanel" hidden>
+  <section class="card tab-panel" data-tab-panel="attendance" id="adminPanel" hidden>
     <h2>管理者：申請承認</h2>
     <div class="admin-section">
       <h3>勤怠修正申請</h3>
@@ -184,6 +198,17 @@
       <h3>有給申請</h3>
       <div id="adminPaidLeaveRequests" class="muted">読み込み中…</div>
     </div>
+  </section>
+
+  <section class="card tab-panel tab-panel--hidden" id="payslipPanel" data-tab-panel="payslip">
+    <div class="card-header">
+      <h2>給与明細</h2>
+      <div class="header-actions">
+        <button id="payslipReloadButton" class="btn ghost" type="button">再読み込み</button>
+      </div>
+    </div>
+    <div id="payslipStatus" class="muted"></div>
+    <div id="payslipList" class="payslip-list muted">読み込み中…</div>
   </section>
 </div>
 
@@ -264,7 +289,7 @@ const MONTH_STORAGE_KEY = 'visitAttendance.selectedMonth';
 const WEEKDAYS = ['日','月','火','水','木','金','土'];
 const LEGACY_SERIAL_DATE_PATTERN = /(1899|1900)/;
 
-let state = { data: null, selectedMonth: null, requestDate: null, paidLeaveDate: null, paidLeavePlan: null, paidLeavePlanToken: 0 };
+let state = { data: null, selectedMonth: null, requestDate: null, paidLeaveDate: null, paidLeavePlan: null, paidLeavePlanToken: 0, activeTab: 'attendance' };
 
 function getSavedMonthKey(){
   try {
@@ -375,6 +400,20 @@ if (paidLeaveDateField) {
   paidLeaveDateField.addEventListener('change', handlePaidLeaveFieldChange);
 }
 
+document.querySelectorAll('[data-tab-target]').forEach(button => {
+  button.addEventListener('click', () => {
+    const target = button.getAttribute('data-tab-target');
+    setActiveTab(target);
+  });
+});
+
+const payslipReloadButton = document.getElementById('payslipReloadButton');
+if (payslipReloadButton) {
+  payslipReloadButton.addEventListener('click', () => {
+    loadMonth(state.selectedMonth || (state.data && state.data.month ? state.data.month.key : null));
+  });
+}
+
 function loadMonth(monthKey){
   setLoading(true, '読み込み中…');
   google.script.run
@@ -401,6 +440,7 @@ function loadMonth(monthKey){
 
 function renderAll(){
   if (!state.data) return;
+  updateTabVisibility();
   renderUser();
   renderMonthSelect();
   renderSummary();
@@ -408,6 +448,29 @@ function renderAll(){
   renderAttendance();
   renderHistory();
   renderAdmin();
+  renderPayslipPanel();
+}
+
+function setActiveTab(tab){
+  const next = tab || 'attendance';
+  if (state.activeTab === next) {
+    updateTabVisibility();
+    return;
+  }
+  state.activeTab = next;
+  updateTabVisibility();
+}
+
+function updateTabVisibility(){
+  const current = state.activeTab || 'attendance';
+  document.querySelectorAll('[data-tab-target]').forEach(button => {
+    const target = button.getAttribute('data-tab-target');
+    button.classList.toggle('active', target === current);
+  });
+  document.querySelectorAll('[data-tab-panel]').forEach(panel => {
+    const target = panel.getAttribute('data-tab-panel');
+    panel.classList.toggle('tab-panel--hidden', target !== current);
+  });
 }
 
 function renderUser(){
@@ -599,6 +662,47 @@ function renderAdmin(){
   panel.hidden = false;
   renderAdminCorrectionRequests(admin.correctionRequests || []);
   renderAdminPaidLeaveRequests(admin.paidLeaveRequests || []);
+}
+
+function renderPayslipPanel(){
+  const list = document.getElementById('payslipList');
+  const status = document.getElementById('payslipStatus');
+  if (!list || !status) return;
+  const payroll = state.data && state.data.payroll ? state.data.payroll : null;
+  if (!payroll) {
+    status.textContent = '給与明細を取得できませんでした。';
+    list.innerHTML = '';
+    return;
+  }
+  if (!payroll.available) {
+    status.textContent = payroll.restrictedReason || '給与明細を閲覧する権限がありません。';
+    list.innerHTML = '';
+    return;
+  }
+  status.textContent = payroll.message || '';
+  const payslips = Array.isArray(payroll.payslips) ? payroll.payslips : [];
+  if (!payslips.length) {
+    list.innerHTML = '<div class="muted">閲覧可能な給与明細はまだありません。</div>';
+    return;
+  }
+  list.innerHTML = payslips.map(item => {
+    const title = escapeHtml(item.monthHint || item.name || '給与明細');
+    const issued = item.createdAtText ? `発行: ${escapeHtml(item.createdAtText)}` : '';
+    const updated = item.updatedAtText && item.updatedAtText !== item.createdAtText
+      ? `更新: ${escapeHtml(item.updatedAtText)}`
+      : '';
+    const size = item.sizeText ? `サイズ: ${escapeHtml(item.sizeText)}` : '';
+    return `
+      <div class="payslip-item">
+        <div class="payslip-info">
+          <div class="payslip-title">${title}</div>
+          ${issued ? `<div class="payslip-meta">${issued}</div>` : ''}
+          ${updated ? `<div class="payslip-meta">${updated}</div>` : ''}
+          ${size ? `<div class="payslip-meta">${size}</div>` : ''}
+        </div>
+        <a class="btn btn-sm" href="${item.url}" target="_blank" rel="noopener">開く</a>
+      </div>`;
+  }).join('');
 }
 
 function renderAdminCorrectionRequests(requests){

--- a/src/payroll.html
+++ b/src/payroll.html
@@ -77,6 +77,22 @@
 
   <section class="card">
     <div class="section-header">
+      <div>
+        <h2>給与明細の一括生成</h2>
+        <p class="meta-line">対象月を選び「全員まとめて生成」を押すと、各従業員のPDFを再計算して上書き保存します（前月以前の修正は不可）。</p>
+      </div>
+      <div class="inline-controls">
+        <label>対象月
+          <input type="month" id="bulkPayslipMonth" />
+        </label>
+        <button id="bulkPayslipButton" type="button" class="btn">全員まとめて生成</button>
+      </div>
+    </div>
+    <div id="bulkPayslipStatus" class="meta-line"></div>
+  </section>
+
+  <section class="card">
+    <div class="section-header">
       <h2>従業員一覧</h2>
       <div style="display:flex; gap:8px; flex-wrap:wrap;">
         <button id="reloadButton" type="button" class="btn ghost">再読み込み</button>
@@ -88,6 +104,7 @@
         <thead>
           <tr>
             <th>氏名</th>
+            <th>拠点</th>
             <th>区分</th>
             <th>基本給</th>
             <th>時給</th>
@@ -100,7 +117,7 @@
             <th></th>
           </tr>
         </thead>
-        <tbody id="employeeTableBody"><tr><td colspan="11" class="table-empty">読み込み中…</td></tr></tbody>
+        <tbody id="employeeTableBody"><tr><td colspan="12" class="table-empty">読み込み中…</td></tr></tbody>
       </table>
     </div>
   </section>
@@ -120,6 +137,9 @@
         </label>
         <label>メール
           <input id="employeeEmail" type="email" placeholder="name@example.com" />
+        </label>
+        <label>拠点
+          <input id="employeeBase" type="text" placeholder="例：八王子" />
         </label>
         <label>雇用区分
           <select id="employmentType" required></select>
@@ -496,6 +516,11 @@ let payrollState = {
   gradeSaving: false,
   selectedId: null,
   selectedGradeId: null,
+  bulk: {
+    month: getPreviousMonthKey(),
+    loading: false,
+    summary: null
+  },
   attendance: {
     month: null,
     loading: false,
@@ -541,6 +566,13 @@ function getCurrentMonthKey(){
   const now = new Date();
   const month = String(now.getMonth() + 1).padStart(2, '0');
   return `${now.getFullYear()}-${month}`;
+}
+
+function getPreviousMonthKey(){
+  const now = new Date();
+  const prev = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+  const month = String(prev.getMonth() + 1).padStart(2, '0');
+  return `${prev.getFullYear()}-${month}`;
 }
 
 function formatMinutesClock(minutes){
@@ -1249,11 +1281,12 @@ function handleInsuranceSummaryTableClick(event){
 function renderTable(){
   const tbody = document.getElementById('employeeTableBody');
   if (!Array.isArray(payrollState.employees) || !payrollState.employees.length){
-    tbody.innerHTML = '<tr><td colspan="11" class="table-empty">登録がありません</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="12" class="table-empty">登録がありません</td></tr>';
     return;
   }
   tbody.innerHTML = payrollState.employees.map(row => {
     const name = row.name ? row.name : '';
+    const baseLocation = row.base || '';
     const employment = row.employmentLabel || '';
     const base = formatCurrency(row.baseSalary);
     const hourly = formatCurrency(row.hourlyWage);
@@ -1268,6 +1301,7 @@ function renderTable(){
     return `
     <tr>
       <td>${name}</td>
+      <td>${baseLocation || '<span class="muted">--</span>'}</td>
       <td>${employment}</td>
       <td>${base}</td>
       <td>${hourly}</td>
@@ -1299,6 +1333,7 @@ function resetForm(){
   document.getElementById('formTitle').textContent = '従業員を登録';
   document.getElementById('formMeta').textContent = '';
   document.getElementById('deleteButton').hidden = true;
+  document.getElementById('employeeBase').value = '';
   updateTransportationAmountState();
   updateGradeHint();
 }
@@ -1324,6 +1359,7 @@ function populateForm(employee){
   document.getElementById('employeeId').value = employee.id || '';
   document.getElementById('employeeName').value = employee.name || '';
   document.getElementById('employeeEmail').value = employee.email || '';
+  document.getElementById('employeeBase').value = employee.base || '';
   document.getElementById('employmentType').value = employee.employmentType || 'employee';
   document.getElementById('employeeGrade').value = employee.grade || '';
   document.getElementById('baseSalary').value = employee.baseSalary != null ? employee.baseSalary : '';
@@ -1352,6 +1388,7 @@ function gatherFormData(){
     id: document.getElementById('employeeId').value,
     name: document.getElementById('employeeName').value,
     email: document.getElementById('employeeEmail').value,
+    base: document.getElementById('employeeBase').value,
     employmentType: document.getElementById('employmentType').value,
     grade: document.getElementById('employeeGrade').value,
     baseSalary: document.getElementById('baseSalary').value,
@@ -1371,12 +1408,12 @@ function gatherFormData(){
 
 function fetchEmployees(){
   const tbody = document.getElementById('employeeTableBody');
-  tbody.innerHTML = '<tr><td colspan="11" class="table-empty">読み込み中…</td></tr>';
+  tbody.innerHTML = '<tr><td colspan="12" class="table-empty">読み込み中…</td></tr>';
   google.script.run
     .withSuccessHandler(res => {
       if (!res || res.ok !== true) {
         showToast(res && res.message ? res.message : '一覧の取得に失敗しました');
-        tbody.innerHTML = '<tr><td colspan="11" class="table-empty">エラーが発生しました</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="12" class="table-empty">エラーが発生しました</td></tr>';
         return;
       }
       payrollState.employees = Array.isArray(res.employees) ? res.employees : [];
@@ -1391,7 +1428,7 @@ function fetchEmployees(){
     })
     .withFailureHandler(err => {
       showToast(err && err.message ? err.message : '一覧の取得に失敗しました');
-      tbody.innerHTML = '<tr><td colspan="11" class="table-empty">エラーが発生しました</td></tr>';
+      tbody.innerHTML = '<tr><td colspan="12" class="table-empty">エラーが発生しました</td></tr>';
     })
     .payrollListEmployees();
 }
@@ -1661,11 +1698,81 @@ function fetchAttendanceSummary(){
     .payrollListAttendanceSummary(payload);
 }
 
+function setBulkFormLoading(isLoading){
+  payrollState.bulk.loading = isLoading;
+  const button = document.getElementById('bulkPayslipButton');
+  const monthInput = document.getElementById('bulkPayslipMonth');
+  if (button) button.disabled = isLoading;
+  if (monthInput) monthInput.disabled = isLoading;
+}
+
+function renderBulkStatus(message){
+  const status = document.getElementById('bulkPayslipStatus');
+  if (!status) return;
+  status.textContent = message || '';
+}
+
+function handleBulkPayslipGenerate(){
+  if (payrollState.bulk.loading) return;
+  const monthInput = document.getElementById('bulkPayslipMonth');
+  const monthValue = monthInput ? monthInput.value : '';
+  if (!monthValue) {
+    showToast('対象月を選択してください');
+    return;
+  }
+  payrollState.bulk.month = monthValue;
+  setBulkFormLoading(true);
+  renderBulkStatus('生成中です…');
+  google.script.run
+    .withSuccessHandler(res => {
+      setBulkFormLoading(false);
+      if (!res || res.ok !== true) {
+        const message = res && res.message ? res.message : '一括生成に失敗しました';
+        showToast(message);
+        renderBulkStatus(message);
+        return;
+      }
+      const summary = res.summary || {};
+      const label = res.month && (res.month.label || res.month.key) ? (res.month.label || res.month.key) : '';
+      let message = `対象 ${summary.total || 0}名 / 成功 ${summary.success || 0} / 失敗 ${summary.failed || 0}`;
+      if (label) {
+        message = `${label}：` + message;
+      }
+      if (Array.isArray(res.errors) && res.errors.length) {
+        const details = res.errors.slice(0, 3).map(err => {
+          const name = err && (err.employeeName || err.employeeId || '');
+          const reason = err && err.message ? err.message : '失敗';
+          return `${name}: ${reason}`;
+        }).join(' / ');
+        if (details) {
+          message += ` / 失敗詳細 ${details}${res.errors.length > 3 ? ' …' : ''}`;
+        }
+      }
+      renderBulkStatus(message);
+      showToast('給与明細を生成しました');
+    })
+    .withFailureHandler(err => {
+      setBulkFormLoading(false);
+      const message = err && err.message ? err.message : '一括生成に失敗しました';
+      showToast(message);
+      renderBulkStatus(message);
+    })
+    .payrollBulkGeneratePayslips({ month: monthValue });
+}
+
 function init(){
   renderOptions(document.getElementById('employmentType'), EMPLOYMENT_OPTIONS);
   renderOptions(document.getElementById('transportationType'), TRANSPORT_OPTIONS);
   renderOptions(document.getElementById('commissionLogic'), COMMISSION_OPTIONS);
   renderOptions(document.getElementById('withholding'), WITHHOLDING_OPTIONS);
+  const bulkMonthInput = document.getElementById('bulkPayslipMonth');
+  if (bulkMonthInput) {
+    bulkMonthInput.value = payrollState.bulk.month;
+  }
+  const bulkButton = document.getElementById('bulkPayslipButton');
+  if (bulkButton) {
+    bulkButton.addEventListener('click', handleBulkPayslipGenerate);
+  }
   document.getElementById('employeeForm').addEventListener('submit', handleSave);
   document.getElementById('employeeTableBody').addEventListener('click', handleTableClick);
   document.getElementById('newButton').addEventListener('click', resetForm);


### PR DESCRIPTION
## Summary
- add payroll base metadata, role assignments, and per-base access enforcement for payroll features
- provide helper utilities for listing payslips and bulk generating PDFs while respecting edit windows
- surface payroll data in the attendance portal, including a payslip tab and payroll master UI updates such as bulk generation controls

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c0b0af4e08321beaa2c1ca37c09f0)