### PR TITLE
Remove Logger redefinitions

### DIFF
--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -9,10 +9,6 @@ const BILLING_TRANSPORT_UNIT_PRICE = (typeof globalThis !== 'undefined' && typeo
   : BILLING_TRANSPORT_UNIT_PRICE_FALLBACK;
 const BILLING_TREATMENT_UNIT_PRICE_BY_BURDEN = { 1: 417, 2: 834, 3: 1251 };
 
-const Logger = typeof globalThis !== 'undefined' && globalThis.Logger
-  ? globalThis.Logger
-  : { log: () => {} };
-
 const billingResolveStaffDisplayName_ = typeof resolveStaffDisplayName_ === 'function'
   ? resolveStaffDisplayName_
   : function fallbackResolveStaffDisplayName_(email, directory) {

--- a/src/main.gs
+++ b/src/main.gs
@@ -5,10 +5,6 @@
  * callers can preview JSON or generate patient invoice PDFs for a given billing month.
  */
 
-const Logger = typeof globalThis !== 'undefined' && globalThis.Logger
-  ? globalThis.Logger
-  : { log: () => {} };
-
 function doGet(e) {
   const template = HtmlService.createTemplateFromFile('billing');
   template.baseUrl = ScriptApp.getService().getUrl() || '';


### PR DESCRIPTION
## Summary
- remove custom Logger initialization from billing logic to rely on Apps Script logger
- delete Logger fallback from main entry points to avoid redefinition of built-in Logger

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d56b17df88325b3d10e082010551a)