### PR TITLE
Ensure billing staff maps preserved in client payload

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -365,6 +365,31 @@ function loadBillingPage() {
 function normalizeBillingResultPayload(raw) {
   if (!raw) return null;
 
+  function applyBillingFieldDefaults(payload) {
+    if (!payload || typeof payload !== 'object') return payload;
+    return Object.assign(
+      {
+        staffByPatient: {},
+        staffDirectory: {},
+        staffDisplayByPatient: {},
+        patients: {},
+        bankInfoByName: {},
+        bankStatuses: {},
+        carryOverByPatient: {}
+      },
+      payload,
+      {
+        staffByPatient: payload.staffByPatient || {},
+        staffDirectory: payload.staffDirectory || {},
+        staffDisplayByPatient: payload.staffDisplayByPatient || {},
+        patients: payload.patients || payload.patientMap || {},
+        bankInfoByName: payload.bankInfoByName || {},
+        bankStatuses: payload.bankStatuses || {},
+        carryOverByPatient: payload.carryOverByPatient || {}
+      }
+    );
+  }
+
   function parseMaybeJson(value) {
     if (typeof value !== 'string') return value;
     try {
@@ -453,19 +478,19 @@ function normalizeBillingResultPayload(raw) {
   if (result == null) return null;
 
   if (Array.isArray(result)) {
-    return { billingJson: result, billingMonth: '', preparedAt: null };
+    return applyBillingFieldDefaults({ billingJson: result, billingMonth: '', preparedAt: null });
   }
 
   const found = findBillingPayload(result, result);
   if (found && found.billingJson) {
-    return found;
+    return applyBillingFieldDefaults(found);
   }
 
   const billingJson = coerceBillingJson(result.billingJson) || [];
   if (!billingJson.length) {
     console.warn('[billing] billingJson not found in payload; returning empty array');
   }
-  return Object.assign({}, result, { billingJson });
+  return applyBillingFieldDefaults(Object.assign({}, result, { billingJson }));
 }
 
 function handleBillingAggregation() {


### PR DESCRIPTION
## Summary
- ensure billing result normalization preserves staff-related maps and other billing metadata
- default missing staff maps to empty objects so responsible staff details render correctly on the client

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e54effd808325b76f1a96102b9723)