### PR TITLE
Refactor billing invoices to PDF workflow

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -69,7 +69,7 @@
   <main class="content">
     <section class="card" id="billingControls">
       <h2>請求書を作成</h2>
-      <p class="muted">対象月を指定すると、請求一覧Excel・口座振替CSV・合算請求書PDFを生成します。</p>
+      <p class="muted">対象月を指定すると、患者ごとの請求書PDFを生成してDriveに保存します。</p>
       <div class="controls">
         <label>請求月
           <input type="month" id="billingMonth" />
@@ -82,7 +82,6 @@
     <section class="card">
       <div class="status-line" style="margin-bottom:6px">
         <h2 style="flex:1">生成結果</h2>
-        <div id="bankWarnings" class="pill warn" style="display:none"></div>
         <div id="billingMonthLabel" class="pill ok" style="display:none"></div>
       </div>
       <div id="downloads" class="downloads"></div>

--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>請求書</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    @page { size: A4; margin: 18mm; }
+    * { box-sizing: border-box; }
+    body { font-family: 'Noto Sans JP', 'Noto Sans', -apple-system, 'Segoe UI', sans-serif; margin: 0; color: #0f172a; }
+    .wrapper { display: flex; flex-direction: column; gap: 16px; }
+    .header { display: flex; justify-content: space-between; align-items: flex-start; }
+    .brand { font-weight: 700; font-size: 20px; letter-spacing: 0.04em; }
+    .meta { text-align: right; color: #475569; font-size: 12px; }
+    .card { border: 1px solid #e2e8f0; border-radius: 12px; padding: 14px 16px; background: #f8fafc; }
+    .section-title { font-weight: 700; margin: 0 0 6px; font-size: 14px; }
+    .info { display: grid; grid-template-columns: 100px 1fr; row-gap: 6px; column-gap: 8px; font-size: 14px; }
+    .info .label { color: #475569; }
+    table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 14px; }
+    th, td { border: 1px solid #e2e8f0; padding: 8px 10px; text-align: left; }
+    th { background: #e5f0ff; font-weight: 700; }
+    td.amount { text-align: right; }
+    tfoot td { font-weight: 700; background: #edf2f7; }
+    .note { color: #475569; font-size: 12px; margin-top: 6px; }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <header class="header">
+      <div>
+        <div class="brand">べるつりー訪問鍼灸マッサージ</div>
+        <div class="note">月次請求書</div>
+      </div>
+      <div class="meta">
+        <div>請求月: <?= data.monthLabel ?></div>
+        <div>発行日: <?= Utilities.formatDate(new Date(), Session.getScriptTimeZone() || 'Asia/Tokyo', 'yyyy年MM月dd日') ?></div>
+      </div>
+    </header>
+
+    <section class="card">
+      <h3 class="section-title">請求先</h3>
+      <div class="info">
+        <div class="label">氏名</div>
+        <div><?= data.nameKanji ?></div>
+        <div class="label">住所</div>
+        <div><?= data.address || '―' ?></div>
+        <div class="label">保険区分</div>
+        <div><?= data.insuranceType || '―' ?> / <?= data.burdenRate ? data.burdenRate + '割' : '―' ?></div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3 class="section-title">ご請求内容</h3>
+      <table>
+        <thead>
+          <tr><th>項目</th><th>詳細</th><th class="amount">金額</th></tr>
+        </thead>
+        <tbody>
+          <? data.rows.forEach(function(row) { ?>
+            <tr>
+              <td><?= row.label ?></td>
+              <td><?= row.detail || '' ?></td>
+              <td class="amount"><?= formatBillingCurrency_(row.amount) ?> 円</td>
+            </tr>
+          <? }); ?>
+        </tbody>
+        <tfoot>
+          <tr>
+            <td colspan="2">合計</td>
+            <td class="amount"><?= formatBillingCurrency_(data.grandTotal) ?> 円</td>
+          </tr>
+        </tfoot>
+      </table>
+      <div class="note">前月繰越を含む合計金額です。口座振替日：毎月20日（祝日の場合は翌営業日）</div>
+    </section>
+  </div>
+</body>
+</html>

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -110,56 +110,21 @@ function renderDownloads(result) {
     box.innerHTML = `<div class="loading"><span class="spinner"></span>ファイル生成中…</div>`;
     return;
   }
-  if (!result) {
+  const files = (result && Array.isArray(result.files)) ? result.files.filter(file => file && file.url) : [];
+  if (!files.length) {
     box.innerHTML = '<div class="muted">出力ファイルはまだありません。</div>';
     return;
   }
-  const links = [];
-  if (result.excel && result.excel.url) links.push({ label: 'Excelダウンロード', url: result.excel.url, name: result.excel.name });
-  if (result.csv && result.csv.url) links.push({ label: 'CSVダウンロード', url: result.csv.url, name: result.csv.name });
-  const pdfLinks = [];
-  if (result.pdfs) {
-    if (result.pdfs.url) {
-      pdfLinks.push({ label: 'PDFダウンロード', url: result.pdfs.url, name: result.pdfs.name });
-    }
-    if (Array.isArray(result.pdfs.files)) {
-      result.pdfs.files.forEach((file, idx) => {
-        if (!file || !file.url) return;
-        const suffix = result.pdfs.files.length > 1 ? ` (${file.patientId || idx + 1})` : '';
-        pdfLinks.push({ label: 'PDFダウンロード' + suffix, url: file.url, name: file.name });
-      });
-    }
-  }
-  links.push(...pdfLinks);
-  if (!links.length) {
-    box.innerHTML = '<div class="muted">出力ファイルはまだありません。</div>';
-    return;
-  }
-  box.innerHTML = links.map(link => `
+  box.innerHTML = files.map(link => `
     <a class="download-link" href="${link.url}" target="_blank" rel="noopener">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M12 3v14" /><path d="M5 10l7 7 7-7" /><path d="M5 21h14" />
       </svg>
       <div>
-        <div>${link.label}</div>
-        <small class="muted" style="display:block;">${link.name || ''}</small>
+        <div>${link.name || '請求書PDF'}</div>
+        <small class="muted" style="display:block;">${link.nameKanji || link.patientId || ''}</small>
       </div>
     </a>`).join('');
-}
-
-function renderWarnings(result) {
-  const warnEl = qs('bankWarnings');
-  if (!warnEl) return;
-  if (result && result.bankJoinWarnings && result.bankJoinWarnings.count) {
-    warnEl.style.display = 'inline-flex';
-    const messages = result.bankJoinWarnings.messages || [];
-    warnEl.textContent = `銀行情報未紐づけ: ${result.bankJoinWarnings.count}件`;
-    warnEl.title = messages.join('\n');
-  } else {
-    warnEl.style.display = 'none';
-    warnEl.textContent = '';
-    warnEl.removeAttribute('title');
-  }
 }
 
 function renderMonthBadge(result) {
@@ -180,7 +145,6 @@ function renderBillingResult() {
   const result = billingState.result;
   renderBillingStatus(result);
   renderDownloads(result);
-  renderWarnings(result);
   renderMonthBadge(result);
 
   if (billingState.loading) {
@@ -193,7 +157,7 @@ function renderBillingResult() {
   }
 
   const rows = result.billingJson;
-  const header = ['患者ID','氏名','保険種別','負担','回数','単価','請求額','繰越','合計','銀行状態'];
+  const header = ['患者ID','氏名','住所','保険種別','負担','回数','単価','施術料','交通費','繰越','合計'];
   const tableHtml = [
     '<table><thead><tr>',
     header.map(h => `<th>${h}</th>`).join(''),
@@ -202,14 +166,15 @@ function renderBillingResult() {
       <tr>
         <td>${item.patientId || ''}</td>
         <td>${item.nameKanji || ''}</td>
+        <td>${item.address || ''}</td>
         <td>${item.insuranceType || ''}</td>
         <td>${item.burdenRate ? item.burdenRate + '割' : ''}</td>
         <td>${item.visitCount || 0}</td>
         <td class="right">${formatCurrency(item.unitPrice)}</td>
-        <td class="right">${formatCurrency(item.billingAmount)}</td>
+        <td class="right">${formatCurrency(item.treatmentAmount)}</td>
+        <td class="right">${formatCurrency(item.transportAmount)}</td>
         <td class="right">${formatCurrency(item.carryOverAmount)}</td>
         <td class="right">${formatCurrency(item.grandTotal)}</td>
-        <td>${item.bankJoinError ? '⚠ ' + (item.bankJoinMessage || '銀行情報なし') : (item.bankStatus || 'OK')}</td>
       </tr>`),
     '</tbody></table>'
   ].join('');


### PR DESCRIPTION
## Summary
- streamline billing logic to produce PDF-focused invoice data with treatment, transport, and carry-over totals
- add Drive-backed invoice PDF generation with patient/year folders and a new invoice template layout
- refresh billing UI to surface PDF links and updated billing breakdown fields

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928141c54e48321ac7146e5376d1679)