### PR TITLE
Improve billing payload normalization

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -389,23 +389,39 @@ function normalizeBillingResultPayload(raw) {
     return null;
   }
 
-  function findBillingPayload(obj, ancestors) {
-    if (!obj || typeof obj !== 'object') return null;
-    const billingJson = coerceBillingJson(obj.billingJson);
-    if (billingJson) {
-      return { payload: obj, billingJson };
+  function findBillingPayload(root, metaSource) {
+    const queue = [];
+    const visited = new WeakSet();
+
+    function mergeWithMeta(obj) {
+      const billingJson = coerceBillingJson(obj.billingJson);
+      if (!billingJson) return null;
+      const meta = metaSource && typeof metaSource === 'object' ? metaSource : {};
+      return Object.assign({}, meta, obj, { billingJson });
     }
 
-    const nestedKeys = ['payload', 'result', 'data', 'response'];
-    for (let i = 0; i < nestedKeys.length; i++) {
-      const key = nestedKeys[i];
-      if (obj[key]) {
-        const found = findBillingPayload(obj[key], (ancestors || []).concat(key));
-        if (found) {
-          const merged = Object.assign({}, obj, found.payload, { billingJson: found.billingJson });
-          return { payload: merged, billingJson: found.billingJson };
-        }
+    function enqueue(candidate) {
+      const parsed = parseMaybeJson(candidate);
+      const value = parsed === null ? candidate : parsed;
+      if (value && typeof value === 'object' && !visited.has(value)) {
+        visited.add(value);
+        queue.push(value);
       }
+    }
+
+    enqueue(root);
+
+    while (queue.length) {
+      const obj = queue.shift();
+      const merged = mergeWithMeta(obj);
+      if (merged) {
+        return merged;
+      }
+
+      Object.keys(obj).forEach(key => {
+        const value = obj[key];
+        enqueue(value);
+      });
     }
 
     return null;
@@ -418,13 +434,9 @@ function normalizeBillingResultPayload(raw) {
     return { billingJson: result, billingMonth: '', preparedAt: null };
   }
 
-  if (result && typeof result === 'object' && result.result && typeof result.result === 'object') {
-    result = result.result;
-  }
-
-  const found = findBillingPayload(result);
+  const found = findBillingPayload(result, result);
   if (found && found.billingJson) {
-    return Object.assign({}, found.payload, { billingJson: found.billingJson });
+    return found;
   }
 
   const billingJson = coerceBillingJson(result.billingJson) || [];
@@ -455,6 +467,7 @@ function handleBillingAggregation() {
 }
 
 function onBillingPrepared(result) {
+  console.warn('[billing-debug] raw result = ', JSON.stringify(result, null, 2).slice(0, 5000));
   const normalized = normalizeBillingResultPayload(result);
   billingState.result = normalized;
   billingState.prepared = normalized;

--- a/tests/billingUiNormalization.test.js
+++ b/tests/billingUiNormalization.test.js
@@ -54,6 +54,21 @@ function testFindsNestedBillingJson() {
   assert.strictEqual(result.preparedAt, '2025-12-01T00:00:00Z', '元のメタデータを保持する');
 }
 
+function testFindsBillingJsonInsideStringifiedPayload() {
+  const raw = {
+    result: JSON.stringify({
+      payload: {
+        billingJson: JSON.stringify([{ patientId: '900' }]),
+        billingMonth: '202512'
+      }
+    })
+  };
+
+  const result = normalizeBillingResultPayload(raw);
+  assert.strictEqual(result.billingJson[0].patientId, '900', '文字列化された payload から billingJson を抽出する');
+  assert.strictEqual(result.billingMonth, '202512', 'billingMonth を保持する');
+}
+
 function testReturnsNullOnUnparsableString() {
   const result = normalizeBillingResultPayload('{invalid json');
   assert.strictEqual(result, null, '不正なJSON文字列は null を返す');
@@ -62,6 +77,7 @@ function testReturnsNullOnUnparsableString() {
 function run() {
   testParsesStringifiedPayload();
   testFindsNestedBillingJson();
+  testFindsBillingJsonInsideStringifiedPayload();
   testReturnsNullOnUnparsableString();
   console.log('billingUiNormalization tests passed');
 }


### PR DESCRIPTION
## Summary
- add debug logging of raw billing aggregation responses
- enhance billing result normalization to parse nested or stringified payloads while retaining metadata
- extend UI normalization tests to cover stringified nested payloads

## Testing
- node tests/billingUiNormalization.test.js
- node tests/billingLogic.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e4375526083258b7f3b2c2f839752)