### PR TITLE
Add ss helper for billing scripts

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -6,6 +6,14 @@
  */
 
 /**
+ * Return the active spreadsheet (utility retained for compatibility).
+ * @return {SpreadsheetApp.Spreadsheet}
+ */
+function ss() {
+  return SpreadsheetApp.getActiveSpreadsheet();
+}
+
+/**
  * Resolve source data for billing generation (patients, visits, bank statuses).
  * @param {string|Date|Object} billingMonth - YYYYMM string, Date, or normalized month object.
  * @return {Object} normalized source data including month metadata.


### PR DESCRIPTION
## Summary
- add the missing ss() helper that returns the active spreadsheet to avoid billing menu failures

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926ba03053c8321b1f44bb0d47084fb)