### PR TITLE
Add unpaid carryover handling to billing generation

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -622,6 +622,13 @@ function getBillingSourceData(billingMonth) {
   const treatmentVisitCounts = visitCountsResult.counts;
   const staffDirectory = loadBillingStaffDirectory_();
   const staffDisplayByPatient = buildStaffDisplayByPatient_(visitCountsResult.staffByPatient || {}, staffDirectory);
+  const unpaidHistory = extractUnpaidBillingHistory(month);
+  const carryOverByPatient = (unpaidHistory || []).reduce((map, entry) => {
+    const pid = billingNormalizePatientId_(entry.patientId);
+    if (!pid) return map;
+    map[pid] = (map[pid] || 0) + (Number(entry.unpaidAmount) || 0);
+    return map;
+  }, {});
   return {
     billingMonth: month.key,
     month,
@@ -633,7 +640,9 @@ function getBillingSourceData(billingMonth) {
     bankStatuses: getBillingPaymentResultsIfExists_(month),
     staffByPatient: visitCountsResult.staffByPatient || {},
     staffDirectory,
-    staffDisplayByPatient
+    staffDisplayByPatient,
+    unpaidHistory,
+    carryOverByPatient
   };
 }
 

--- a/tests/billingLogic.test.js
+++ b/tests/billingLogic.test.js
@@ -67,11 +67,33 @@ function testPaidStatusIsIncludedInBillingJson() {
   assert.strictEqual(billingJson[0].bankStatus, 'OK', '従来の入金ステータスも維持される');
 }
 
+function testCarryOverIncludesUnpaidHistory() {
+  const source = {
+    billingMonth: '202503',
+    patients: {
+      '010': {
+        nameKanji: 'テスト太郎',
+        burdenRate: 3,
+        insuranceType: '鍼灸',
+        carryOverAmount: 500
+      }
+    },
+    treatmentVisitCounts: { '010': 2 },
+    carryOverByPatient: { '010': 1500 }
+  };
+
+  const billingJson = generateBillingJsonFromSource(source);
+  assert.strictEqual(billingJson[0].carryOverAmount, 2000, '患者シートの繰越と未回収が合算される');
+  assert.strictEqual(billingJson[0].carryOverFromHistory, 1500, '未回収分が別途保持される');
+  assert.strictEqual(billingJson[0].grandTotal, 4566, '合計には繰越を含めた金額が反映される');
+}
+
 function run() {
   testBurdenRateDigitConversion();
   testMassageBillingExclusion();
   testBillingAmountRoundsToNearestTen();
   testPaidStatusIsIncludedInBillingJson();
+  testCarryOverIncludesUnpaidHistory();
   console.log('billingLogic tests passed');
 }
 


### PR DESCRIPTION
## Summary
- build unpaid carryover amounts from billing history and include them in billing source data
- combine patient carryover values with unpaid history when generating billing JSON and surface the history portion separately
- add a regression test to ensure carryover totals and grand totals include unpaid balances

## Testing
- node tests/billingLogic.test.js
- node tests/billingGet.test.js
- node tests/billingOutput.test.js
- node tests/billingInvoiceLayout.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bb814e338832595b58dfbcac1bde4)