### PR TITLE
Add diagnostics for billing aggregation logs

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -433,7 +433,7 @@ function loadTreatmentLogs_() {
   const range = sheet.getRange(2, 1, lastRow - 1, width);
   const values = range.getValues();
   const displayValues = range.getDisplayValues();
-  return values.map((row, idx) => {
+  const logs = values.map((row, idx) => {
     const pid = billingNormalizePatientId_(row[colPid - 1]);
     const dateCell = row[colDate - 1];
     const displayRow = displayValues[idx] || [];
@@ -450,6 +450,16 @@ function loadTreatmentLogs_() {
       raw: row
     };
   });
+
+  const timestampDebug = logs.map(log => ({
+    rowNumber: log.rowNumber,
+    patientId: log.patientId,
+    timestamp: log.timestamp instanceof Date ? log.timestamp.toISOString() : String(log.timestamp),
+    isDate: log.timestamp instanceof Date,
+    isValidDate: log.timestamp instanceof Date && !isNaN(log.timestamp.getTime())
+  }));
+  Logger.log('[billing] loadTreatmentLogs_ timestamps: ' + JSON.stringify(timestampDebug));
+  return logs;
 }
 
 function buildVisitCountMap_(billingMonth) {

--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -175,7 +175,7 @@ function generateBillingJsonFromSource(sourceData) {
   } = normalizeBillingSource_(sourceData);
   const patientIds = Object.keys(treatmentVisitCounts || {});
 
-  return patientIds.map(pid => {
+  const billingJson = patientIds.map(pid => {
     const patient = patients[pid] || {};
     const visitCount = normalizeVisitCount_(treatmentVisitCounts[pid]);
     const staffEmails = Array.isArray(staffByPatient[pid]) ? staffByPatient[pid] : (staffByPatient[pid] ? [staffByPatient[pid]] : []);
@@ -224,6 +224,9 @@ function generateBillingJsonFromSource(sourceData) {
       paidStatus: bankStatusEntry && bankStatusEntry.paidStatus ? bankStatusEntry.paidStatus : ''
     };
   });
+
+  Logger.log('[billing] generateBillingJsonFromSource raw billingJson: ' + JSON.stringify(billingJson));
+  return billingJson;
 }
 
 function simulateBillingGeneration(sourceData) {

--- a/src/main.gs
+++ b/src/main.gs
@@ -60,6 +60,7 @@ function loadPreparedBilling_(billingMonthKey) {
   if (!cache) return null;
   const cached = cache.get(key);
   if (!cached) return null;
+  Logger.log('[billing] loadPreparedBilling_ raw cache for ' + key + ': ' + cached);
   try {
     return JSON.parse(cached);
   } catch (err) {

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -82,9 +82,19 @@ function normalizeYm(raw) {
   return '';
 }
 
+function logBillingState(stage, extra) {
+  try {
+    const snapshot = JSON.parse(JSON.stringify(billingState));
+    console.log('[billingState][' + stage + ']', snapshot, extra || '');
+  } catch (err) {
+    console.log('[billingState][' + stage + '] (serialization failed)', err, billingState, extra || '');
+  }
+}
+
 function setBillingLoading(flag, message) {
   billingState.loading = !!flag;
   billingState.statusMessage = flag ? (message || '生成中…') : '';
+  logBillingState('setBillingLoading', { message: billingState.statusMessage });
   renderBillingResult();
 }
 
@@ -386,6 +396,7 @@ function onBillingPrepared(result) {
   billingState.statusMessage = '集計が完了しました。内容確認後にPDFを生成してください。';
   billingState.edits = {};
   billingState.editing = null;
+  logBillingState('onBillingPrepared', { rows: normalized && normalized.billingJson ? normalized.billingJson.length : 0 });
   renderBillingResult();
 }
 
@@ -411,6 +422,7 @@ function onBillingPdfCompleted(result) {
   billingState.statusMessage = 'PDF生成と担当者フォルダへの保存が完了しました';
   billingState.edits = {};
   billingState.editing = null;
+  logBillingState('onBillingPdfCompleted', { rows: normalized && normalized.billingJson ? normalized.billingJson.length : 0 });
   renderBillingResult();
 }
 
@@ -429,6 +441,7 @@ function handleBankExport() {
 function onBankExportCompleted(result) {
   billingState.loading = false;
   billingState.statusMessage = '銀行データを出力しました' + (result && result.inserted ? `（${result.inserted}件）` : '');
+  logBillingState('onBankExportCompleted');
   renderBillingResult();
 }
 
@@ -453,6 +466,7 @@ function onBillingSaveCompleted(result) {
   billingState.statusMessage = '保存が完了しました';
   billingState.edits = {};
   billingState.editing = null;
+  logBillingState('onBillingSaveCompleted', { rows: billingState.prepared && billingState.prepared.billingJson ? billingState.prepared.billingJson.length : 0 });
   renderBillingResult();
 }
 
@@ -461,6 +475,7 @@ function onBillingFailed(err) {
   const msg = err && err.message ? err.message : String(err);
   billingState.loading = false;
   billingState.statusMessage = '請求処理に失敗しました';
+  logBillingState('onBillingFailed', { error: msg });
   renderBillingResult();
   alert('請求生成に失敗しました: ' + msg);
 }
@@ -553,6 +568,10 @@ function renderBillingSummary(rows) {
 }
 
 function renderBillingResult() {
+  logBillingState('renderBillingResult', {
+    resultLength: billingState.result && billingState.result.billingJson ? billingState.result.billingJson.length : 0,
+    preparedLength: billingState.prepared && billingState.prepared.billingJson ? billingState.prepared.billingJson.length : 0
+  });
   updateBillingControls();
   const box = qs('billingResult');
   if (!box) return;


### PR DESCRIPTION
## Summary
- log raw billing JSON output when generating billing data
- record treatment log timestamps and cached prepared billing payloads for debugging
- add client-side billing state snapshots to trace when state becomes empty

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d3c29e53c8325a791833c3fc8832a)