### PR TITLE
Fix billing UI payload normalization for nested results

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -365,7 +365,6 @@ function loadBillingPage() {
 function normalizeBillingResultPayload(raw) {
   if (!raw) return null;
 
-  // Helper to parse stringified payloads safely.
   function parseMaybeJson(value) {
     if (typeof value !== 'string') return value;
     try {
@@ -375,30 +374,10 @@ function normalizeBillingResultPayload(raw) {
       return null;
     }
   }
-  // Coerce billingJson only when it is actually present.
+
   function coerceBillingJson(value) {
     if (Array.isArray(value)) return value;
     if (typeof value === 'string') {
-      
-  if (result && typeof result === 'object' && result.payload && typeof result.payload === 'object') {
-    const payload = result.payload;
-    if (payload.billingJson) {
-      result = payload;
-    }
-  }
-
-  if (Array.isArray(result)) {
-    return { billingJson: result, billingMonth: '', preparedAt: null };
-  }
-
-  if (result && typeof result === 'object' && result.result && typeof result.result === 'object') {
-    result = result.result;
-  }
-
-  const billingJson = (() => {
-    if (Array.isArray(result.billingJson)) return result.billingJson;
-    if (typeof result.billingJson === 'string') {
-    
       try {
         const parsed = JSON.parse(value);
         return Array.isArray(parsed) ? parsed : null;
@@ -410,7 +389,6 @@ function normalizeBillingResultPayload(raw) {
     return null;
   }
 
-  // Recursively search for an object that already contains billingJson.
   function findBillingPayload(obj, ancestors) {
     if (!obj || typeof obj !== 'object') return null;
     const billingJson = coerceBillingJson(obj.billingJson);
@@ -438,6 +416,10 @@ function normalizeBillingResultPayload(raw) {
 
   if (Array.isArray(result)) {
     return { billingJson: result, billingMonth: '', preparedAt: null };
+  }
+
+  if (result && typeof result === 'object' && result.result && typeof result.result === 'object') {
+    result = result.result;
   }
 
   const found = findBillingPayload(result);

--- a/tests/billingUiNormalization.test.js
+++ b/tests/billingUiNormalization.test.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const code = fs.readFileSync(path.join(__dirname, '../src/main.js.html'), 'utf8')
+  .replace(/^\s*<script>\s*/, '')
+  .replace(/\s*<\/script>\s*$/, '');
+
+function createContext() {
+  const documentStub = {
+    body: { dataset: {} },
+    getElementById: () => null,
+    querySelector: () => null,
+    querySelectorAll: () => []
+  };
+
+  const windowStub = { APP_CONFIG: {}, document: documentStub };
+  windowStub.window = windowStub;
+
+  const ctx = {
+    console,
+    alert: () => {},
+    document: documentStub,
+    window: windowStub,
+    Intl,
+  };
+
+  vm.createContext(ctx);
+  vm.runInContext(code, ctx);
+  return ctx;
+}
+
+const { normalizeBillingResultPayload } = createContext();
+
+function testParsesStringifiedPayload() {
+  const raw = JSON.stringify({ billingJson: [{ patientId: '001' }], billingMonth: '202501' });
+  const result = normalizeBillingResultPayload(raw);
+  assert.strictEqual(result.billingMonth, '202501', '請求月が保持される');
+  assert.strictEqual(result.billingJson.length, 1, 'billingJson が配列として復元される');
+}
+
+function testFindsNestedBillingJson() {
+  const raw = {
+    data: {
+      response: {
+        billingJson: JSON.stringify([{ patientId: '777' }]),
+        preparedAt: '2025-12-01T00:00:00Z'
+      }
+    }
+  };
+  const result = normalizeBillingResultPayload(raw);
+  assert.strictEqual(result.billingJson[0].patientId, '777', 'ネストした billingJson を抽出する');
+  assert.strictEqual(result.preparedAt, '2025-12-01T00:00:00Z', '元のメタデータを保持する');
+}
+
+function testReturnsNullOnUnparsableString() {
+  const result = normalizeBillingResultPayload('{invalid json');
+  assert.strictEqual(result, null, '不正なJSON文字列は null を返す');
+}
+
+function run() {
+  testParsesStringifiedPayload();
+  testFindsNestedBillingJson();
+  testReturnsNullOnUnparsableString();
+  console.log('billingUiNormalization tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- rewrite billing payload normalization to safely parse string inputs and nested billingJson wrappers
- add coverage for billing UI payload normalization scenarios

## Testing
- node tests/billingUiNormalization.test.js
- node tests/billingLogic.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e403aab6c832591355a24c3eb9757)