### PR TITLE
Add billing aggregation debug logging

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -458,7 +458,7 @@ function loadTreatmentLogs_() {
     isDate: log.timestamp instanceof Date,
     isValidDate: log.timestamp instanceof Date && !isNaN(log.timestamp.getTime())
   }));
-  Logger.log('[billing] loadTreatmentLogs_ timestamps: ' + JSON.stringify(timestampDebug));
+  Logger.log('[billing] loadTreatmentLogs_: timestamps=' + JSON.stringify(timestampDebug));
   return logs;
 }
 
@@ -467,11 +467,13 @@ function buildVisitCountMap_(billingMonth) {
   const logs = loadTreatmentLogs_();
   const counts = {};
   const staffHistoryByPatient = {};
+  let filteredCount = 0;
   logs.forEach(log => {
     const pid = log && log.patientId ? billingNormalizePatientId_(log.patientId) : '';
     const ts = log && log.timestamp;
     if (!pid || !(ts instanceof Date) || isNaN(ts.getTime())) return;
     if (ts < month.start || ts >= month.end) return;
+    filteredCount += 1;
     const current = counts[pid] || { visitCount: 0 };
     current.visitCount += 1;
     counts[pid] = current;
@@ -502,6 +504,8 @@ function buildVisitCountMap_(billingMonth) {
     map[pid] = sorted;
     return map;
   }, {});
+  Logger.log('[billing] buildVisitCountMap_: after month filter count=' + filteredCount);
+  Logger.log('[billing] buildVisitCountMap_: visitCountMap keys=' + JSON.stringify(Object.keys(counts)));
   return { billingMonth: month.key, counts, staffByPatient, staffHistoryByPatient };
 }
 

--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -62,6 +62,7 @@ function normalizeBillingSource_(source) {
   const staffDisplayByPatient = source.staffDisplayByPatient || {};
   const bankStatuses = source.bankStatuses || {};
   const carryOverByPatient = source.carryOverByPatient || {};
+  billingLogger_.log('[billing] patients keys=' + JSON.stringify(Object.keys(patientMap)));
   return {
     billingMonth,
     patients: patientMap,
@@ -232,7 +233,8 @@ function generateBillingJsonFromSource(sourceData) {
     };
   });
 
-  billingLogger_.log('[billing] generateBillingJsonFromSource raw billingJson: ' + JSON.stringify(billingJson));
+  billingLogger_.log('[billing] raw billingJson=' + JSON.stringify(billingJson));
+  billingLogger_.log('[billing] billingJson length=' + billingJson.length);
   return billingJson;
 }
 


### PR DESCRIPTION
## Summary
- add detailed timestamp debug logging for treatment log loading
- record visit map keys and month-filtered counts during visit count aggregation
- log patient map keys and final billing JSON details and length during billing generation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d5f7e4f3483259203aae4f13413d4)