### PR TITLE
Remove Logger redefinition in billingGet

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -1,9 +1,5 @@
 /***** Get layer: billing data retrieval *****/
 
-const Logger = typeof globalThis !== 'undefined' && globalThis.Logger
-  ? globalThis.Logger
-  : { log: () => {} };
-
 /**
  * Provide local fallbacks for shared helpers so the billing pipeline can run
  * without depending on Code.js ordering.


### PR DESCRIPTION
## Summary
- remove the custom Logger fallback in billingGet.js to avoid redeclaration conflicts and rely on the standard Apps Script Logger

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d542618808325bc87a68077478f92)