### PR TITLE
Add billing logger fallbacks for tests

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -4,6 +4,13 @@
  * Provide local fallbacks for shared helpers so the billing pipeline can run
  * without depending on Code.js ordering.
  */
+if (typeof billingLogger_ === 'undefined') {
+  const billingFallbackLog_ = typeof console !== 'undefined' && console && typeof console.log === 'function'
+    ? (...args) => console.log(...args)
+    : () => {};
+  billingLogger_ = { log: billingFallbackLog_ }; // eslint-disable-line no-global-assign
+}
+
 const billingNormalizeHeaderKey_ = typeof normalizeHeaderKey_ === 'function'
   ? normalizeHeaderKey_
   : function normalizeHeaderKey_(s) {

--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -1,5 +1,12 @@
 /***** Logic layer: billing JSON generation (pure functions) *****/
 
+if (typeof billingLogger_ === 'undefined') {
+  const billingFallbackLog_ = typeof console !== 'undefined' && console && typeof console.log === 'function'
+    ? (...args) => console.log(...args)
+    : () => {};
+  billingLogger_ = { log: billingFallbackLog_ }; // eslint-disable-line no-global-assign
+}
+
 const BILLING_TREATMENT_PRICE = 4070;
 const BILLING_ELECTRO_PRICE = 100;
 const BILLING_UNIT_PRICE = BILLING_TREATMENT_PRICE + BILLING_ELECTRO_PRICE;


### PR DESCRIPTION
## Summary
- add a console-based billing logger fallback to billing retrieval and logic scripts
- allow billing utilities to operate when the shared logger module has not been loaded

## Testing
- node tests/billingGet.test.js
- node tests/billingInvoiceLayout.test.js
- node tests/billingLogic.test.js
- node tests/billingOutput.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e3bd85d9c8325b1cf0962496a146f)