### PR TITLE
Fix billing script globals for invoice page

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -1,4 +1,3 @@
-<script>
 const billingState = {
   loading: false,
   result: null,
@@ -523,4 +522,9 @@ function initBillingPage() {
     initBillingPage();
   }
 })();
-</script>
+
+if (typeof window !== 'undefined') {
+  window.loadBillingPage = loadBillingPage;
+  window.handleBillingAggregation = handleBillingAggregation;
+  window.handleBillingPdfGeneration = handleBillingPdfGeneration;
+}


### PR DESCRIPTION
## Summary
- remove redundant script wrapper from billing JavaScript template so it executes when embedded
- expose billing handlers to the global window for inline onclick usage

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692be7130ab08325b639c8507d586312)