### PR TITLE
Ensure billing normalization inherits ancestor metadata

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -420,20 +420,36 @@ function normalizeBillingResultPayload(raw) {
     const queue = [];
     const visited = new WeakSet();
 
+    const OBJECT_META_FIELDS = [
+      'staffByPatient',
+      'staffDirectory',
+      'staffDisplayByPatient',
+      'patients',
+      'patientMap',
+      'bankInfoByName',
+      'bankStatuses',
+      'carryOverByPatient'
+    ];
+
     function extractMetaFields(source) {
       if (!source || typeof source !== 'object') return {};
       const meta = {};
       Object.keys(source).forEach(key => {
         const value = source[key];
         const type = typeof value;
-        if (
-          value === null ||
-          type === 'string' ||
-          type === 'number' ||
-          type === 'boolean' ||
-          Object.prototype.toString.call(value) === '[object Date]'
-        ) {
+        const isDate = Object.prototype.toString.call(value) === '[object Date]';
+        const isPlainObject = value && !Array.isArray(value) && !isDate && type === 'object';
+        if (OBJECT_META_FIELDS.includes(key) && isPlainObject) {
           meta[key] = value;
+        } else if (value === null || type === 'string' || type === 'number' || type === 'boolean' || isDate) {
+          meta[key] = value;
+        }
+      });
+
+      ['meta', 'metadata'].forEach(nestedKey => {
+        const nested = source[nestedKey];
+        if (nested && typeof nested === 'object') {
+          Object.assign(meta, extractMetaFields(nested));
         }
       });
       return meta;

--- a/tests/billingUiNormalization.test.js
+++ b/tests/billingUiNormalization.test.js
@@ -86,6 +86,26 @@ function testMergesMetadataFromAncestorObjects() {
   assert.strictEqual(result.preparedAt, '2025-03-01T00:00:00Z', '祖先オブジェクトの preparedAt を引き継ぐ');
 }
 
+function testInheritsObjectMetadataFromAncestors() {
+  const raw = {
+    meta: {
+      staffByPatient: { '111': ['taro@example.com'] },
+      staffDirectory: { 'taro@example.com': '太郎' },
+      carryOverByPatient: { '111': 4000 }
+    },
+    nested: {
+      payload: {
+        billingJson: JSON.stringify([{ patientId: '111' }])
+      }
+    }
+  };
+
+  const result = normalizeBillingResultPayload(raw);
+  assert.deepStrictEqual(result.staffByPatient['111'], ['taro@example.com'], 'staffByPatient を祖先から引き継ぐ');
+  assert.strictEqual(result.staffDirectory['taro@example.com'], '太郎', 'staffDirectory を祖先から引き継ぐ');
+  assert.strictEqual(result.carryOverByPatient['111'], 4000, 'carryOverByPatient を祖先から引き継ぐ');
+}
+
 function testReturnsNullOnUnparsableString() {
   const result = normalizeBillingResultPayload('{invalid json');
   assert.strictEqual(result, null, '不正なJSON文字列は null を返す');
@@ -96,6 +116,7 @@ function run() {
   testFindsNestedBillingJson();
   testFindsBillingJsonInsideStringifiedPayload();
   testMergesMetadataFromAncestorObjects();
+  testInheritsObjectMetadataFromAncestors();
   testReturnsNullOnUnparsableString();
   console.log('billingUiNormalization tests passed');
 }


### PR DESCRIPTION
## Summary
- propagate billing metadata objects (e.g., staff and carry-over maps) from ancestor containers when normalizing client payloads
- allow metadata nested under meta/metadata keys to be merged during payload discovery and cover the case with a new UI normalization test

## Testing
- node tests/billingUiNormalization.test.js
- for f in tests/*.js; do echo "Running $f"; node $f; done


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e56d760688325b29100af8001494e)