### PR TITLE
Show carryover in invoice HTML

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -194,6 +194,7 @@ function buildBillingInvoiceHtml_(item, billingMonth) {
   const visits = breakdown.visits || 0;
   const treatmentUnitPrice = breakdown.treatmentUnitPrice || 0;
   const transportUnitPrice = TRANSPORT_PRICE;
+  const carryOverAmount = normalizeInvoiceMoney_(item && item.carryOverAmount);
   const totalLabel = formatBillingCurrency_(breakdown.grandTotal) + '円';
 
   const name = (item && item.nameKanji) || '';
@@ -206,8 +207,9 @@ function buildBillingInvoiceHtml_(item, billingMonth) {
     name ? `<p class="patient-name">${name} 様</p>` : '',
     address ? `<p class="patient-address">${address}</p>` : '',
     '<div class="charge-breakdown">',
-    `<p>施術料（${formatBillingCurrency_(treatmentUnitPrice)}円 × ${visits}回）</p>`,
-    `<p>交通費（${formatBillingCurrency_(transportUnitPrice)}円 × ${visits}回）</p>`,
+    `<p>前月繰越: ${formatBillingCurrency_(carryOverAmount)}円</p>`,
+    `<p>施術料（${formatBillingCurrency_(treatmentUnitPrice)}円 × ${visits}回）: ${formatBillingCurrency_(breakdown.treatmentAmount)}円</p>`,
+    `<p>交通費（${formatBillingCurrency_(transportUnitPrice)}円 × ${visits}回）: ${formatBillingCurrency_(breakdown.transportAmount)}円</p>`,
     `<p class="grand-total">合計: ${totalLabel}</p>`,
     '</div>',
     '</div>'

--- a/tests/billingInvoiceLayout.test.js
+++ b/tests/billingInvoiceLayout.test.js
@@ -52,8 +52,11 @@ function testInvoiceHtmlIncludesBreakdown() {
   }, '202512');
 
   assert(html.includes('2025年12月 ご請求書'), '請求月の見出しが含まれる');
+  assert(html.includes('前月繰越: 1,000円'), '繰越内訳が含まれる');
   assert(html.includes('施術料（417円 × 8回）'), '施術料の内訳が含まれる');
+  assert(html.includes('施術料（417円 × 8回）: 3,336円'), '施術料の金額が含まれる');
   assert(html.includes('交通費（33円 × 8回）'), '交通費の内訳が含まれる');
+  assert(html.includes('交通費（33円 × 8回）: 264円'), '交通費の金額が含まれる');
   assert(html.includes('4,600円'), '合計金額がカンマ区切りで表示される');
   assert(html.includes('べるつりー訪問鍼灸マッサージ'), 'タイトルが含まれる');
 }


### PR DESCRIPTION
## Summary
- show carryover and per-item amounts in the invoice HTML breakdown
- add coverage for the updated invoice breakdown content

## Testing
- node tests/billingInvoiceLayout.test.js
- node tests/billingOutput.test.js
- node tests/billingLogic.test.js
- node tests/billingGet.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bba64c9288325bb4fdd13a7fc19f4)