### PR TITLE
Handle missing Logger in billing logic

### DIFF
--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -20,6 +20,10 @@ const billingResolveStaffDisplayName_ = typeof resolveStaffDisplayName_ === 'fun
     return parts[0] || normalized;
   };
 
+const billingLogger_ = typeof Logger === 'object' && Logger && typeof Logger.log === 'function'
+  ? Logger
+  : { log: () => {} };
+
 function roundToNearestTen_(value) {
   const num = Number(value);
   if (!Number.isFinite(num)) return 0;
@@ -228,7 +232,7 @@ function generateBillingJsonFromSource(sourceData) {
     };
   });
 
-  Logger.log('[billing] generateBillingJsonFromSource raw billingJson: ' + JSON.stringify(billingJson));
+  billingLogger_.log('[billing] generateBillingJsonFromSource raw billingJson: ' + JSON.stringify(billingJson));
   return billingJson;
 }
 


### PR DESCRIPTION
## Summary
- add a fallback logger for billing logic when Apps Script Logger is unavailable
- preserve existing logging while allowing the module to run in non-Apps Script contexts

## Testing
- node tests/billingLogic.test.js
- node tests/billingGet.test.js
- node tests/billingInvoiceLayout.test.js
- node tests/billingOutput.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d584ff53083259a1c360b6c21ebda)