### PR TITLE
Refine billing downloads and remove inline scripts

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -56,7 +56,7 @@
   }
 </style>
 </head>
-<body data-view="billing">
+<body data-view="billing" data-base-url="<?= baseUrl ?>">
 <div class="layout">
   <aside class="sidebar">
     <h1>請求メニュー</h1>
@@ -92,11 +92,7 @@
 </div>
 
 <script>
-  window.APP_CONFIG = Object.assign({}, window.APP_CONFIG, {
-    baseUrl: '<?= baseUrl ?>' || '',
-    view: 'billing'
-  });
-  <?!= HtmlService.createHtmlOutputFromFile('main.js').getContent(); ?>
+<?!= HtmlService.createHtmlOutputFromFile('main.js').getContent(); ?>
 </script>
 </body>
 </html>

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -65,6 +65,18 @@ function handleBillingGeneration() {
 function onBillingCompleted(result) {
   billingState.result = result || null;
   setBillingLoading(false);
+
+  const downloads = qs('downloads');
+  if (downloads) {
+    const links = [];
+    if (result?.excel?.url) links.push({ label: 'Excelダウンロード', url: result.excel.url });
+    if (result?.csv?.url) links.push({ label: 'CSVダウンロード', url: result.csv.url });
+    if (result?.pdfs?.url) links.push({ label: 'PDFダウンロード', url: result.pdfs.url });
+    downloads.innerHTML = links.length
+      ? links.map(link => `<a class="download-link" href="${link.url}" target="_blank" rel="noopener">${link.label}</a>`).join('')
+      : '<div class="muted">出力ファイルはまだありません。</div>';
+  }
+
   renderBillingResult();
 }
 
@@ -87,15 +99,9 @@ function renderDownloads(result) {
   box.innerHTML = '';
   if (!result) return;
   const links = [];
-  if (result.excel && result.excel.url) {
-    links.push({ label: 'Excelを開く', url: result.excel.url, name: result.excel.name });
-  }
-  if (result.csv && result.csv.url) {
-    links.push({ label: 'CSVを開く', url: result.csv.url, name: result.csv.name });
-  }
-  if (result.pdfs && result.pdfs.files && result.pdfs.files.length) {
-    links.push({ label: '合算請求書PDF一覧', url: result.pdfs.files[0].url, name: 'PDF (' + result.pdfs.count + '件)' });
-  }
+  if (result.excel && result.excel.url) links.push({ label: 'Excelダウンロード', url: result.excel.url, name: result.excel.name });
+  if (result.csv && result.csv.url) links.push({ label: 'CSVダウンロード', url: result.csv.url, name: result.csv.name });
+  if (result.pdfs && result.pdfs.url) links.push({ label: 'PDFダウンロード', url: result.pdfs.url, name: result.pdfs.name });
   if (!links.length) {
     box.innerHTML = '<div class="muted">出力ファイルはまだありません。</div>';
     return;
@@ -187,6 +193,14 @@ function initBillingPage() {
 }
 
 (function bootstrap() {
+  const body = document.body;
+  if (body && body.dataset) {
+    window.APP_CONFIG = Object.assign({}, window.APP_CONFIG, {
+      view: body.dataset.view || (window.APP_CONFIG && window.APP_CONFIG.view) || '',
+      baseUrl: body.dataset.baseUrl || (window.APP_CONFIG && window.APP_CONFIG.baseUrl) || ''
+    });
+  }
+
   const view = (window.APP_CONFIG && window.APP_CONFIG.view) || '';
   if (view === 'billing') {
     initBillingPage();


### PR DESCRIPTION
## Summary
- update billing download rendering to show Excel/CSV/PDF links from billing generation results
- move billing configuration initialization into main.js using data attributes
- remove inline script logic from billing.html and keep markup display-only

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927c1f753dc83218c9a41752f571be8)