### PR TITLE
Include historical carry-over in invoice totals

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -102,9 +102,13 @@ function normalizeInvoiceVisitCount_(value) {
 
 function normalizeBillingCarryOver_(item) {
   if (!item) return 0;
-  if (item.carryOverAmount != null && item.carryOverAmount !== '') return Number(item.carryOverAmount) || 0;
-  if (item.raw && item.raw.carryOverAmount != null) return Number(item.raw.carryOverAmount) || 0;
-  return 0;
+  const directCarryOver = (item.carryOverAmount != null && item.carryOverAmount !== '')
+    ? normalizeInvoiceMoney_(item.carryOverAmount)
+    : (item.raw && item.raw.carryOverAmount != null)
+      ? normalizeInvoiceMoney_(item.raw.carryOverAmount)
+      : 0;
+  const historyCarryOver = normalizeInvoiceMoney_(item.carryOverFromHistory);
+  return directCarryOver + historyCarryOver;
 }
 
 function formatBillingCurrency_(value) {
@@ -212,7 +216,7 @@ function calculateInvoiceChargeBreakdown_(params) {
   const visits = normalizeInvoiceVisitCount_(params && params.visitCount);
   const insuranceType = params && params.insuranceType ? String(params.insuranceType).trim() : '';
   const burdenRateInt = normalizeInvoiceBurdenRateInt_(params && params.burdenRate);
-  const carryOverAmount = normalizeInvoiceMoney_(params && params.carryOverAmount);
+  const carryOverAmount = normalizeBillingCarryOver_(params);
 
   const treatmentUnitPrice = (function resolveTreatmentUnitPrice() {
     if (insuranceType === '自費') {
@@ -241,7 +245,7 @@ function calculateInvoiceChargeBreakdown_(params) {
     const visits = breakdown.visits || 0;
   const treatmentUnitPrice = breakdown.treatmentUnitPrice || 0;
   const transportUnitPrice = TRANSPORT_PRICE;
-  const carryOverAmount = normalizeInvoiceMoney_(item && item.carryOverAmount);
+  const carryOverAmount = normalizeBillingCarryOver_(item);
   const totalLabel = formatBillingCurrency_(breakdown.grandTotal) + '円';
 
     const name = escapeHtml_((item && item.nameKanji) || '');

--- a/tests/billingOutput.test.js
+++ b/tests/billingOutput.test.js
@@ -174,6 +174,23 @@ function testMassageBillingDoesNotChargeTransport() {
   assert.strictEqual(breakdown.grandTotal, 200, '繰越のみの場合は交通費なしで合計される');
 }
 
+function testCarryOverHistoryIsIncluded() {
+  const context = createContext();
+  vm.createContext(context);
+  vm.runInContext(billingOutputCode, context);
+
+  const breakdown = context.calculateInvoiceChargeBreakdown_({
+    insuranceType: '鍼灸',
+    burdenRate: 1,
+    visitCount: 1,
+    carryOverAmount: 500,
+    carryOverFromHistory: 200
+  });
+
+  assert.strictEqual(breakdown.treatmentAmount, 420, '施術料は四捨五入後の負担額で計算される');
+  assert.strictEqual(breakdown.grandTotal, 1153, '未回収分も繰越に合算される');
+}
+
 function run() {
   testRejectsPdfBlobConversion();
   testSpreadsheetBlobIsConverted();
@@ -183,6 +200,7 @@ function run() {
   testInsuranceBillingIsRoundedToNearestTen();
   testWelfareBillingStillAddsTransport();
   testMassageBillingDoesNotChargeTransport();
+  testCarryOverHistoryIsIncluded();
   console.log('billingOutput blob guard tests passed');
 }
 


### PR DESCRIPTION
## Summary
- include unpaid history when normalizing carry-over amounts for invoices
- ensure invoice charge breakdown uses combined carry-over values in calculations
- add a regression test covering carry-over from history in invoice totals

## Testing
- node tests/billingOutput.test.js
- node tests/billingLogic.test.js
- node tests/billingGet.test.js
- node tests/billingInvoiceLayout.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bf12b3e108325b417f55f026db477)