### PR TITLE
Avoid rounding manual self-paid billing amounts

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -253,6 +253,7 @@ function calculateInvoiceChargeBreakdown_(params) {
   const hasManualUnitPrice = Number.isFinite(manualUnitPrice) && manualUnitPrice !== 0;
   const isMedicalAssistance = normalizeInvoiceMedicalAssistanceFlag_(params && params.medicalAssistance);
   const isMassage = insuranceType === 'マッサージ';
+  const isSelfPaid = insuranceType === '自費';
   const shouldZero = (insuranceType === '生保' || isMedicalAssistance) && !hasManualUnitPrice;
   const isZeroChargeInsurance = shouldZero || (insuranceType === '自費' && !hasManualUnitPrice);
 
@@ -266,7 +267,7 @@ function calculateInvoiceChargeBreakdown_(params) {
   const rawTreatmentAmount = visits > 0 ? treatmentUnitPrice * visits : 0;
   const treatmentAmount = (isZeroChargeInsurance || isMassage)
     ? rawTreatmentAmount
-    : roundToNearestTen_(rawTreatmentAmount);
+    : (isSelfPaid ? rawTreatmentAmount : roundToNearestTen_(rawTreatmentAmount));
   const transportAmount = visits > 0 && !isMassage && !isZeroChargeInsurance
     ? TRANSPORT_PRICE * visits
     : 0;

--- a/tests/billingLogic.test.js
+++ b/tests/billingLogic.test.js
@@ -140,6 +140,19 @@ function testSelfPaidDefaultsToZeroWithoutManualUnitPrice() {
   assert.strictEqual(result.grandTotal, 500, '繰越額のみが合計に反映される');
 }
 
+function testSelfPaidManualPriceIsNotRounded() {
+  const result = calculateBillingAmounts_({
+    visitCount: 1,
+    insuranceType: '自費',
+    unitPrice: 3333,
+    carryOverAmount: 0
+  });
+
+  assert.strictEqual(result.treatmentAmount, 3333, '自費の手動単価はそのまま乗算される');
+  assert.strictEqual(result.billingAmount, 3333, '自費では10円単位に丸めず請求する');
+  assert.strictEqual(result.grandTotal, 3366, '施術料と交通費を合算した金額が保持される');
+}
+
 function run() {
   testBurdenRateDigitConversion();
   testMassageBillingExclusion();
@@ -149,6 +162,7 @@ function run() {
   testCustomTransportUnitPriceIsUsed();
   testFullWidthNumbersAreParsedAndAppliedForSelfPaidManualPrice();
   testSelfPaidDefaultsToZeroWithoutManualUnitPrice();
+  testSelfPaidManualPriceIsNotRounded();
   console.log('billingLogic tests passed');
 }
 

--- a/tests/billingOutput.test.js
+++ b/tests/billingOutput.test.js
@@ -164,6 +164,22 @@ function testSelfPaidInvoiceStaysZeroWithoutManualUnitPrice() {
   assert.strictEqual(breakdown.grandTotal, 500, '繰越のみが合計に残る');
 }
 
+function testSelfPaidInvoiceDoesNotRoundManualUnitPrice() {
+  const context = createContext();
+  vm.createContext(context);
+  vm.runInContext(billingOutputCode, context);
+
+  const breakdown = context.calculateInvoiceChargeBreakdown_({
+    insuranceType: '自費',
+    unitPrice: 3333,
+    visitCount: 1,
+    carryOverAmount: 0
+  });
+
+  assert.strictEqual(breakdown.treatmentAmount, 3333, '自費の手動単価は四捨五入せずに計上する');
+  assert.strictEqual(breakdown.grandTotal, 3366, '施術料と交通費の合計をそのまま出力する');
+}
+
 function testInsuranceBillingIsRoundedToNearestTen() {
   const context = createContext();
   vm.createContext(context);
@@ -238,6 +254,7 @@ function run() {
   testCustomUnitPriceForSelfPaidInvoice();
   testFullWidthInputsAreNormalized();
   testSelfPaidInvoiceStaysZeroWithoutManualUnitPrice();
+  testSelfPaidInvoiceDoesNotRoundManualUnitPrice();
   testInsuranceBillingIsRoundedToNearestTen();
   testWelfareBillingStillAddsTransport();
   testMassageBillingDoesNotChargeTransport();


### PR DESCRIPTION
## Summary
- keep self-paid manual billing amounts from being rounded while preserving transport fees
- update invoice breakdown calculations so self-paid invoices use exact entered prices
- add regression tests covering self-paid manual price handling

## Testing
- node tests/billingLogic.test.js
- node tests/billingOutput.test.js
- node tests/billingGet.test.js
- node tests/billingInvoiceLayout.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d4f8cde508325bc155b8c1854d88f)