### PR TITLE
Handle manual self-pay overrides and remove address output

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -44,8 +44,6 @@
       <div class="info">
         <div class="label">氏名</div>
         <div><?= data.nameKanji ?></div>
-        <div class="label">住所</div>
-        <div><?= data.address || '―' ?></div>
         <div class="label">保険区分</div>
         <div><?= data.insuranceType || '―' ?> / <?= data.burdenRate ? data.burdenRate + '割' : '―' ?></div>
       </div>

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -123,9 +123,9 @@ function resolveFrontEndUnitPrice(insuranceType, burdenRate, customUnitPrice, me
   const hasManualUnitPrice = Number.isFinite(manualUnitPrice) && manualUnitPrice !== 0;
   const isMedicalAssistance = normalizeMedicalAssistanceFlag(medicalAssistance);
   if ((type === '生保' || isMedicalAssistance) && !hasManualUnitPrice) return 0;
-  if (type === '自費') return 0;
-  if (isDeprecatedInsuranceType(type) && !hasManualUnitPrice) return 0;
+  if (isDeprecatedInsuranceType(type)) return 0;
   if (hasManualUnitPrice) return manualUnitPrice;
+  if (type === '自費') return 0;
   const normalizedBurden = burdenRate === '自費' ? 0 : Number(burdenRate);
   return BILLING_TREATMENT_UNIT_PRICE_BY_BURDEN[normalizedBurden] || BILLING_UNIT_PRICE;
 }
@@ -137,7 +137,7 @@ function recalculateBillingRow(row) {
   const hasManualUnitPrice = Number.isFinite(manualUnitPrice) && manualUnitPrice !== 0;
   const isMedicalAssistance = normalizeMedicalAssistanceFlag(row.medicalAssistance);
   const shouldZeroByAssistance = (row.insuranceType === '生保' || isMedicalAssistance) && !hasManualUnitPrice;
-  const isZeroCharge = shouldZeroByAssistance || row.insuranceType === '自費';
+  const isZeroCharge = shouldZeroByAssistance || (row.insuranceType === '自費' && !hasManualUnitPrice);
   const isMassage = isDeprecatedInsuranceType(row.insuranceType);
   const treatmentAmount = visits > 0 && !isMassage && !isZeroCharge ? unitPrice * visits : 0;
   const transportAmount = visits > 0 && !isMassage && !isZeroCharge ? BILLING_TRANSPORT_UNIT_PRICE * visits : 0;

--- a/tests/billingInvoiceLayout.test.js
+++ b/tests/billingInvoiceLayout.test.js
@@ -89,7 +89,7 @@ function testInvoiceHtmlEscapesUserInput() {
 
   assert(!html.includes('<script>'), '埋め込みスクリプトはサニタイズされる');
   assert(html.includes('&lt;script&gt;alert(1)&lt;/script&gt;'), '氏名はエスケープされる');
-  assert(html.includes('東京都 &lt;b&gt;江東区&lt;/b&gt;'), '住所もHTMLエスケープされる');
+  assert(!html.includes('江東区'), '住所は出力に含まれない');
 }
 
 function run() {


### PR DESCRIPTION
## Summary
- Allow manually entered unit prices to apply for self-pay billing while keeping welfare/medical assistance and massage charges at zero
- Normalize manual unit price inputs, keep deprecated massage type suppressed, and ensure invoice PDFs omit patient addresses
- Update inline UI calculations and server-side invoice generation tests to reflect the new billing behavior

## Testing
- node tests/billingLogic.test.js
- node tests/billingOutput.test.js
- node tests/billingGet.test.js
- node tests/billingInvoiceLayout.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d23435c84832597db471fca8b8f7e)