### PR TITLE
Add base URL routing guard to billing view

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -92,6 +92,7 @@
 </div>
 
 <script>
+const baseUrl = '<?= baseUrl ?>' || '';
 const billingState = {
   loading: false,
   result: null
@@ -116,7 +117,16 @@ function setLoading(isLoading, message){
   }
 }
 
+function ensureBillingRoute(){
+  if(!baseUrl) return;
+  const targetUrl = baseUrl + '?view=billing';
+  if(window.location.href !== targetUrl){
+    window.history.replaceState({}, '', targetUrl);
+  }
+}
+
 function loadBillingPage(){
+  ensureBillingRoute();
   const input = qs('billingMonth');
   if(!input.value){
     input.value = formatDefaultMonth();


### PR DESCRIPTION
## Summary
- inject the Apps Script base URL into billing.html for routing awareness
- ensure the billing page replaces the URL to the billing route when loaded

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926d1ad9b2c832191b0c38be58116ec)