### PR TITLE
Add billing web app doGet and fix billing script include

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -92,7 +92,7 @@
 </div>
 
 <script>
-<?!= HtmlService.createHtmlOutputFromFile('main.js').getContent(); ?>
+<?!= HtmlService.createHtmlOutputFromFile('main.js.html').getContent(); ?>
 </script>
 </body>
 </html>

--- a/src/main.gs
+++ b/src/main.gs
@@ -5,6 +5,19 @@
  * callers can preview JSON or generate Excel/CSV files for a given billing month.
  */
 
+function doGet(e) {
+  const template = HtmlService.createTemplateFromFile('billing');
+  template.baseUrl = ScriptApp.getService().getUrl() || '';
+  return template
+    .evaluate()
+    .setTitle('請求処理アプリ')
+    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+}
+
+function include(filename) {
+  return HtmlService.createHtmlOutputFromFile(filename).getContent();
+}
+
 /**
  * Return the active spreadsheet (utility retained for compatibility).
  * @return {SpreadsheetApp.Spreadsheet}


### PR DESCRIPTION
## Summary
- add Apps Script doGet handler for billing web app with baseUrl support
- expose include helper for embedded HTML partials
- load billing main script via main.js.html template include

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927ecb7f6508321844cdb7ca35764d5)