### PR TITLE
Add bank transfer export flow

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -92,6 +92,7 @@
           <button class="btn" id="billingAggregateBtn" type="button" onclick="handleBillingAggregation()">請求データを集計</button>
           <button class="btn secondary" id="billingSaveBtn" type="button" onclick="handleBillingSaveEdits()">変更を保存</button>
           <button class="btn secondary" id="billingPdfBtn" type="button" onclick="handleBillingPdfGeneration()">PDF生成＆担当者フォルダ保存</button>
+          <button class="btn secondary" id="billingBankBtn" type="button" onclick="handleBankExport()">銀行データ出力</button>
         <div id="billingStatus" class="status-line"></div>
       </div>
     </section>

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -44,6 +44,7 @@ function updateBillingControls() {
   const aggregateBtn = qs('billingAggregateBtn');
   const pdfBtn = qs('billingPdfBtn');
   const saveBtn = qs('billingSaveBtn');
+  const bankBtn = qs('billingBankBtn');
   const loading = billingState.loading;
   const prepared = !!(billingState.prepared && billingState.prepared.billingMonth);
 
@@ -65,6 +66,12 @@ function updateBillingControls() {
     saveBtn.disabled = disabled;
     saveBtn.setAttribute('aria-busy', loading ? 'true' : 'false');
     saveBtn.title = disabled && !prepared ? '先に「請求データを集計」を実行してください' : '';
+  }
+  if (bankBtn) {
+    const disabled = loading || !prepared;
+    bankBtn.disabled = disabled;
+    bankBtn.setAttribute('aria-busy', loading ? 'true' : 'false');
+    bankBtn.title = disabled && !prepared ? '先に「請求データを集計」を実行してください' : '';
   }
 }
 
@@ -314,6 +321,24 @@ function onBillingPdfCompleted(result) {
   billingState.statusMessage = 'PDF生成と担当者フォルダへの保存が完了しました';
   billingState.edits = {};
   billingState.editing = null;
+  renderBillingResult();
+}
+
+function handleBankExport() {
+  if (!billingState.prepared || !billingState.prepared.billingMonth) {
+    alert('先に「請求データを集計」を実行してください。');
+    return;
+  }
+  setBillingLoading(true, '銀行データ出力中…');
+  google.script.run
+    .withSuccessHandler(onBankExportCompleted)
+    .withFailureHandler(onBillingFailed)
+    .generateBankTransferDataFromCache(billingState.prepared.billingMonth, {});
+}
+
+function onBankExportCompleted(result) {
+  billingState.loading = false;
+  billingState.statusMessage = '銀行データを出力しました' + (result && result.inserted ? `（${result.inserted}件）` : '');
   renderBillingResult();
 }
 
@@ -669,5 +694,6 @@ if (billingGlobal) {
   billingGlobal.handleBillingAggregation = handleBillingAggregation;
   billingGlobal.handleBillingPdfGeneration = handleBillingPdfGeneration;
   billingGlobal.handleBillingSaveEdits = handleBillingSaveEdits;
+  billingGlobal.handleBankExport = handleBankExport;
 }
 </script>


### PR DESCRIPTION
## Summary
- add bank transfer export helpers that map billing rows to bank transfer format and write to the 銀行情報 sheet
- include bank and patient context in prepared billing payloads and export bank data during PDF generation
- add a dedicated 銀行データ出力 button to trigger bank transfer output from cached billing data

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d1dc60a64832581d310fb35b0b3c0)