### PR TITLE
Implement payment result PDF parsing for billing history

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -60,6 +60,20 @@ function applyBillingPaymentResultsEntry(billingMonth) {
   return applyPaymentResultsToHistory(month.key, bankStatuses);
 }
 
+function applyBillingPaymentResultPdfEntry(billingMonth, fileId, options) {
+  const month = normalizeBillingMonthInput(billingMonth);
+  const source = getBillingSourceData(month);
+  const billingJson = generateBillingJsonFromSource(source);
+  const file = DriveApp.getFileById(fileId);
+  const pdfBlob = file.getBlob();
+  const result = applyPaymentResultPdf(month.key, pdfBlob, billingJson);
+  return Object.assign({}, result, {
+    fileId,
+    fileName: file.getName(),
+    billingJson
+  });
+}
+
 function promptBillingMonthInput_() {
   const ui = SpreadsheetApp.getUi();
   const today = new Date();


### PR DESCRIPTION
## Summary
- parse payment result PDFs to extract bank statuses and payments and map them to billing records
- update billing history rows with bank status, paid amount, and unpaid amount using parsed results
- add an entry point to apply payment results from an uploaded PDF for a given billing month

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692691135d408321843845d40b8dd028)