### PR TITLE
Preserve ancestor files when normalizing billing payloads

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -430,6 +430,7 @@ function normalizeBillingResultPayload(raw) {
       'bankStatuses',
       'carryOverByPatient'
     ];
+    const ARRAY_META_FIELDS = ['files'];
 
     function extractMetaFields(source) {
       if (!source || typeof source !== 'object') return {};
@@ -440,6 +441,8 @@ function normalizeBillingResultPayload(raw) {
         const isDate = Object.prototype.toString.call(value) === '[object Date]';
         const isPlainObject = value && !Array.isArray(value) && !isDate && type === 'object';
         if (OBJECT_META_FIELDS.includes(key) && isPlainObject) {
+          meta[key] = value;
+        } else if (ARRAY_META_FIELDS.includes(key) && Array.isArray(value)) {
           meta[key] = value;
         } else if (value === null || type === 'string' || type === 'number' || type === 'boolean' || isDate) {
           meta[key] = value;

--- a/tests/billingUiNormalization.test.js
+++ b/tests/billingUiNormalization.test.js
@@ -106,6 +106,24 @@ function testInheritsObjectMetadataFromAncestors() {
   assert.strictEqual(result.carryOverByPatient['111'], 4000, 'carryOverByPatient を祖先から引き継ぐ');
 }
 
+function testInheritsFilesFromAncestorMeta() {
+  const raw = {
+    response: {
+      files: [
+        { name: 'invoice-001.pdf', url: 'https://example.com/invoice-001.pdf' }
+      ],
+      payload: {
+        billingJson: [{ patientId: '222' }]
+      }
+    }
+  };
+
+  const result = normalizeBillingResultPayload(raw);
+  assert.strictEqual(result.billingJson[0].patientId, '222', 'billingJson を抽出する');
+  assert.strictEqual(result.files[0].name, 'invoice-001.pdf', '祖先オブジェクトの files 配列を引き継ぐ');
+  assert.strictEqual(result.files[0].url, 'https://example.com/invoice-001.pdf', 'files の中身を保持する');
+}
+
 function testReturnsNullOnUnparsableString() {
   const result = normalizeBillingResultPayload('{invalid json');
   assert.strictEqual(result, null, '不正なJSON文字列は null を返す');
@@ -117,6 +135,7 @@ function run() {
   testFindsBillingJsonInsideStringifiedPayload();
   testMergesMetadataFromAncestorObjects();
   testInheritsObjectMetadataFromAncestors();
+  testInheritsFilesFromAncestorMeta();
   testReturnsNullOnUnparsableString();
   console.log('billingUiNormalization tests passed');
 }


### PR DESCRIPTION
## Summary
- inherit files arrays from ancestor objects when normalizing billing payloads
- add coverage to ensure billing downloads remain available even when metadata is nested

## Testing
- node tests/billingUiNormalization.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e596e83188325bedfd44aa995f36f)