### PR TITLE
Add CSV upload flow for withholding tax tables

### DIFF
--- a/src/payroll.html
+++ b/src/payroll.html
@@ -211,21 +211,21 @@
     <div class="section-header">
       <div>
         <h2>所得税（源泉徴収）設定</h2>
-        <p class="meta-line" id="incomeTaxMeta">税額表のCSV URLを保存し、必要に応じて再読み込みします。</p>
+        <p class="meta-line" id="incomeTaxMeta">国税庁の税額表CSVをアップロードし、必要に応じて再解析します。</p>
       </div>
       <div class="inline-controls">
-        <button id="incomeTaxReloadButton" type="button" class="btn">税額表を再読み込み</button>
+        <button id="incomeTaxReloadButton" type="button" class="btn">保存済み税額表を再解析</button>
       </div>
     </div>
     <div class="form-grid">
-      <label>税額表 CSV URL
-        <input id="incomeTaxUrl" type="url" placeholder="https://www.nta.go.jp/.../xxx.csv" />
-        <small class="muted">国税庁の源泉徴収税額表（CSV）のURLを入力してください</small>
+      <label>税額表（CSVアップロード）
+        <input id="incomeTaxFile" type="file" accept=".csv,text/csv" />
+        <small class="muted">国税庁の源泉徴収税額表（Excel）をCSVに変換してアップロードしてください</small>
       </label>
     </div>
     <div class="form-actions">
-      <button id="incomeTaxSaveButton" type="button" class="btn">URLを保存</button>
-      <button id="incomeTaxResetButton" type="button" class="btn ghost">入力をリセット</button>
+      <button id="incomeTaxSaveButton" type="button" class="btn">CSVをアップロード</button>
+      <button id="incomeTaxResetButton" type="button" class="btn ghost">選択をリセット</button>
     </div>
   </section>
 
@@ -574,12 +574,12 @@ let payrollState = {
     summary: null
   },
   incomeTax: {
-    url: '',
     loading: false,
     saving: false,
     reloading: false,
     fetchedAt: null,
-    stats: null
+    stats: null,
+    fileName: ''
   },
   socialInsurance: {
     rates: { ...SOCIAL_INSURANCE_RATE_DEFAULTS },
@@ -667,17 +667,17 @@ function formatTransportation(row){
 function setIncomeTaxFormLoading(isSaving){
   payrollState.incomeTax.saving = isSaving;
   const saveButton = document.getElementById('incomeTaxSaveButton');
-  if (saveButton) saveButton.disabled = isSaving;
-  const urlInput = document.getElementById('incomeTaxUrl');
-  if (urlInput) urlInput.disabled = isSaving || payrollState.incomeTax.reloading;
+  if (saveButton) saveButton.disabled = isSaving || payrollState.incomeTax.reloading;
+  const fileInput = document.getElementById('incomeTaxFile');
+  if (fileInput) fileInput.disabled = isSaving || payrollState.incomeTax.reloading;
 }
 
 function setIncomeTaxReloading(isLoading){
   payrollState.incomeTax.reloading = isLoading;
   const reloadButton = document.getElementById('incomeTaxReloadButton');
-  if (reloadButton) reloadButton.disabled = isLoading;
-  const urlInput = document.getElementById('incomeTaxUrl');
-  if (urlInput) urlInput.disabled = isLoading || payrollState.incomeTax.saving;
+  if (reloadButton) reloadButton.disabled = isLoading || payrollState.incomeTax.saving;
+  const fileInput = document.getElementById('incomeTaxFile');
+  if (fileInput) fileInput.disabled = isLoading || payrollState.incomeTax.saving;
 }
 
 function renderIncomeTaxMeta(message){
@@ -694,21 +694,22 @@ function renderIncomeTaxMeta(message){
   const summary = stats
     ? `甲欄 ${stats.koDependents || 0}件 / 乙欄 ${stats.otsuRows || 0}行`
     : '未読み込み';
-  meta.textContent = `最終取得: ${fetchedAt} / ${summary}`;
+  const fileLabel = payrollState.incomeTax.fileName ? ` / ファイル: ${payrollState.incomeTax.fileName}` : '';
+  meta.textContent = `最終取得: ${fetchedAt} / ${summary}${fileLabel}`;
 }
 
 function renderIncomeTaxSettings(){
-  const urlInput = document.getElementById('incomeTaxUrl');
-  if (urlInput) {
-    urlInput.value = payrollState.incomeTax.url || '';
+  const fileInput = document.getElementById('incomeTaxFile');
+  if (fileInput) {
+    fileInput.value = '';
   }
   renderIncomeTaxMeta();
 }
 
 function resetIncomeTaxForm(){
-  const urlInput = document.getElementById('incomeTaxUrl');
-  if (urlInput) {
-    urlInput.value = payrollState.incomeTax.url || '';
+  const fileInput = document.getElementById('incomeTaxFile');
+  if (fileInput) {
+    fileInput.value = '';
   }
 }
 
@@ -723,9 +724,9 @@ function fetchIncomeTaxSettings(){
         return;
       }
       const settings = res.settings || {};
-      payrollState.incomeTax.url = settings.url || '';
       payrollState.incomeTax.fetchedAt = settings.fetchedAt || null;
       payrollState.incomeTax.stats = { koDependents: settings.koDependents || 0, otsuRows: settings.otsuRows || 0 };
+      payrollState.incomeTax.fileName = settings.fileName || '';
       renderIncomeTaxSettings();
     })
     .withFailureHandler(err => {
@@ -737,54 +738,59 @@ function fetchIncomeTaxSettings(){
 
 function handleIncomeTaxSave(){
   if (payrollState.incomeTax.saving) return;
-  const urlInput = document.getElementById('incomeTaxUrl');
-  const url = urlInput ? urlInput.value : '';
+  const fileInput = document.getElementById('incomeTaxFile');
+  const file = fileInput && fileInput.files && fileInput.files[0];
+  if (!file) {
+    showToast('CSVファイルを選択してください');
+    return;
+  }
   setIncomeTaxFormLoading(true);
   google.script.run
     .withSuccessHandler(res => {
       setIncomeTaxFormLoading(false);
       if (!res || res.ok !== true) {
-        showToast(res && res.message ? res.message : 'URLの保存に失敗しました');
+        showToast(res && res.message ? res.message : 'CSVのアップロードに失敗しました');
         return;
       }
-      payrollState.incomeTax.url = res.url || url;
-      showToast('CSV URLを保存しました');
+      payrollState.incomeTax.fetchedAt = res.fetchedAt || null;
+      payrollState.incomeTax.stats = res.stats || null;
+      payrollState.incomeTax.fileName = res.fileName || '';
+      showToast('税額表を保存しました');
       renderIncomeTaxSettings();
+      fetchDeductionSummary();
     })
     .withFailureHandler(err => {
       setIncomeTaxFormLoading(false);
-      showToast(err && err.message ? err.message : 'URLの保存に失敗しました');
+      showToast(err && err.message ? err.message : 'CSVのアップロードに失敗しました');
     })
-    .payrollSaveIncomeTaxCsvUrl({ url });
+    .payrollUploadIncomeTaxCsv(file);
 }
 
 function handleIncomeTaxReload(){
   if (payrollState.incomeTax.reloading) return;
-  const urlInput = document.getElementById('incomeTaxUrl');
-  const url = urlInput ? urlInput.value : '';
   setIncomeTaxReloading(true);
-  renderIncomeTaxMeta('税額表を読み込み中です…');
+  renderIncomeTaxMeta('保存済みの税額表を再解析しています…');
   google.script.run
     .withSuccessHandler(res => {
       setIncomeTaxReloading(false);
       if (!res || res.ok !== true) {
-        renderIncomeTaxMeta(res && res.message ? res.message : '税額表の再取得に失敗しました');
-        showToast(res && res.message ? res.message : '税額表の再取得に失敗しました');
+        renderIncomeTaxMeta(res && res.message ? res.message : '税額表の再解析に失敗しました');
+        showToast(res && res.message ? res.message : '税額表の再解析に失敗しました');
         return;
       }
-      payrollState.incomeTax.url = res.url || url;
       payrollState.incomeTax.fetchedAt = res.fetchedAt || null;
       payrollState.incomeTax.stats = res.stats || null;
+      payrollState.incomeTax.fileName = res.fileName || '';
       renderIncomeTaxSettings();
-      showToast('税額表を更新しました');
+      showToast('税額表を再解析しました');
       fetchDeductionSummary();
     })
     .withFailureHandler(err => {
       setIncomeTaxReloading(false);
-      renderIncomeTaxMeta(err && err.message ? err.message : '税額表の再取得に失敗しました');
-      showToast(err && err.message ? err.message : '税額表の再取得に失敗しました');
+      renderIncomeTaxMeta(err && err.message ? err.message : '税額表の再解析に失敗しました');
+      showToast(err && err.message ? err.message : '税額表の再解析に失敗しました');
     })
-    .payrollReloadIncomeTaxTables({ url });
+    .payrollReloadIncomeTaxTables();
 }
 
 


### PR DESCRIPTION
## Summary
- replace the income tax settings URL form with a CSV upload flow and refreshed messaging
- store uploaded withholding tax tables in ScriptProperties with metadata for reuse
- add server-side handlers to parse uploaded CSV data and reparse saved tables for calculations

## Testing
- Not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923e29669408321be42185a715fe613)