### PR TITLE
Fix billing history routing in iframe sandbox

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -268,8 +268,20 @@ function ensureBillingRoute() {
   const baseUrl = getBillingBaseUrl();
   if (!baseUrl || typeof window === 'undefined') return;
   const targetUrl = baseUrl + '?view=billing';
-  if (window.location.href !== targetUrl) {
-    window.history.replaceState({}, '', targetUrl);
+  if (typeof google !== 'undefined' && google.script && google.script.history && typeof google.script.history.replace === 'function') {
+    // Use Apps Script history API inside IFRAME sandbox to avoid invalid URL errors.
+    google.script.history.replace(null, { view: 'billing' });
+    return;
+  }
+
+  try {
+    const currentUrl = new URL(window.location.href);
+    const target = new URL(targetUrl, currentUrl);
+    if (target.origin === currentUrl.origin && window.location.href !== target.toString()) {
+      window.history.replaceState({}, '', target.toString());
+    }
+  } catch (err) {
+    console.warn('Failed to update billing route', err);
   }
 }
 


### PR DESCRIPTION
## Summary
- use the Apps Script history API when available to avoid replaceState SecurityError inside the billing iframe
- guard browser history updates with same-origin checks so billing aggregation continues even if history cannot be updated

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d2b4011348325b2e385f54e392891)