### PR TITLE
Handle full-width burden rates in billing source data

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -32,6 +32,16 @@ const billingNormalizeVisitCount_ = typeof normalizeVisitCount_ === 'function'
     return Number.isFinite(num) && num > 0 ? num : 0;
   };
 
+const billingNormalizeBurdenRatio_ = typeof normalizeBurdenRatio_ === 'function'
+  ? normalizeBurdenRatio_
+  : function normalizeBurdenRatio_(text) {
+    if (!text) return null;
+    const normalized = String(text).normalize('NFKC').replace(/\s/g, '').replace('％', '%').replace('割', '');
+    if (/^[123]$/.test(normalized)) return Number(normalized) / 10;
+    if (/^(10|20|30)%?$/.test(normalized)) return Number(RegExp.$1) / 100;
+    return null;
+  };
+
 const BILLING_LABELS = typeof LABELS !== 'undefined' ? LABELS : {
   recNo: ['施術録番号', '施術録No', '施術録NO', '記録番号', 'カルテ番号', '患者ID', '患者番号'],
   name: ['名前', '氏名', '患者名', 'お名前'],
@@ -204,7 +214,7 @@ function normalizeBurdenRateInt_(value) {
     if (value === 10 || value === 20 || value === 30) return value / 10;
     if (value === 0) return 0;
   }
-  const text = String(value).trim();
+  const text = String(value).normalize('NFKC').trim();
   if (!text) return 0;
   const digits = text.replace(/[^0-9.]/g, '');
   if (digits) {
@@ -216,7 +226,7 @@ function normalizeBurdenRateInt_(value) {
       if (num === 10 || num === 20 || num === 30) return num / 10;
     }
   }
-  const ratio = normalizeBurdenRatio_(text);
+  const ratio = billingNormalizeBurdenRatio_(text);
   if (ratio === 0) return 0;
   if (ratio != null) return Math.round(ratio * 10);
   return 0;

--- a/tests/billingGet.test.js
+++ b/tests/billingGet.test.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const billingGetCode = fs.readFileSync(path.join(__dirname, '../src/get/billingGet.js'), 'utf8');
+
+const context = {
+  columnLetterToNumber_: letter => {
+    if (!letter) return 0;
+    const normalized = String(letter).toUpperCase();
+    let result = 0;
+    for (let i = 0; i < normalized.length; i++) {
+      const code = normalized.charCodeAt(i);
+      if (code < 65 || code > 90) continue;
+      result = result * 26 + (code - 64);
+    }
+    return result;
+  },
+  columnNumberToLetter_: () => ''
+};
+
+vm.createContext(context);
+vm.runInContext(billingGetCode, context);
+
+const { normalizeBurdenRateInt_ } = context;
+
+if (typeof normalizeBurdenRateInt_ !== 'function') {
+  throw new Error('normalizeBurdenRateInt_ failed to load in the test context');
+}
+
+function testFullWidthDigitsAreParsed() {
+  assert.strictEqual(normalizeBurdenRateInt_('３割'), 3, '全角1〜3割は整数に変換される');
+  assert.strictEqual(normalizeBurdenRateInt_('３'), 3, '全角数字だけの場合も整数に変換される');
+  assert.strictEqual(normalizeBurdenRateInt_('３０％'), 3, '全角パーセント表記も正しく解釈される');
+}
+
+function testAsciiInputsRemainCompatible() {
+  assert.strictEqual(normalizeBurdenRateInt_('2割'), 2, '従来の半角入力も維持される');
+  assert.strictEqual(normalizeBurdenRateInt_(0.2), 2, '数値入力もそのまま正規化される');
+}
+
+function run() {
+  testFullWidthDigitsAreParsed();
+  testAsciiInputsRemainCompatible();
+  console.log('billingGet burden rate tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- normalize burden ratio parsing with an internal fallback that handles full-width digits and symbols
- adjust burden rate normalization to use the sanitized text and shared parser
- add unit tests covering full-width and existing burden rate inputs

## Testing
- node tests/billingGet.test.js
- node tests/billingLogic.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926dd6a0d608321b459b90055c9ea85)