### PR TITLE
Add medical assistance billing handling and save flow

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -67,7 +67,7 @@
     <div class="menu">
       <button type="button" onclick="loadBillingPage()">請求書作成</button>
     </div>
-    <p class="muted" style="margin:0; font-size:0.9rem;">請求額の算定ロジックは 4170円/回（鍼灸）・自費/生保は0円で固定されています。</p>
+    <p class="muted" style="margin:0; font-size:0.9rem;">請求額の算定ロジックは 4170円/回（鍼灸）・自費/生保/医療助成は0円で固定されています。</p>
   </aside>
 
   <main class="content">
@@ -79,6 +79,7 @@
           <input type="month" id="billingMonth" />
         </label>
           <button class="btn" id="billingAggregateBtn" type="button" onclick="handleBillingAggregation()">請求データを集計</button>
+          <button class="btn secondary" id="billingSaveBtn" type="button" onclick="handleBillingSaveEdits()">変更を保存</button>
           <button class="btn secondary" id="billingPdfBtn" type="button" onclick="handleBillingPdfGeneration()">PDF生成＆担当者フォルダ保存</button>
         <div id="billingStatus" class="status-line"></div>
       </div>

--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -497,6 +497,7 @@ function getBillingPatientRecords() {
   const colAccount = resolveBillingColumn_(headers, ['口座番号', '口座No', '口座NO', 'accountNumber', '口座'], '口座番号', { fallbackLetter: 'Q' });
   const colIsNew = resolveBillingColumn_(headers, ['新規', '新患', 'isNew', '新規フラグ', '新規区分'], '新規区分', { fallbackLetter: 'U' });
   const colCarryOver = resolveBillingColumn_(headers, ['未入金', '未入金額', '未収金', '未収', '繰越', '繰越額', '繰り越し', '差引繰越', '前回未払', '前回未収', 'carryOverAmount'], '未入金額', {});
+  const colMedical = resolveBillingColumn_(headers, ['医療助成'], '医療助成', { fallbackLetter: 'AS' });
 
   return values.map(row => {
     const pid = billingNormalizePatientId_(row[colPid - 1]);
@@ -511,6 +512,7 @@ function getBillingPatientRecords() {
       unitPrice: colUnitPrice ? normalizeMoneyValue_(row[colUnitPrice - 1]) : 0,
       address: colAddress ? String(row[colAddress - 1] || '').trim() : '',
       payerType: colPayer ? String(row[colPayer - 1] || '').trim() : '',
+      medicalAssistance: colMedical ? normalizeZeroOneFlag_(row[colMedical - 1]) : 0,
       bankCode: colBank ? String(row[colBank - 1] || '').trim() : '',
       branchCode: colBranch ? String(row[colBranch - 1] || '').trim() : '',
       accountNumber: colAccount ? String(row[colAccount - 1] || '').trim() : '',

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -9,7 +9,7 @@ const billingState = {
   sort: { field: null, direction: 'asc' }
 };
 
-const BILLING_INSURANCE_OPTIONS = ['後期高齢', '国保', '社保', '生保', '自費', 'マッサージ'];
+const BILLING_INSURANCE_OPTIONS = ['後期高齢', '国保', '社保', '生保', '自費'];
 const BILLING_BURDEN_OPTIONS = [
   { value: 1, label: '1割' },
   { value: 2, label: '2割' },
@@ -42,7 +42,9 @@ function updateBillingControls() {
   const monthInput = qs('billingMonth');
   const aggregateBtn = qs('billingAggregateBtn');
   const pdfBtn = qs('billingPdfBtn');
+  const saveBtn = qs('billingSaveBtn');
   const loading = billingState.loading;
+  const prepared = !!(billingState.prepared && billingState.prepared.billingMonth);
 
   if (monthInput) {
     monthInput.disabled = loading;
@@ -52,11 +54,16 @@ function updateBillingControls() {
     aggregateBtn.setAttribute('aria-busy', loading ? 'true' : 'false');
   }
   if (pdfBtn) {
-    const prepared = !!(billingState.prepared && billingState.prepared.billingMonth);
     const disabled = loading || !prepared;
     pdfBtn.disabled = disabled;
     pdfBtn.setAttribute('aria-busy', loading ? 'true' : 'false');
     pdfBtn.title = disabled && !prepared ? '先に「請求データを集計」を実行してください' : '';
+  }
+  if (saveBtn) {
+    const disabled = loading || !prepared;
+    saveBtn.disabled = disabled;
+    saveBtn.setAttribute('aria-busy', loading ? 'true' : 'false');
+    saveBtn.title = disabled && !prepared ? '先に「請求データを集計」を実行してください' : '';
   }
 }
 
@@ -87,20 +94,40 @@ function normalizeBurdenRateDisplay(value) {
   return num + '割';
 }
 
-function resolveFrontEndUnitPrice(insuranceType, burdenRate, customUnitPrice) {
+function normalizeMedicalAssistanceFlag(value) {
+  if (value === true) return true;
+  if (value === false) return false;
+  const num = Number(value);
+  if (Number.isFinite(num)) return !!num;
+  const text = String(value || '').trim().toLowerCase();
+  if (!text) return false;
+  return ['1', 'true', 'yes', 'y', 'on', '有', 'あり', '〇', '○', '◯'].includes(text);
+}
+
+function resolveFrontEndUnitPrice(insuranceType, burdenRate, customUnitPrice, medicalAssistance) {
   const type = String(insuranceType || '').trim();
+  const manualUnitPrice = Number(customUnitPrice);
+  const hasManualUnitPrice = Number.isFinite(manualUnitPrice) && manualUnitPrice !== 0;
+  const isMedicalAssistance = normalizeMedicalAssistanceFlag(medicalAssistance);
+  if ((type === '生保' || isMedicalAssistance) && !hasManualUnitPrice) return 0;
   if (type === '自費') return 0;
-  if (type === '生保' || type === 'マッサージ') return 0;
+  if (type === 'マッサージ' && !hasManualUnitPrice) return 0;
+  if (hasManualUnitPrice) return manualUnitPrice;
   const normalizedBurden = burdenRate === '自費' ? 0 : Number(burdenRate);
   return BILLING_TREATMENT_UNIT_PRICE_BY_BURDEN[normalizedBurden] || BILLING_UNIT_PRICE;
 }
 
 function recalculateBillingRow(row) {
   const visits = normalizeEditNumber(row.visitCount);
-  const unitPrice = resolveFrontEndUnitPrice(row.insuranceType, row.burdenRate, row.unitPrice);
-  const isZeroCharge = row.insuranceType === '生保' || row.insuranceType === '自費';
-  const treatmentAmount = visits > 0 && !isZeroCharge ? unitPrice * visits : 0;
-  const transportAmount = visits > 0 && !isZeroCharge ? BILLING_TRANSPORT_UNIT_PRICE * visits : 0;
+  const unitPrice = resolveFrontEndUnitPrice(row.insuranceType, row.burdenRate, row.unitPrice, row.medicalAssistance);
+  const manualUnitPrice = Number(row.unitPrice);
+  const hasManualUnitPrice = Number.isFinite(manualUnitPrice) && manualUnitPrice !== 0;
+  const isMedicalAssistance = normalizeMedicalAssistanceFlag(row.medicalAssistance);
+  const shouldZeroByAssistance = (row.insuranceType === '生保' || isMedicalAssistance) && !hasManualUnitPrice;
+  const isZeroCharge = shouldZeroByAssistance || row.insuranceType === '自費';
+  const isMassage = row.insuranceType === 'マッサージ';
+  const treatmentAmount = visits > 0 && !isMassage && !isZeroCharge ? unitPrice * visits : 0;
+  const transportAmount = visits > 0 && !isMassage && !isZeroCharge ? BILLING_TRANSPORT_UNIT_PRICE * visits : 0;
   const carryOverAmount = normalizeEditNumber(row.carryOverAmount);
   const grandTotal = treatmentAmount + transportAmount + carryOverAmount;
   return Object.assign({}, row, {
@@ -272,6 +299,30 @@ function onBillingPdfCompleted(result) {
   renderBillingResult();
 }
 
+function handleBillingSaveEdits() {
+  if (!billingState.prepared || !billingState.prepared.billingMonth) {
+    alert('先に「請求データを集計」を実行してください。');
+    return;
+  }
+  setBillingLoading(true, '保存中…');
+  google.script.run
+    .withSuccessHandler(onBillingSaveCompleted)
+    .withFailureHandler(onBillingFailed)
+    .applyBillingEdits(billingState.prepared.billingMonth, {
+      edits: Object.keys(billingState.edits || {}).map(pid => Object.assign({ patientId: pid }, billingState.edits[pid]))
+    });
+}
+
+function onBillingSaveCompleted(result) {
+  billingState.result = result || billingState.result;
+  billingState.prepared = result || billingState.prepared;
+  billingState.loading = false;
+  billingState.statusMessage = '保存が完了しました';
+  billingState.edits = {};
+  billingState.editing = null;
+  renderBillingResult();
+}
+
 function onBillingFailed(err) {
   console.error('[billing generation failed]', err);
   const msg = err && err.message ? err.message : String(err);
@@ -371,6 +422,7 @@ function renderBillingResult() {
     { key: 'responsible', label: '担当者', sortable: true },
     { key: 'address', label: '住所', sortable: true },
     { key: 'insuranceType', label: '保険種別', sortable: true },
+    { key: 'medicalAssistance', label: '医療助成', sortable: false },
     { key: 'payerType', label: '保険者', sortable: false },
     { key: 'burdenRate', label: '負担', sortable: true },
     { key: 'visitCount', label: '回数', sortable: true },
@@ -398,13 +450,20 @@ function renderBillingResult() {
     const viewClass = alignRight ? 'cell-edit right' : 'cell-edit';
     if (editing) {
       if (field === 'insuranceType') {
-        return `<select class="${editClass}" ${baseAttrs}>${BILLING_INSURANCE_OPTIONS.map(opt => `<option value="${opt}" ${opt === item.insuranceType ? 'selected' : ''}>${opt}</option>`).join('')}</select>`;
+        const options = BILLING_INSURANCE_OPTIONS.indexOf(item.insuranceType) >= 0
+          ? BILLING_INSURANCE_OPTIONS
+          : BILLING_INSURANCE_OPTIONS.concat(item.insuranceType || []);
+        return `<select class="${editClass}" ${baseAttrs}>${options.map(opt => `<option value="${opt}" ${opt === item.insuranceType ? 'selected' : ''}>${opt}</option>`).join('')}</select>`;
       }
       if (field === 'burdenRate') {
         return `<select class="${editClass}" ${baseAttrs}>${BILLING_BURDEN_OPTIONS.map(opt => `<option value="${opt.value}" ${String(opt.value) === String(item.burdenRate) ? 'selected' : ''}>${opt.label}</option>`).join('')}</select>`;
       }
       if (field === 'payerType') {
         return `<select class="${editClass}" ${baseAttrs}>${BILLING_PAYER_OPTIONS.map(opt => `<option value="${opt}" ${opt === item.payerType ? 'selected' : ''}>${opt}</option>`).join('')}</select>`;
+      }
+      if (field === 'medicalAssistance') {
+        const checked = normalizeMedicalAssistanceFlag(item.medicalAssistance) ? 'checked' : '';
+        return `<label class="${editClass}" style="display:flex;align-items:center;gap:6px;"><input type="checkbox" ${baseAttrs} ${checked} />医療助成</label>`;
       }
       if (field === 'unitPrice' || field === 'carryOverAmount') {
         const val = normalizeEditNumber(item[field]);
@@ -416,6 +475,8 @@ function renderBillingResult() {
       switch (field) {
         case 'insuranceType':
           return item.insuranceType || '編集';
+        case 'medicalAssistance':
+          return normalizeMedicalAssistanceFlag(item.medicalAssistance) ? '有' : 'なし';
         case 'burdenRate':
           return normalizeBurdenRateDisplay(item.burdenRate) || '編集';
         case 'payerType':
@@ -442,6 +503,7 @@ function renderBillingResult() {
         <td>${getResponsibleDisplay(item)}</td>
         <td>${item.address || ''}</td>
         <td>${renderEditableCell(item, 'insuranceType')}</td>
+        <td>${renderEditableCell(item, 'medicalAssistance')}</td>
         <td>${renderEditableCell(item, 'payerType')}</td>
         <td>${renderEditableCell(item, 'burdenRate')}</td>
         <td>${item.visitCount || 0}</td>
@@ -474,6 +536,9 @@ function attachBillingEditHandlers() {
       const pid = this.getAttribute('data-edit-patient');
       const field = this.getAttribute('data-edit-field');
       let value = this.value;
+      if (this.type === 'checkbox') {
+        value = this.checked;
+      }
       if (field === 'burdenRate' && value !== '自費') {
         value = Number(value);
       }
@@ -527,5 +592,6 @@ if (billingGlobal) {
   billingGlobal.loadBillingPage = loadBillingPage;
   billingGlobal.handleBillingAggregation = handleBillingAggregation;
   billingGlobal.handleBillingPdfGeneration = handleBillingPdfGeneration;
+  billingGlobal.handleBillingSaveEdits = handleBillingSaveEdits;
 }
 </script>


### PR DESCRIPTION
## Summary
- add medical assistance handling to billing calculations and invoice output, ensuring life welfare or assistance patients default to zero charges unless manually overridden and removing the massage insurance option from editors
- load and persist medical assistance, insurance type, and burden rate edits back to the patient sheet with a dedicated save flow and UI checkbox column
- refresh billing UI with a save button, updated controls, and contextual messaging for zero-charge insurance logic

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d05e2d40c8325b5f2b15172ad35aa)