### PR TITLE
Ensure billing burden rates and massage handling follow specifications

### DIFF
--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -43,7 +43,8 @@ function normalizeBurdenMultiplier_(burdenRate, insuranceType) {
   if (String(insuranceType || '').trim() === '自費') return 1;
   const raw = Number(burdenRate);
   if (!Number.isFinite(raw) || raw <= 0) return 0;
-  if (raw <= 1) return raw;
+  if (raw < 1) return raw;
+  if (raw < 10) return raw / 10;
   return raw / 10;
 }
 
@@ -54,15 +55,15 @@ function resolveBillingUnitPrice_(params) {
 
 function calculateBillingAmounts_(params) {
   const visits = normalizeVisitCount_(params.visitCount);
-  const unitPrice = resolveBillingUnitPrice_(params);
-  const total = visits * unitPrice;
   const insuranceType = String(params.insuranceType || '').trim();
+  const unitPrice = insuranceType === 'マッサージ' ? 0 : resolveBillingUnitPrice_(params);
+  const total = visits * unitPrice;
   const burdenMultiplier = normalizeBurdenMultiplier_(params.burdenRate, insuranceType);
 
   let billingAmount = 0;
   if (insuranceType === '自費') {
     billingAmount = visits * unitPrice;
-  } else if (insuranceType === '生保' || burdenMultiplier === 0) {
+  } else if (insuranceType === '生保' || insuranceType === 'マッサージ' || burdenMultiplier === 0) {
     billingAmount = 0;
   } else {
     billingAmount = Math.round(visits * unitPrice * burdenMultiplier);

--- a/tests/billingLogic.test.js
+++ b/tests/billingLogic.test.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const billingLogicCode = fs.readFileSync(path.join(__dirname, '../src/logic/billingLogic.js'), 'utf8');
+const context = {};
+vm.createContext(context);
+vm.runInContext(billingLogicCode, context);
+
+const { calculateBillingAmounts_, normalizeBurdenMultiplier_ } = context;
+
+if (typeof calculateBillingAmounts_ !== 'function' || typeof normalizeBurdenMultiplier_ !== 'function') {
+  throw new Error('Billing logic functions failed to load in the test context');
+}
+
+function testBurdenRateDigitConversion() {
+  assert.strictEqual(normalizeBurdenMultiplier_(1, ''), 0.1, '1割は0.1に換算される');
+  assert.strictEqual(normalizeBurdenMultiplier_(3, ''), 0.3, '3割は0.3に換算される');
+  assert.strictEqual(normalizeBurdenMultiplier_(0.3, ''), 0.3, '小数表記はそのまま利用される');
+  assert.strictEqual(normalizeBurdenMultiplier_(2, '自費'), 1, '自費は常に1倍');
+}
+
+function testMassageBillingExclusion() {
+  const result = calculateBillingAmounts_({
+    visitCount: 4,
+    insuranceType: 'マッサージ',
+    burdenRate: 3,
+    unitPrice: 5000,
+    carryOverAmount: 2000
+  });
+
+  assert.strictEqual(result.unitPrice, 0, 'マッサージは単価を計上しない');
+  assert.strictEqual(result.total, 0, 'マッサージは合計0円');
+  assert.strictEqual(result.billingAmount, 0, 'マッサージは請求額0円');
+  assert.strictEqual(result.grandTotal, 2000, '繰越額のみが合計に残る');
+}
+
+function run() {
+  testBurdenRateDigitConversion();
+  testMassageBillingExclusion();
+  console.log('billingLogic tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- adjust burden multiplier normalization so single-digit burden rates are treated as割 instead of percentages
- skip billing charges for massage insurance entries while keeping carry-over amounts intact
- add lightweight Node-based tests covering burden rate conversion and massage billing exclusion

## Testing
- node tests/billingLogic.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926d582dcdc8321bc2f819bd9e17429)