### PR TITLE
Use dedicated billing template spreadsheet

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -1,7 +1,7 @@
 
 /***** Output layer: billing Excel/CSV/history generation *****/
 
-const BILLING_TEMPLATE_SPREADSHEET_ID = '1ajnW9Fuvu0YzUUkfTmw0CrbhrM3lM5tt5OA1dK2_CoQ';
+const BILLING_TEMPLATE_SPREADSHEET_ID = '19bsk9rN5HRAGeaQ0hjvr6VTOOHBxDAGoD80nLs6hChk';
 const BILLING_TEMPLATE_SHEET_NAME = '請求一覧_TEMPLATE';
 
 const billingColumnLetterToNumber_ = typeof columnLetterToNumber_ === 'function'
@@ -109,11 +109,15 @@ function copyTemplateSheet_(templateSheetName, copyName) {
     throw new Error('請求テンプレートシート「' + templateName + '」が見つかりません。');
   }
 
-  const targetSpreadsheet = templateSpreadsheet.copy(copyName || '請求一覧_出力中');
-  const copiedSheet = targetSpreadsheet.getSheetByName(templateName);
-  if (!copiedSheet) {
-    throw new Error('テンプレートシートが見つかりません: ' + templateName);
-  }
+  const targetSpreadsheet = SpreadsheetApp.create(copyName || '請求一覧_出力中');
+  const copiedSheet = templateSheet.copyTo(targetSpreadsheet);
+  copiedSheet.setName(templateName);
+
+  targetSpreadsheet.getSheets().forEach(sheet => {
+    if (sheet.getSheetId() !== copiedSheet.getSheetId() && targetSpreadsheet.getSheets().length > 1) {
+      targetSpreadsheet.deleteSheet(sheet);
+    }
+  });
 
   targetSpreadsheet.setActiveSheet(copiedSheet);
   targetSpreadsheet.moveActiveSheet(targetSpreadsheet.getSheets().length);


### PR DESCRIPTION
## Summary
- update the billing template IDs to point at the new dedicated spreadsheet
- copy the billing template sheet into a fresh workbook to avoid form-linked sheets and safely drop default sheets

## Testing
- node tests/billingLogic.test.js
- node tests/billingGet.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927fb7bfa5883218fd891f667aa78f2)