### PR TITLE
Propagate billing metadata from ancestor payloads

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -395,34 +395,54 @@ function normalizeBillingResultPayload(raw) {
     const queue = [];
     const visited = new WeakSet();
 
-    function mergeWithMeta(obj) {
+    function extractMetaFields(source) {
+      if (!source || typeof source !== 'object') return {};
+      const meta = {};
+      Object.keys(source).forEach(key => {
+        const value = source[key];
+        const type = typeof value;
+        if (
+          value === null ||
+          type === 'string' ||
+          type === 'number' ||
+          type === 'boolean' ||
+          Object.prototype.toString.call(value) === '[object Date]'
+        ) {
+          meta[key] = value;
+        }
+      });
+      return meta;
+    }
+
+    function mergeWithMeta(obj, meta) {
       const billingJson = coerceBillingJson(obj.billingJson);
       if (!billingJson) return null;
-      const meta = metaSource && typeof metaSource === 'object' ? metaSource : {};
       return Object.assign({}, meta, obj, { billingJson });
     }
 
-    function enqueue(candidate) {
+    function enqueue(candidate, inheritedMeta) {
       const parsed = parseMaybeJson(candidate);
       const value = parsed === null ? candidate : parsed;
       if (value && typeof value === 'object' && !visited.has(value)) {
         visited.add(value);
-        queue.push(value);
+        const meta = Object.assign({}, inheritedMeta, extractMetaFields(value));
+        queue.push({ obj: value, meta });
       }
     }
 
-    enqueue(root);
+    const initialMeta = extractMetaFields(metaSource);
+    enqueue(root, initialMeta);
 
     while (queue.length) {
-      const obj = queue.shift();
-      const merged = mergeWithMeta(obj);
+      const { obj, meta } = queue.shift();
+      const merged = mergeWithMeta(obj, meta);
       if (merged) {
         return merged;
       }
 
       Object.keys(obj).forEach(key => {
         const value = obj[key];
-        enqueue(value);
+        enqueue(value, meta);
       });
     }
 

--- a/tests/billingUiNormalization.test.js
+++ b/tests/billingUiNormalization.test.js
@@ -69,6 +69,23 @@ function testFindsBillingJsonInsideStringifiedPayload() {
   assert.strictEqual(result.billingMonth, '202512', 'billingMonth を保持する');
 }
 
+function testMergesMetadataFromAncestorObjects() {
+  const raw = {
+    data: {
+      preparedAt: '2025-03-01T00:00:00Z',
+      billingMonth: '202503',
+      payload: {
+        billingJson: JSON.stringify([{ patientId: '555' }])
+      }
+    }
+  };
+
+  const result = normalizeBillingResultPayload(raw);
+  assert.strictEqual(result.billingJson[0].patientId, '555', 'ネストした billingJson を抽出する');
+  assert.strictEqual(result.billingMonth, '202503', '祖先オブジェクトの billingMonth を引き継ぐ');
+  assert.strictEqual(result.preparedAt, '2025-03-01T00:00:00Z', '祖先オブジェクトの preparedAt を引き継ぐ');
+}
+
 function testReturnsNullOnUnparsableString() {
   const result = normalizeBillingResultPayload('{invalid json');
   assert.strictEqual(result, null, '不正なJSON文字列は null を返す');
@@ -78,6 +95,7 @@ function run() {
   testParsesStringifiedPayload();
   testFindsNestedBillingJson();
   testFindsBillingJsonInsideStringifiedPayload();
+  testMergesMetadataFromAncestorObjects();
   testReturnsNullOnUnparsableString();
   console.log('billingUiNormalization tests passed');
 }


### PR DESCRIPTION
## Summary
- carry forward scalar metadata from ancestor objects when normalizing billing result payloads
- ensure billing JSON extraction still works when metadata lives above the payload
- add coverage for nested billing payload metadata retention

## Testing
- node tests/billingUiNormalization.test.js
- node tests/billingGet.test.js
- node tests/billingLogic.test.js
- node tests/billingOutput.test.js
- node tests/billingInvoiceLayout.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e49e016888325ad03e2068e6201dc)