### PR TITLE
Fix self-pay invoice calculation

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -177,9 +177,14 @@ function calculateInvoiceChargeBreakdown_(params) {
   const burdenRateInt = normalizeInvoiceBurdenRateInt_(params && params.burdenRate);
   const carryOverAmount = normalizeInvoiceMoney_(params && params.carryOverAmount);
 
-  const treatmentUnitPrice = (insuranceType === '生保' || insuranceType === '自費' || insuranceType === 'マッサージ')
-    ? 0
-    : (INVOICE_TREATMENT_UNIT_PRICE_BY_BURDEN[burdenRateInt] || 0);
+  const treatmentUnitPrice = (function resolveTreatmentUnitPrice() {
+    if (insuranceType === '自費') {
+      const custom = normalizeInvoiceMoney_(params && params.unitPrice);
+      return custom > 0 ? custom : 0;
+    }
+    if (insuranceType === '生保' || insuranceType === 'マッサージ') return 0;
+    return INVOICE_TREATMENT_UNIT_PRICE_BY_BURDEN[burdenRateInt] || 0;
+  })();
   const treatmentAmount = visits > 0 ? treatmentUnitPrice * visits : 0;
   const transportAmount = visits > 0 && treatmentUnitPrice > 0 ? TRANSPORT_PRICE * visits : 0;
   const grandTotal = carryOverAmount + treatmentAmount + transportAmount;

--- a/tests/billingOutput.test.js
+++ b/tests/billingOutput.test.js
@@ -67,9 +67,32 @@ function testSpreadsheetBlobIsConverted() {
   assert.strictEqual(tracker.setNameCalledWith, 'export_name.xlsx', 'setName が適切なファイル名で呼ばれる');
 }
 
+function testCustomUnitPriceForSelfPaidInvoice() {
+  const context = createContext();
+  vm.createContext(context);
+  vm.runInContext(billingOutputCode, context);
+
+  const { calculateInvoiceChargeBreakdown_ } = context;
+  assert.strictEqual(typeof calculateInvoiceChargeBreakdown_, 'function', '請求額計算の関数が定義されている');
+
+  const result = calculateInvoiceChargeBreakdown_({
+    insuranceType: '自費',
+    unitPrice: 5000,
+    burdenRate: '',
+    visitCount: 2,
+    carryOverAmount: 1000
+  });
+
+  assert.strictEqual(result.treatmentUnitPrice, 5000, '自費の場合はカスタム単価を使用する');
+  assert.strictEqual(result.treatmentAmount, 10000, '単価と訪問回数から施術料が算出される');
+  assert.strictEqual(result.transportAmount, 66, '自費でも交通費が計上される');
+  assert.strictEqual(result.grandTotal, 11066, '繰越分も含めて合計が算出される');
+}
+
 function run() {
   testRejectsPdfBlobConversion();
   testSpreadsheetBlobIsConverted();
+  testCustomUnitPriceForSelfPaidInvoice();
   console.log('billingOutput blob guard tests passed');
 }
 


### PR DESCRIPTION
## Summary
- ensure self-pay invoice calculations use the provided custom unit price while keeping exemptions for other insurance types
- maintain transport and carry-over totals in invoice breakdowns for self-pay billing
- add a regression test covering self-pay invoice charge breakdown calculations

## Testing
- node tests/billingOutput.test.js
- node tests/billingGet.test.js
- node tests/billingLogic.test.js
- node tests/billingInvoiceLayout.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bbbce6f508325ad8b18a90a8751a9)