### PR TITLE
Add console fallback for billing logger

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -28,9 +28,21 @@ const billingParseDateFlexible_ = typeof parseDateFlexible_ === 'function'
     return isNaN(parsed.getTime()) ? null : parsed;
   };
 
-const billingLogger_ = typeof Logger === 'object' && Logger && typeof Logger.log === 'function'
-  ? Logger
-  : { log: () => {} };
+const billingLogger_ = (() => {
+  try {
+    if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+      return { log: (...args) => Logger.log(...args) };
+    }
+  } catch (err) {
+    // ignore logging setup errors and fall back to console
+  }
+
+  const fallback = typeof console !== 'undefined' && console && typeof console.log === 'function'
+    ? (...args) => console.log(...args)
+    : () => {};
+
+  return { log: fallback };
+})();
 
 function billingParseTreatmentTimestamp_(rawValue, displayValue) {
   const excelSerialToDate = (value) => {

--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -20,9 +20,21 @@ const billingResolveStaffDisplayName_ = typeof resolveStaffDisplayName_ === 'fun
     return parts[0] || normalized;
   };
 
-const billingLogger_ = typeof Logger === 'object' && Logger && typeof Logger.log === 'function'
-  ? Logger
-  : { log: () => {} };
+const billingLogger_ = (() => {
+  try {
+    if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+      return { log: (...args) => Logger.log(...args) };
+    }
+  } catch (err) {
+    // ignore logging setup errors and fall back to console
+  }
+
+  const fallback = typeof console !== 'undefined' && console && typeof console.log === 'function'
+    ? (...args) => console.log(...args)
+    : () => {};
+
+  return { log: fallback };
+})();
 
 function roundToNearestTen_(value) {
   const num = Number(value);


### PR DESCRIPTION
## Summary
- wrap billing logging initialization in a try/catch to safely use Logger when available
- add console-based fallback so billing logging continues without runtime errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d68a3b63883259827e0dc2f687719)