### PR TITLE
Improve billing payload parse error logging

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -370,7 +370,8 @@ function normalizeBillingResultPayload(raw) {
     try {
       return JSON.parse(value);
     } catch (err) {
-      console.warn('Failed to parse billing payload text', err);
+      const msg = err && err.message ? err.message : err;
+      console.warn('Failed to parse billing payload text:', msg);
       return null;
     }
   }
@@ -382,7 +383,8 @@ function normalizeBillingResultPayload(raw) {
         const parsed = JSON.parse(value);
         return Array.isArray(parsed) ? parsed : null;
       } catch (err) {
-        console.warn('Failed to parse billingJson string', err);
+        const msg = err && err.message ? err.message : err;
+        console.warn('Failed to parse billingJson string:', msg);
         return null;
       }
     }


### PR DESCRIPTION
## Summary
- limit billing payload parse warnings to error messages instead of full stack traces
- apply the same concise logging when billingJson strings fail to parse

## Testing
- node tests/billingUiNormalization.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e4876491c832582fc200b6229b515)