### PR TITLE
Track consent dismissal on treatment sheet

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3284,7 +3284,12 @@ function shouldShowConsentVerificationButton(news){
 }
 
 function shouldShowConsentDismissButton(news){
-  return isConsentReminderNews(news);
+  if (!isConsentReminderNews(news)) return false;
+  const header = _currentHeader;
+  if (!header) return true;
+  const dismissed = !!(header.consentNewsDismissed);
+  const hasConsentDate = !!(header.consentDate && String(header.consentDate).trim());
+  return !(dismissed || hasConsentDate);
 }
 
 function shouldShowConsentEditButton(news){


### PR DESCRIPTION
## Summary
- add a NewsConsentDismissed column to the treatment sheet and ensure it is created automatically
- read and write consent dismissal flags from the latest treatment row for each patient, clearing consent news when dismissed
- hide the consent dismissal action in the UI when a consent date or dismissal flag already exists

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923bbda7c288321b608535bec8479e2)