### PR TITLE
Handle Excel blobs in billing export conversion

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -28,13 +28,23 @@ const normalizeInvoiceBurdenRateInt_ = typeof normalizeBurdenRateInt_ === 'funct
   };
 
 function convertSpreadsheetToExcelBlob_(file, exportName) {
-  if (!file || typeof file.getMimeType !== 'function' || file.getMimeType() !== MimeType.GOOGLE_SHEETS) {
+  if (!file || typeof file.getMimeType !== 'function') {
+    throw new Error('スプレッドシート以外のファイルをExcelに変換することはできません');
+  }
+
+  const mimeType = file.getMimeType();
+  const isSpreadsheet = mimeType === MimeType.GOOGLE_SHEETS;
+  const isExcel = mimeType === MimeType.MICROSOFT_EXCEL;
+  if (!isSpreadsheet && !isExcel) {
     throw new Error('スプレッドシート以外のファイルをExcelに変換することはできません');
   }
 
   const blob = file.getBlob();
   const name = (exportName && String(exportName).trim()) || 'export';
-  return blob.getAs(MimeType.MICROSOFT_EXCEL).setName(name + '.xlsx');
+  const excelBlob = isSpreadsheet && typeof blob.getAs === 'function'
+    ? blob.getAs(MimeType.MICROSOFT_EXCEL)
+    : blob;
+  return excelBlob.setName(name + '.xlsx');
 }
 
 function normalizeBillingAmount_(item) {

--- a/tests/billingOutput.test.js
+++ b/tests/billingOutput.test.js
@@ -28,7 +28,10 @@ function createFakeFile(mimeType, tracker) {
         }
       };
     },
-    setName: () => blob
+    setName: name => {
+      blobTracker.setNameCalledWith = name;
+      return { name };
+    }
   };
 
   return {
@@ -67,6 +70,20 @@ function testSpreadsheetBlobIsConverted() {
   assert.strictEqual(tracker.setNameCalledWith, 'export_name.xlsx', 'setName が適切なファイル名で呼ばれる');
 }
 
+function testExcelBlobIsReturnedWithoutConversion() {
+  const context = createContext();
+  vm.createContext(context);
+  vm.runInContext(billingOutputCode, context);
+
+  const tracker = { getAsCalled: false, setNameCalledWith: null };
+  const file = createFakeFile(context.MimeType.MICROSOFT_EXCEL, tracker);
+
+  const result = context.convertSpreadsheetToExcelBlob_(file, 'already_excel');
+  assert.deepStrictEqual(result, { name: 'already_excel.xlsx' }, 'Excel Blob はそのまま返却される');
+  assert.strictEqual(tracker.getAsCalled, false, 'Excel Blob では getAs が呼び出されない');
+  assert.strictEqual(tracker.setNameCalledWith, 'already_excel.xlsx', '既存の Excel にも名称設定が行われる');
+}
+
 function testCustomUnitPriceForSelfPaidInvoice() {
   const context = createContext();
   vm.createContext(context);
@@ -92,6 +109,7 @@ function testCustomUnitPriceForSelfPaidInvoice() {
 function run() {
   testRejectsPdfBlobConversion();
   testSpreadsheetBlobIsConverted();
+  testExcelBlobIsReturnedWithoutConversion();
   testCustomUnitPriceForSelfPaidInvoice();
   console.log('billingOutput blob guard tests passed');
 }


### PR DESCRIPTION
## Summary
- allow `convertSpreadsheetToExcelBlob_` to accept existing Excel blobs while still guarding against invalid inputs
- reuse the requested export name when bypassing conversion and preserve spreadsheet conversion for Google Sheets
- add regression coverage for Excel blob passthrough behavior

## Testing
- node tests/billingOutput.test.js
- node tests/billingLogic.test.js
- node tests/billingGet.test.js
- node tests/billingInvoiceLayout.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bbf0db08c8325883e105f77b0d5da)