### PR TITLE
Improve consent reminder detection and hiding

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -5358,6 +5358,16 @@ function normalizeConsentNewsMeta_(meta, message){
   return { meta: nextMeta, metaType: normalizedType, changed };
 }
 
+function isConsentReminderMessage_(message){
+  if (!message) return false;
+  const text = String(message);
+  return (
+    text.indexOf('同意書受渡が必要です') >= 0
+      || text.indexOf('同意書の取得') >= 0
+      || text.indexOf('同意書取得') >= 0
+  );
+}
+
 function isConsentReminderNews_(news){
   if (!news) return false;
   const type = String(news.type || '').trim();
@@ -5365,8 +5375,7 @@ function isConsentReminderNews_(news){
   const metaType = normalizeNewsMetaType_(resolveNewsMetaType_(news.meta));
   if (metaType === 'consent_reminder') return true;
   if (metaType === 'consent_verification') return false;
-  const message = String(news.message || '');
-  return message.indexOf('同意書受渡が必要です') >= 0;
+  return isConsentReminderMessage_(news.message);
 }
 
 function shouldHideConsentNews_(news, options){

--- a/src/app.html
+++ b/src/app.html
@@ -3064,7 +3064,9 @@ function loadNews(patientId, next){
         if (done) done();
         return;
       }
-      const shouldHideConsentNews = !!(_currentHeader && _currentHeader.consentNewsDismissed);
+      const hasConsentDate = !!(_currentHeader && _currentHeader.consentDate && String(_currentHeader.consentDate).trim());
+      const consentNewsDismissed = !!(_currentHeader && _currentHeader.consentNewsDismissed);
+      const shouldHideConsentNews = hasConsentDate || consentNewsDismissed;
       const visibleList = shouldHideConsentNews
         ? list.filter(item => !isConsentReminderNews(item))
         : list.slice();
@@ -3253,14 +3255,23 @@ function getNewsMetaType(news){
   return '';
 }
 
+function isConsentReminderMessage(message){
+  if (!message) return false;
+  const text = String(message);
+  return (
+    text.indexOf('同意書受渡が必要です') >= 0
+      || text.indexOf('同意書の取得') >= 0
+      || text.indexOf('同意書取得') >= 0
+  );
+}
+
 function isConsentReminderNews(news){
   if(!news) return false;
   if (String(news.type || '').trim() !== '同意') return false;
   const metaType = getNewsMetaType(news);
   if (metaType === 'consent_verification') return false;
   if (metaType === 'consent_reminder') return true;
-  const message = String(news.message || '');
-  return message.indexOf('同意書受渡が必要です') >= 0;
+  return isConsentReminderMessage(news.message);
 }
 
 function resolveNewsStatus(news){
@@ -3276,8 +3287,7 @@ function resolveNewsStatus(news){
   if (type !== '同意') return '';
   if (metaType === 'consent_verification') return 'consent-doctor-report';
   if (metaType === 'consent_reminder') return 'consent-reminder';
-  const message = String(news.message || '');
-  if (message.indexOf('同意書受渡が必要です') >= 0) return 'consent-reminder';
+  if (isConsentReminderMessage(news.message)) return 'consent-reminder';
   return '';
 }
 


### PR DESCRIPTION
## Summary
- expand consent reminder detection to treat "同意書の取得" related messages as reminders
- hide consent reminder news client-side when consent is already recorded or dismissed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923c5b5317083218a4276e73afbf691)