### PR TITLE
Improve income tax upload feedback messaging

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -4433,7 +4433,8 @@ function payrollReloadIncomeTaxTables(payload){
         ok: true,
         fetchedAt: saved && saved.fetchedAt ? saved.fetchedAt : null,
         stats: saved && saved.stats ? saved.stats : null,
-        fileName: saved && saved.fileName ? saved.fileName : ''
+        fileName: saved && saved.fileName ? saved.fileName : '',
+        message: '保存済みの税額表を再解析しました（甲欄 ' + (saved && saved.stats ? saved.stats.koDependents : 0) + '件 / 乙欄 ' + (saved && saved.stats ? saved.stats.otsuRows : 0) + '行）'
       };
     } catch (err) {
       return { ok: false, reason: 'parse_failed', message: '保存済みの税額表を再解析できませんでした: ' + (err && err.message ? err.message : err) };
@@ -4482,7 +4483,9 @@ function payrollUploadIncomeTaxCsv(file){
       ok: true,
       fetchedAt: saved && saved.fetchedAt ? saved.fetchedAt : null,
       stats: saved && saved.stats ? saved.stats : { koDependents: koCount, otsuRows: otsuCount },
-      fileName: saved && saved.fileName ? saved.fileName : ''
+      fileName: saved && saved.fileName ? saved.fileName : '',
+      message: '税額表のCSVをアップロードしました（甲欄 ' + (saved && saved.stats ? saved.stats.koDependents : koCount) +
+        '件 / 乙欄 ' + (saved && saved.stats ? saved.stats.otsuRows : otsuCount) + '行）'
     };
   });
 }

--- a/src/payroll.html
+++ b/src/payroll.html
@@ -784,7 +784,9 @@ function handleIncomeTaxSave(){
         return;
       }
       setIncomeTaxStateFromResponse(res);
-      const successMessage = formatIncomeTaxResultMessage('税額表のCSVをアップロードしました');
+      const successMessage = res && res.message
+        ? res.message
+        : formatIncomeTaxResultMessage('税額表のCSVをアップロードしました');
       renderIncomeTaxSettings();
       renderIncomeTaxMeta(successMessage);
       showToast(successMessage);
@@ -812,7 +814,9 @@ function handleIncomeTaxReload(){
         return;
       }
       setIncomeTaxStateFromResponse(res);
-      const successMessage = formatIncomeTaxResultMessage('保存済みの税額表を再解析しました');
+      const successMessage = res && res.message
+        ? res.message
+        : formatIncomeTaxResultMessage('保存済みの税額表を再解析しました');
       renderIncomeTaxSettings();
       renderIncomeTaxMeta(successMessage);
       showToast(successMessage);


### PR DESCRIPTION
## Summary
- add explicit success messages to income tax CSV upload and reload responses with parsed counts
- show backend-provided success messages in the payroll income tax UI so users see immediate results

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69241078856883218b67b380287d2cb3)