### PR TITLE
Add billing debug logging for visit count investigation

### DIFF
--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -178,10 +178,21 @@ function generateBillingJsonFromSource(sourceData) {
     carryOverByPatient
   } = normalizeBillingSource_(sourceData);
   const patientIds = Object.keys(treatmentVisitCounts || {});
+  const zeroVisitDebug = [];
 
   const billingJson = patientIds.map(pid => {
     const patient = patients[pid] || {};
-    const visitCount = normalizeVisitCount_(treatmentVisitCounts[pid]);
+    const rawVisitCount = treatmentVisitCounts[pid];
+    const visitCount = normalizeVisitCount_(rawVisitCount);
+    if (!visitCount && zeroVisitDebug.length < 20) {
+      zeroVisitDebug.push({
+        patientId: pid,
+        rawVisitCount,
+        normalizedVisitCount: visitCount,
+        payerType: patient.payerType,
+        carryOverAmount: patient.carryOverAmount
+      });
+    }
     const staffEmails = Array.isArray(staffByPatient[pid]) ? staffByPatient[pid] : (staffByPatient[pid] ? [staffByPatient[pid]] : []);
     const resolvedStaffNames = Array.isArray(staffDisplayByPatient[pid]) ? staffDisplayByPatient[pid] : [];
     const responsibleNames = resolvedStaffNames.length
@@ -230,6 +241,7 @@ function generateBillingJsonFromSource(sourceData) {
   });
 
   billingLogger_.log('[billing] raw billingJson=' + JSON.stringify(billingJson));
+  billingLogger_.log('[billing] generateBillingJsonFromSource: zero visit samples=' + JSON.stringify(zeroVisitDebug));
   billingLogger_.log('[billing] billingJson length=' + billingJson.length);
   return billingJson;
 }

--- a/src/main.gs
+++ b/src/main.gs
@@ -81,18 +81,44 @@ function loadPreparedBilling_(billingMonthKey) {
   const cache = getBillingCache_();
   if (!cache) return null;
   const cached = cache.get(key);
-  if (!cached) return null;
-  Logger.log('[billing] loadPreparedBilling_ raw cache for ' + key + ': ' + cached);
+  if (!cached) {
+    try {
+      Logger.log('[billing] loadPreparedBilling_: cache miss for ' + key);
+    } catch (err) {
+      // ignore logging errors in non-GAS environments
+    }
+    return null;
+  }
+  try {
+    Logger.log('[billing] loadPreparedBilling_ raw cache for ' + key + ': ' + cached);
+  } catch (err) {
+    // ignore logging errors in non-GAS environments
+  }
   try {
     const parsed = JSON.parse(cached);
     const validation = validatePreparedBillingPayload_(parsed, billingMonthKey);
     if (!validation.ok) {
+      try {
+        Logger.log('[billing] loadPreparedBilling_: invalid cache for ' + key + ' reason=' + validation.reason);
+      } catch (err) {
+        // ignore logging errors in non-GAS environments
+      }
       console.warn('[billing] Prepared cache invalid for ' + key + ': ' + validation.reason);
       clearBillingCache_(key);
       return null;
     }
+    try {
+      Logger.log('[billing] loadPreparedBilling_: parsed cache billingJson length=' + (parsed.billingJson || []).length);
+    } catch (err) {
+      // ignore logging errors in non-GAS environments
+    }
     return Object.assign({}, parsed, { billingMonth: validation.billingMonth });
   } catch (err) {
+    try {
+      Logger.log('[billing] loadPreparedBilling_: failed to parse cache for ' + key + ' error=' + err);
+    } catch (logErr) {
+      // ignore logging errors in non-GAS environments
+    }
     console.warn('[billing] Failed to parse prepared cache', err);
     clearBillingCache_(key);
     return null;


### PR DESCRIPTION
## Summary
- add detailed logging to treatment log loading and visit count aggregation to surface PID normalization and timestamp issues
- log billing source creation, zero-visit samples, and billing JSON generation details
- log prepared billing cache usage to trace cache misses, validation failures, and parse errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e34bb043c83258921676d42e8630b)