### PR TITLE
Handle missing billing payment sheets gracefully

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -434,6 +434,18 @@ function getBillingPaymentResults(billingMonth) {
   return map;
 }
 
+function getBillingPaymentResultsIfExists_(billingMonth) {
+  try {
+    return getBillingPaymentResults(billingMonth);
+  } catch (e) {
+    const message = e && e.message ? String(e.message) : '';
+    if (message.indexOf('入金結果シートが見つかりません') >= 0) {
+      return {};
+    }
+    throw e;
+  }
+}
+
 function getBillingSourceData(billingMonth) {
   const month = normalizeBillingMonthInput(billingMonth);
   const patientRecords = getBillingPatientRecords();
@@ -448,6 +460,6 @@ function getBillingSourceData(billingMonth) {
     patients: patientMap,
     patientMap,
     bankInfoByName: buildBankLookupByKanji_(bankRecords),
-    bankStatuses: getBillingPaymentResults(month)
+    bankStatuses: getBillingPaymentResultsIfExists_(month)
   };
 }


### PR DESCRIPTION
## Summary
- add a safe helper to return empty payment results when the month sheet does not exist
- use the safe helper when building billing source data so JSON generation works before payment sheets are created

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926c981f108832198beba15daeb8b03)