### PR TITLE
Charge transport for welfare invoices

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -226,7 +226,9 @@ function calculateInvoiceChargeBreakdown_(params) {
   const treatmentAmount = (insuranceType === '自費' || insuranceType === '生保' || insuranceType === 'マッサージ')
     ? rawTreatmentAmount
     : roundToNearestTen_(rawTreatmentAmount);
-  const transportAmount = visits > 0 && treatmentUnitPrice > 0 ? TRANSPORT_PRICE * visits : 0;
+  const transportAmount = visits > 0 && insuranceType !== 'マッサージ'
+    ? TRANSPORT_PRICE * visits
+    : 0;
   const grandTotal = carryOverAmount + treatmentAmount + transportAmount;
 
   return { treatmentUnitPrice, treatmentAmount, transportAmount, grandTotal, visits };


### PR DESCRIPTION
## Summary
- ensure invoice transport fees are applied for welfare billing while keeping massage invoices transport-free
- add coverage for welfare and massage transport handling in invoice breakdown tests

## Testing
- node tests/billingOutput.test.js
- node tests/billingLogic.test.js
- node tests/billingInvoiceLayout.test.js
- node tests/billingGet.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692be3192a3083258a0c6e36db2a0ff4)