### PR TITLE
Align invoice charge rounding

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -7,6 +7,12 @@ const TRANSPORT_PRICE = (typeof BILLING_TRANSPORT_UNIT_PRICE !== 'undefined')
   : 33;
 const INVOICE_TREATMENT_UNIT_PRICE_BY_BURDEN = { 1: 417, 2: 834, 3: 1251 };
 
+function roundToNearestTen_(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return 0;
+  return Math.round(num / 10) * 10;
+}
+
 function escapeHtml_(value) {
   return String(value || '').replace(/[&<>"']/g, (c) => ({
     '&': '&amp;',
@@ -216,7 +222,10 @@ function calculateInvoiceChargeBreakdown_(params) {
     if (insuranceType === '生保' || insuranceType === 'マッサージ') return 0;
     return INVOICE_TREATMENT_UNIT_PRICE_BY_BURDEN[burdenRateInt] || 0;
   })();
-  const treatmentAmount = visits > 0 ? treatmentUnitPrice * visits : 0;
+  const rawTreatmentAmount = visits > 0 ? treatmentUnitPrice * visits : 0;
+  const treatmentAmount = (insuranceType === '自費' || insuranceType === '生保' || insuranceType === 'マッサージ')
+    ? rawTreatmentAmount
+    : roundToNearestTen_(rawTreatmentAmount);
   const transportAmount = visits > 0 && treatmentUnitPrice > 0 ? TRANSPORT_PRICE * visits : 0;
   const grandTotal = carryOverAmount + treatmentAmount + transportAmount;
 

--- a/tests/billingInvoiceLayout.test.js
+++ b/tests/billingInvoiceLayout.test.js
@@ -36,9 +36,9 @@ function testInvoiceChargeBreakdown() {
   });
 
   assert.strictEqual(breakdown.treatmentUnitPrice, 417, '1割の単価が417円に設定される');
-  assert.strictEqual(breakdown.treatmentAmount, 3336, '施術料が回数に応じて計算される');
+  assert.strictEqual(breakdown.treatmentAmount, 3340, '施術料が10円単位で四捨五入される');
   assert.strictEqual(breakdown.transportAmount, 264, '交通費は33円×回数で算定される');
-  assert.strictEqual(breakdown.grandTotal, 4600, '合計は繰越+施術料+交通費の和となる');
+  assert.strictEqual(breakdown.grandTotal, 4604, '合計は繰越+施術料+交通費の和となる');
 }
 
 function testInvoiceChargeBreakdownUsesCustomTransportPrice() {
@@ -53,7 +53,7 @@ function testInvoiceChargeBreakdownUsesCustomTransportPrice() {
   });
 
   assert.strictEqual(breakdown.transportAmount, 200, '交通費が上書き単価で算出される');
-  assert.strictEqual(breakdown.grandTotal, 3536, '合計にも上書き単価の交通費が反映される');
+  assert.strictEqual(breakdown.grandTotal, 3540, '合計にも上書き単価の交通費が反映される');
 }
 
 function testInvoiceHtmlIncludesBreakdown() {
@@ -70,10 +70,10 @@ function testInvoiceHtmlIncludesBreakdown() {
   assert(html.includes('2025年12月 ご請求書'), '請求月の見出しが含まれる');
   assert(html.includes('前月繰越: 1,000円'), '繰越内訳が含まれる');
   assert(html.includes('施術料（417円 × 8回）'), '施術料の内訳が含まれる');
-  assert(html.includes('施術料（417円 × 8回）: 3,336円'), '施術料の金額が含まれる');
+  assert(html.includes('施術料（417円 × 8回）: 3,340円'), '施術料の金額が含まれる');
   assert(html.includes('交通費（33円 × 8回）'), '交通費の内訳が含まれる');
   assert(html.includes('交通費（33円 × 8回）: 264円'), '交通費の金額が含まれる');
-  assert(html.includes('4,600円'), '合計金額がカンマ区切りで表示される');
+  assert(html.includes('4,604円'), '合計金額がカンマ区切りで表示される');
   assert(html.includes('べるつりー訪問鍼灸マッサージ'), 'タイトルが含まれる');
 }
 

--- a/tests/billingOutput.test.js
+++ b/tests/billingOutput.test.js
@@ -125,12 +125,30 @@ function testFullWidthInputsAreNormalized() {
   assert.strictEqual(breakdown.grandTotal, 11066, '全角入力でも合計が正しく算出される');
 }
 
+function testInsuranceBillingIsRoundedToNearestTen() {
+  const context = createContext();
+  vm.createContext(context);
+  vm.runInContext(billingOutputCode, context);
+
+  const breakdown = context.calculateInvoiceChargeBreakdown_({
+    insuranceType: '鍼灸',
+    burdenRate: 1,
+    visitCount: 7,
+    carryOverAmount: 0
+  });
+
+  assert.strictEqual(breakdown.treatmentAmount, 2920, '施術料は10円単位で四捨五入される');
+  assert.strictEqual(breakdown.transportAmount, 231, '交通費は回数分計上される');
+  assert.strictEqual(breakdown.grandTotal, 3151, '合計も四捨五入後の施術料を利用する');
+}
+
 function run() {
   testRejectsPdfBlobConversion();
   testSpreadsheetBlobIsConverted();
   testExcelBlobIsReturnedWithoutConversion();
   testCustomUnitPriceForSelfPaidInvoice();
   testFullWidthInputsAreNormalized();
+  testInsuranceBillingIsRoundedToNearestTen();
   console.log('billingOutput blob guard tests passed');
 }
 


### PR DESCRIPTION
## Summary
- round insurance invoice treatment amounts to the nearest ten yen to mirror billing logic totals
- update invoice HTML expectations and totals to reflect rounded amounts
- add regression coverage for rounded insurance charges in billing output tests

## Testing
- node tests/billingOutput.test.js
- node tests/billingInvoiceLayout.test.js
- node tests/billingGet.test.js
- node tests/billingLogic.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bdcb5983483258c04fafe59549d71)