### PR TITLE
Handle billing rounding and guard invoice generation

### DIFF
--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -5,6 +5,12 @@ const BILLING_ELECTRO_PRICE = 100;
 const BILLING_UNIT_PRICE = BILLING_TREATMENT_PRICE + BILLING_ELECTRO_PRICE;
 const BILLING_COMBINE_STATUSES = ['NO_DOCUMENT', 'INSUFFICIENT', 'NOT_FOUND'];
 
+function roundToNearestTen_(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return 0;
+  return Math.round(num / 10) * 10;
+}
+
 function normalizeBillingSource_(source) {
   if (!source || typeof source !== 'object') {
     throw new Error('請求生成の入力が不正です');
@@ -66,7 +72,7 @@ function calculateBillingAmounts_(params) {
   } else if (insuranceType === '生保' || insuranceType === 'マッサージ' || burdenMultiplier === 0) {
     billingAmount = 0;
   } else {
-    billingAmount = Math.round(visits * unitPrice * burdenMultiplier);
+    billingAmount = roundToNearestTen_(visits * unitPrice * burdenMultiplier);
   }
 
   const carryOverAmount = normalizeMoneyNumber_(params.carryOverAmount);

--- a/src/main.gs
+++ b/src/main.gs
@@ -88,20 +88,27 @@ function generateCombinedBillingPdfsEntry(billingMonth, options) {
  * @return {Object} billingMonth key, billingJson, file metadata, and bank join warnings.
  */
 function generateInvoices(billingMonth, options) {
-  const source = getBillingSourceData(billingMonth);
-  const billingJson = generateBillingJsonFromSource(source);
-  const outputOptions = Object.assign({}, options, { billingMonth: source.billingMonth });
-  const outputs = generateBillingOutputs(billingJson, outputOptions);
-  const pdfs = generateCombinedBillingPdfs(billingJson, outputOptions);
-  return {
-    billingMonth: source.billingMonth,
-    billingJson,
-    excel: outputs.excel,
-    csv: outputs.csv,
-    history: outputs.history,
-    pdfs,
-    bankJoinWarnings: summarizeBankJoinErrors_(billingJson)
-  };
+  try {
+    const source = getBillingSourceData(billingMonth);
+    const billingJson = generateBillingJsonFromSource(source);
+    const outputOptions = Object.assign({}, options, { billingMonth: source.billingMonth });
+    const outputs = generateBillingOutputs(billingJson, outputOptions);
+    const pdfs = generateCombinedBillingPdfs(billingJson, outputOptions);
+    return {
+      billingMonth: source.billingMonth,
+      billingJson,
+      excel: outputs.excel,
+      csv: outputs.csv,
+      history: outputs.history,
+      pdfs,
+      bankJoinWarnings: summarizeBankJoinErrors_(billingJson)
+    };
+  } catch (err) {
+    const msg = err && err.message ? err.message : String(err);
+    const stack = err && err.stack ? '\n' + err.stack : '';
+    console.error('[generateInvoices] failed:', msg, stack);
+    throw new Error('請求生成中にエラーが発生しました: ' + msg);
+  }
 }
 
 function applyBillingPaymentResultsEntry(billingMonth) {

--- a/tests/billingLogic.test.js
+++ b/tests/billingLogic.test.js
@@ -36,9 +36,24 @@ function testMassageBillingExclusion() {
   assert.strictEqual(result.grandTotal, 2000, '繰越額のみが合計に残る');
 }
 
+function testBillingAmountRoundsToNearestTen() {
+  const result = calculateBillingAmounts_({
+    visitCount: 6,
+    insuranceType: '鍼灸',
+    burdenRate: 3,
+    unitPrice: 4170,
+    carryOverAmount: 0
+  });
+
+  assert.strictEqual(result.visits, 6, '施術回数が正しく反映される');
+  assert.strictEqual(result.unitPrice, 4170, '単価がデフォルト料金で設定される');
+  assert.strictEqual(result.billingAmount, 7510, '請求額は10円単位に四捨五入される');
+}
+
 function run() {
   testBurdenRateDigitConversion();
   testMassageBillingExclusion();
+  testBillingAmountRoundsToNearestTen();
   console.log('billingLogic tests passed');
 }
 


### PR DESCRIPTION
## Summary
- round insurance billing amounts to the nearest 10 yen and cover new test expectations
- add a regression test for the billing calculation step
- wrap generateInvoices with error handling to return clearer failures to the UI

## Testing
- node tests/billingLogic.test.js
- node tests/billingGet.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69278c9e645c8321a85fe9c31bf28d13)