### PR TITLE
Adjust billing script inclusion

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -95,8 +95,6 @@
   </main>
 </div>
 
-<script>
 <?!= HtmlService.createHtmlOutputFromFile('main.js.html').getContent(); ?>
-</script>
 </body>
 </html>

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -1,3 +1,4 @@
+<script>
 const billingState = {
   loading: false,
   result: null,
@@ -529,3 +530,4 @@ if (billingGlobal) {
   billingGlobal.handleBillingAggregation = handleBillingAggregation;
   billingGlobal.handleBillingPdfGeneration = handleBillingPdfGeneration;
 }
+</script>


### PR DESCRIPTION
## Summary
- move billing page script inclusion out of inline `<script>` tag and let the shared JS template wrap itself
- ensure the billing JavaScript remains globally available for inline handlers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692beef68ce8832584a022069173ac76)