### PR TITLE
Default billing month to previous cycle

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -28,8 +28,9 @@ function qs(id) {
 
 function getDefaultMonth() {
   const today = new Date();
-  const y = today.getFullYear();
-  const m = String(today.getMonth() + 1).padStart(2, '0');
+  const prevMonth = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+  const y = prevMonth.getFullYear();
+  const m = String(prevMonth.getMonth() + 1).padStart(2, '0');
   return y + '-' + m;
 }
 


### PR DESCRIPTION
## Summary
- default the billing view's month picker to the previous month so entry starts at the last cycle

## Testing
- node tests/billingGet.test.js
- node tests/billingInvoiceLayout.test.js
- node tests/billingLogic.test.js
- node tests/billingOutput.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bd0792d508325bc8243ecf93af5f6)