### PR TITLE
Handle missing Logger in billing logic

### DIFF
--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -9,6 +9,10 @@ const BILLING_TRANSPORT_UNIT_PRICE = (typeof globalThis !== 'undefined' && typeo
   : BILLING_TRANSPORT_UNIT_PRICE_FALLBACK;
 const BILLING_TREATMENT_UNIT_PRICE_BY_BURDEN = { 1: 417, 2: 834, 3: 1251 };
 
+const Logger = typeof globalThis !== 'undefined' && globalThis.Logger
+  ? globalThis.Logger
+  : { log: () => {} };
+
 const billingResolveStaffDisplayName_ = typeof resolveStaffDisplayName_ === 'function'
   ? resolveStaffDisplayName_
   : function fallbackResolveStaffDisplayName_(email, directory) {


### PR DESCRIPTION
## Summary
- add a no-op Logger fallback in billing logic when the global Logger is absent
- prevent reference errors during billing JSON generation in non-Apps Script environments

## Testing
- node tests/billingGet.test.js
- node tests/billingInvoiceLayout.test.js
- node tests/billingOutput.test.js
- node tests/billingLogic.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d4c75227c8325a3f8b85a5d4be54e)