### PR TITLE
Implement billing output policy and billing menus

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -9719,6 +9719,13 @@ function doGet(e) {
 /***** メニュー *****/
 function onOpen(){
   const ui = SpreadsheetApp.getUi();
+  ui.createMenu('請求処理')
+    .addItem('請求データ生成（施術録 → JSON）','billingGenerateJsonFromMenu')
+    .addItem('請求一覧Excel出力','billingGenerateExcelFromMenu')
+    .addItem('口座振替CSV出力','billingGenerateCsvFromMenu')
+    .addItem('入金結果反映','billingApplyPaymentResultsFromMenu')
+    .addItem('合算請求書出力','billingGenerateCombinedPdfsFromMenu')
+    .addToUi();
   ui.createMenu('請求')
     .addItem('今月の集計（回数+負担割合）','rebuildInvoiceForCurrentMonth')
     .addToUi();

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -1,29 +1,38 @@
 /***** Output layer: billing Excel/CSV/history generation *****/
 
-const BILLING_OUTPUT_HEADER = [
-  '請求月',
-  '施術録番号',
-  '氏名',
-  'フリガナ',
-  '保険区分',
-  '負担割合',
-  '施術回数',
-  '単価',
-  '合計金額',
-  '請求金額',
-  '銀行コード',
-  '支店コード',
-  '口座番号',
-  '入金ステータス',
-  '未入金額',
-  '請求総額',
-  '新規'
-];
+const BILLING_EXCEL_COLUMNS = {
+  nameKanji: columnLetterToNumber_('F'),
+  bankCode: columnLetterToNumber_('N'),
+  branchCode: columnLetterToNumber_('O'),
+  constantOne: columnLetterToNumber_('P'),
+  accountNumber: columnLetterToNumber_('Q'),
+  nameKana: columnLetterToNumber_('R'),
+  billingAmount: columnLetterToNumber_('S'),
+  isNew: columnLetterToNumber_('U')
+};
 
-function formatBillingOutputRows(billingJson) {
+function normalizeBillingAmount_(item) {
+  if (!item) return 0;
+  if (item.grandTotal != null && item.grandTotal !== '') return item.grandTotal;
+  if (item.billingAmount != null && item.billingAmount !== '') return item.billingAmount;
+  return 0;
+}
+
+function buildBillingExcelRows_(billingJson) {
   if (!Array.isArray(billingJson)) {
     throw new Error('請求データが不正です');
   }
+  const maxCol = BILLING_EXCEL_COLUMNS.isNew;
+  const header = Array(maxCol).fill('');
+  header[BILLING_EXCEL_COLUMNS.nameKanji - 1] = 'nameKanji';
+  header[BILLING_EXCEL_COLUMNS.bankCode - 1] = 'bankCode';
+  header[BILLING_EXCEL_COLUMNS.branchCode - 1] = 'branchCode';
+  header[BILLING_EXCEL_COLUMNS.constantOne - 1] = '1固定';
+  header[BILLING_EXCEL_COLUMNS.accountNumber - 1] = 'accountNumber';
+  header[BILLING_EXCEL_COLUMNS.nameKana - 1] = 'nameKana';
+  header[BILLING_EXCEL_COLUMNS.billingAmount - 1] = 'billingAmount/grandTotal';
+  header[BILLING_EXCEL_COLUMNS.isNew - 1] = 'isNew';
+
   const sorted = billingJson.slice().sort((a, b) => {
     const aid = Number(a && a.patientId);
     const bid = Number(b && b.patientId);
@@ -33,52 +42,30 @@ function formatBillingOutputRows(billingJson) {
     return aid - bid;
   });
 
-  const rows = sorted.map(item => [
-    item && item.billingMonth ? item.billingMonth : '',
-    item && item.patientId ? item.patientId : '',
-    item && item.nameKanji ? item.nameKanji : '',
-    item && item.nameKana ? item.nameKana : '',
-    item && item.insuranceType ? item.insuranceType : '',
-    item && item.burdenRate != null ? item.burdenRate : '',
-    item && item.visitCount != null ? item.visitCount : '',
-    item && item.unitPrice != null ? item.unitPrice : '',
-    item && item.total != null ? item.total : '',
-    item && item.billingAmount != null ? item.billingAmount : '',
-    item && item.bankCode ? item.bankCode : '',
-    item && item.branchCode ? item.branchCode : '',
-    item && item.accountNumber ? item.accountNumber : '',
-    item && item.bankStatus ? item.bankStatus : '',
-    item && item.carryOverAmount != null ? item.carryOverAmount : '',
-    item && item.grandTotal != null ? item.grandTotal : '',
-    item && item.isNew ? 1 : 0
-  ]);
+  const rows = sorted.map(item => {
+    const row = Array(maxCol).fill('');
+    row[BILLING_EXCEL_COLUMNS.nameKanji - 1] = item && item.nameKanji ? item.nameKanji : '';
+    row[BILLING_EXCEL_COLUMNS.bankCode - 1] = item && item.bankCode ? item.bankCode : '';
+    row[BILLING_EXCEL_COLUMNS.branchCode - 1] = item && item.branchCode ? item.branchCode : '';
+    row[BILLING_EXCEL_COLUMNS.constantOne - 1] = 1;
+    row[BILLING_EXCEL_COLUMNS.accountNumber - 1] = item && item.accountNumber ? item.accountNumber : '';
+    row[BILLING_EXCEL_COLUMNS.nameKana - 1] = item && item.nameKana ? item.nameKana : '';
+    row[BILLING_EXCEL_COLUMNS.billingAmount - 1] = normalizeBillingAmount_(item);
+    row[BILLING_EXCEL_COLUMNS.isNew - 1] = item && item.isNew ? 1 : 0;
+    return row;
+  });
 
-  return [BILLING_OUTPUT_HEADER].concat(rows);
-}
-
-function createBillingOutputSheet_(rows, sheetName) {
-  const workbook = ss();
-  const targetName = sheetName || '請求データ出力';
-  let sheet = workbook.getSheetByName(targetName);
-  if (!sheet) {
-    sheet = workbook.insertSheet(targetName);
-  } else {
-    sheet.clear();
-  }
-  if (rows.length) {
-    sheet.getRange(1, 1, rows.length, rows[0].length).setValues(rows);
-  }
-  return sheet;
+  return [header].concat(rows);
 }
 
 function createBillingExcelFile(billingJson, options) {
   const opts = options || {};
   const billingMonth = opts.billingMonth || (Array.isArray(billingJson) && billingJson.length && billingJson[0].billingMonth) || '';
-  const baseName = opts.fileName || (billingMonth ? '請求データ_' + billingMonth : '請求データ');
-  const rows = formatBillingOutputRows(billingJson);
+  const baseName = opts.fileName || (billingMonth ? '請求一覧_' + billingMonth : '請求一覧');
+  const rows = buildBillingExcelRows_(billingJson);
   const temp = SpreadsheetApp.create(baseName);
   const sheet = temp.getSheets()[0];
-  sheet.setName('請求データ');
+  sheet.setName('請求一覧');
   if (rows.length) {
     sheet.getRange(1, 1, rows.length, rows[0].length).setValues(rows);
   }
@@ -119,8 +106,20 @@ function escapeBillingCsvCell_(value) {
 function createBillingCsvFile(billingJson, options) {
   const opts = options || {};
   const billingMonth = opts.billingMonth || (Array.isArray(billingJson) && billingJson.length && billingJson[0].billingMonth) || '';
-  const baseName = opts.fileName || (billingMonth ? '請求データ_' + billingMonth : '請求データ');
-  const rows = formatBillingOutputRows(billingJson);
+  const baseName = opts.fileName || (billingMonth ? '口座振替_' + billingMonth : '口座振替');
+  const sorted = Array.isArray(billingJson) ? billingJson.slice().sort((a, b) => {
+    const aid = Number(a && a.patientId);
+    const bid = Number(b && b.patientId);
+    if (isNaN(aid) && isNaN(bid)) return 0;
+    if (isNaN(aid)) return 1;
+    if (isNaN(bid)) return -1;
+    return aid - bid;
+  }) : [];
+  const rows = sorted.map(item => [
+    item && item.nameKanji ? item.nameKanji : '',
+    item && item.nameKana ? item.nameKana : '',
+    normalizeBillingAmount_(item)
+  ]);
   const csv = rows.map(row => row.map(escapeBillingCsvCell_).join(',')).join('\r\n');
   const blob = Utilities.newBlob(csv, 'text/csv', baseName + '.csv');
   let folder = null;
@@ -134,62 +133,135 @@ function createBillingCsvFile(billingJson, options) {
     fileId: file.getId(),
     url: file.getUrl(),
     name: file.getName(),
-    rowCount: rows.length ? rows.length - 1 : 0,
+    rowCount: rows.length,
     billingMonth
   };
 }
 
 function ensureBillingHistorySheet_() {
-  const SHEET_NAME = '請求出力履歴';
+  const SHEET_NAME = '請求履歴';
   const workbook = ss();
   let sheet = workbook.getSheetByName(SHEET_NAME);
   if (!sheet) {
     sheet = workbook.insertSheet(SHEET_NAME);
-    sheet.getRange(1, 1, 1, 8).setValues([[
-      '出力日時',
-      '請求月',
-      'レコード数',
-      'Excel ファイルID',
-      'Excel URL',
-      'CSV ファイルID',
-      'CSV URL',
-      'メモ'
+    sheet.getRange(1, 1, 1, 11).setValues([[
+      'billingMonth',
+      'patientId',
+      'nameKanji',
+      'billingAmount',
+      'carryOverAmount',
+      'grandTotal',
+      'paidAmount',
+      'unpaidAmount',
+      'bankStatus',
+      'updatedAt',
+      'memo'
     ]]);
   }
   return sheet;
 }
 
-function recordBillingOutputHistory(params) {
+function appendBillingHistoryRows(billingJson, options) {
+  const opts = options || {};
   const sheet = ensureBillingHistorySheet_();
-  const row = [
-    new Date(),
-    params && params.billingMonth ? params.billingMonth : '',
-    params && params.rowCount ? params.rowCount : 0,
-    params && params.excelFileId ? params.excelFileId : '',
-    params && params.excelUrl ? params.excelUrl : '',
-    params && params.csvFileId ? params.csvFileId : '',
-    params && params.csvUrl ? params.csvUrl : '',
-    params && params.note ? params.note : ''
-  ];
-  sheet.insertRows(2, 1);
-  sheet.getRange(2, 1, 1, row.length).setValues([row]);
-  return {
-    billingMonth: row[1],
-    rowNumber: 2
-  };
+  const billingMonth = opts.billingMonth || (Array.isArray(billingJson) && billingJson.length && billingJson[0].billingMonth) || '';
+  const memo = opts.memo || '';
+  const rows = (billingJson || []).map(item => {
+    const billingAmount = item && item.billingAmount != null ? item.billingAmount : 0;
+    const carryOver = item && item.carryOverAmount != null ? item.carryOverAmount : 0;
+    const paid = item && item.paidAmount != null ? item.paidAmount : 0;
+    const grandTotal = normalizeBillingAmount_(item);
+    const unpaid = grandTotal - paid;
+    return [
+      billingMonth,
+      item && item.patientId ? item.patientId : '',
+      item && item.nameKanji ? item.nameKanji : '',
+      billingAmount,
+      carryOver,
+      grandTotal,
+      paid,
+      unpaid,
+      item && item.bankStatus ? item.bankStatus : '',
+      new Date(),
+      memo
+    ];
+  });
+  if (rows.length) {
+    sheet.insertRows(2, rows.length);
+    sheet.getRange(2, 1, rows.length, rows[0].length).setValues(rows);
+  }
+  return { billingMonth, inserted: rows.length };
+}
+
+function applyPaymentResultsToHistory(billingMonth, bankStatuses) {
+  const sheet = ensureBillingHistorySheet_();
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) return { billingMonth, updated: 0 };
+  const data = sheet.getRange(2, 1, lastRow - 1, 11).getValues();
+  const updates = [];
+  const statusMap = bankStatuses || {};
+  data.forEach((row, idx) => {
+    if (row[0] !== billingMonth) return;
+    const pid = row[1];
+    const status = statusMap[pid] && statusMap[pid].bankStatus ? statusMap[pid].bankStatus : null;
+    if (!status) return;
+    const newRow = row.slice();
+    newRow[8] = status;
+    newRow[9] = new Date();
+    updates.push({ rowNumber: idx + 2, values: newRow });
+  });
+  updates.forEach(update => {
+    sheet.getRange(update.rowNumber, 1, 1, update.values.length).setValues([update.values]);
+  });
+  return { billingMonth, updated: updates.length };
+}
+
+function generateCombinedBillingPdfs(billingJson, options) {
+  const opts = options || {};
+  const billingMonth = opts.billingMonth || (Array.isArray(billingJson) && billingJson.length && billingJson[0].billingMonth) || '';
+  const targets = (billingJson || []).filter(item => item && item.shouldCombine);
+  const results = [];
+  let folder = null;
+  try {
+    folder = getParentFolder_();
+  } catch (e) {
+    folder = null;
+  }
+
+  targets.forEach(item => {
+    const title = '合算請求書_' + billingMonth + '_' + (item.patientId || '');
+    const doc = DocumentApp.create(title);
+    const body = doc.getBody();
+    body.appendParagraph('合算請求書');
+    body.appendParagraph('請求月: ' + billingMonth);
+    body.appendParagraph('患者ID: ' + (item.patientId || ''));
+    body.appendParagraph('氏名: ' + (item.nameKanji || ''));
+    body.appendParagraph('請求金額: ' + normalizeBillingAmount_(item));
+    body.appendParagraph('未入金額: ' + (item && item.carryOverAmount != null ? item.carryOverAmount : 0));
+    body.appendParagraph('未入金分を含む合算請求となります。');
+
+    const docFile = DriveApp.getFileById(doc.getId());
+    if (folder) {
+      folder.addFile(docFile);
+      DriveApp.getRootFolder().removeFile(docFile);
+    }
+    const pdfBlob = docFile.getBlob().getAs(MimeType.PDF).setName(title + '.pdf');
+    const pdfFile = folder ? folder.createFile(pdfBlob) : DriveApp.createFile(pdfBlob);
+    docFile.setTrashed(true);
+    results.push({
+      patientId: item.patientId,
+      fileId: pdfFile.getId(),
+      url: pdfFile.getUrl(),
+      name: pdfFile.getName()
+    });
+  });
+
+  return { billingMonth, count: results.length, files: results };
 }
 
 function generateBillingOutputs(billingJson, options) {
   const excel = createBillingExcelFile(billingJson, options);
   const csv = createBillingCsvFile(billingJson, options);
-  const history = recordBillingOutputHistory({
-    billingMonth: excel.billingMonth || csv.billingMonth,
-    rowCount: excel.rowCount,
-    excelFileId: excel.fileId,
-    excelUrl: excel.url,
-    csvFileId: csv.fileId,
-    csvUrl: csv.url,
-    note: options && options.note ? options.note : ''
-  });
+  const history = appendBillingHistoryRows(billingJson, { billingMonth: excel.billingMonth || csv.billingMonth, memo: options && options.note });
   return { excel, csv, history };
 }


### PR DESCRIPTION
## Summary
- align billing Excel/CSV generation with the specified column mapping, naming, and billing history records
- add menu entry points for billing JSON generation, outputs, payment reflection, and combined invoice PDFs
- support 請求履歴 updates and combined invoice PDF exports for shouldCombine patients

## Testing
- Not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692680bb15508321b6bc91c058d69117)