### PR TITLE
Guard billing exports from PDF blob conversions

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -106,6 +106,17 @@ function generateInvoices(billingMonth, options) {
     const billingJson = generateBillingJsonFromSource(source);
     const outputOptions = Object.assign({}, options, { billingMonth: source.billingMonth });
     const outputs = generateBillingOutputs(billingJson, outputOptions);
+    if (!outputs || !outputs.excel || !outputs.excel.url) {
+      return {
+        billingMonth: source.billingMonth,
+        billingJson,
+        excel: outputs && outputs.excel ? { url: outputs.excel.url || '', name: outputs.excel.name || '' } : null,
+        csv: outputs && outputs.csv ? { url: outputs.csv.url || '', name: outputs.csv.name || '' } : null,
+        pdfs: null,
+        bankJoinWarnings: summarizeBankJoinErrors_(billingJson)
+      };
+    }
+
     const pdfs = generateCombinedBillingPdfs(billingJson, outputOptions);
     return {
       billingMonth: source.billingMonth,

--- a/tests/billingOutput.test.js
+++ b/tests/billingOutput.test.js
@@ -1,0 +1,76 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const billingOutputCode = fs.readFileSync(path.join(__dirname, '../src/output/billingOutput.js'), 'utf8');
+
+function createContext() {
+  return {
+    console,
+    MimeType: {
+      GOOGLE_SHEETS: 'application/vnd.google-apps.spreadsheet',
+      MICROSOFT_EXCEL: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      PDF: 'application/pdf'
+    }
+  };
+}
+
+function createFakeFile(mimeType, tracker) {
+  const blobTracker = tracker || { getAsCalled: false, setNameCalledWith: null };
+  const blob = {
+    getAs: () => {
+      blobTracker.getAsCalled = true;
+      return {
+        setName: name => {
+          blobTracker.setNameCalledWith = name;
+          return { name };
+        }
+      };
+    },
+    setName: () => blob
+  };
+
+  return {
+    getMimeType: () => mimeType,
+    getBlob: () => blob,
+    tracker: blobTracker
+  };
+}
+
+function testRejectsPdfBlobConversion() {
+  const context = createContext();
+  vm.createContext(context);
+  vm.runInContext(billingOutputCode, context);
+
+  const file = createFakeFile(context.MimeType.PDF);
+
+  assert.throws(
+    () => context.convertSpreadsheetToExcelBlob_(file, 'test'),
+    /スプレッドシート以外のファイルをExcelに変換することはできません/,
+    'PDF Blob が Excel 変換に渡された場合は例外を投げる'
+  );
+  assert.strictEqual(file.tracker.getAsCalled, false, 'PDF Blob では getAs が呼び出されない');
+}
+
+function testSpreadsheetBlobIsConverted() {
+  const context = createContext();
+  vm.createContext(context);
+  vm.runInContext(billingOutputCode, context);
+
+  const tracker = { getAsCalled: false, setNameCalledWith: null };
+  const file = createFakeFile(context.MimeType.GOOGLE_SHEETS, tracker);
+
+  const result = context.convertSpreadsheetToExcelBlob_(file, 'export_name');
+  assert.deepStrictEqual(result, { name: 'export_name.xlsx' }, 'Excel 変換結果が返却される');
+  assert.strictEqual(tracker.getAsCalled, true, 'Spreadsheet Blob では getAs が呼び出される');
+  assert.strictEqual(tracker.setNameCalledWith, 'export_name.xlsx', 'setName が適切なファイル名で呼ばれる');
+}
+
+function run() {
+  testRejectsPdfBlobConversion();
+  testSpreadsheetBlobIsConverted();
+  console.log('billingOutput blob guard tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- add validation to prevent non-spreadsheet blobs from being converted during Excel export
- stop invoice generation from continuing to PDF creation when Excel output is unavailable
- add billingOutput unit tests to enforce the new blob handling safeguards

## Testing
- node tests/billingLogic.test.js
- node tests/billingGet.test.js
- node tests/billingOutput.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927fe719c348321a1eacbc86d8c1272)