### PR TITLE
Add logging to trace billing JSON through pipeline

### DIFF
--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -249,6 +249,9 @@ function generateBillingJsonFromSource(sourceData) {
 
   billingLogger_.log('[billing] raw billingJson=' + JSON.stringify(billingJson));
   billingLogger_.log('[billing] generateBillingJsonFromSource: zero visit samples=' + JSON.stringify(zeroVisitDebug));
+  if (!billingJson.length) {
+    billingLogger_.log('[billing] generateBillingJsonFromSource: empty billingJson with visitCountKeys=' + JSON.stringify(patientIds));
+  }
   billingLogger_.log('[billing] billingJson length=' + billingJson.length);
   return billingJson;
 }


### PR DESCRIPTION
## Summary
- add buildPreparedBillingPayload_ diagnostics for billing JSON generation and visit counts
- log billingJson lengths during client payload normalization and serialization to trace disappearance points
- emit explicit billingLogic warning when generation yields an empty billingJson

## Testing
- node tests/billingGet.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e52c789908325ad88742ccf266353)