### PR TITLE
Add Logger fallbacks for billing pipeline

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -1,5 +1,9 @@
 /***** Get layer: billing data retrieval *****/
 
+const Logger = typeof globalThis !== 'undefined' && globalThis.Logger
+  ? globalThis.Logger
+  : { log: () => {} };
+
 /**
  * Provide local fallbacks for shared helpers so the billing pipeline can run
  * without depending on Code.js ordering.

--- a/src/main.gs
+++ b/src/main.gs
@@ -5,6 +5,10 @@
  * callers can preview JSON or generate patient invoice PDFs for a given billing month.
  */
 
+const Logger = typeof globalThis !== 'undefined' && globalThis.Logger
+  ? globalThis.Logger
+  : { log: () => {} };
+
 function doGet(e) {
   const template = HtmlService.createTemplateFromFile('billing');
   template.baseUrl = ScriptApp.getService().getUrl() || '';


### PR DESCRIPTION
## Summary
- add a defensive Logger fallback to the billing data retrieval layer so scripts can run without Apps Script globals
- add the same Logger fallback to billing entry points to avoid reference errors when Logger is unavailable

## Testing
- node tests/billingGet.test.js
- node tests/billingLogic.test.js
- node tests/billingOutput.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d4d3dae248325a2aacecd931ad3c8)