### PR TITLE
Normalize staff identifiers for billing directory

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -127,7 +127,13 @@ const BILLING_LABELS = typeof LABELS !== 'undefined' ? LABELS : {
 const billingNormalizeEmailKey_ = typeof normalizeEmailKey_ === 'function'
   ? normalizeEmailKey_
   : function normalizeEmailKey_(email) {
-    return String(email || '').trim().toLowerCase();
+    const raw = String(email || '').trim();
+    if (!raw) return '';
+    const normalized = raw.normalize('NFKC').replace(/\s+/g, '').toLowerCase();
+    if (normalized.includes('@')) {
+      return normalized;
+    }
+    return normalized.replace(/[-_]/g, '');
   };
 
 const BILLING_PATIENT_COLS_FIXED = typeof PATIENT_COLS_FIXED !== 'undefined' ? PATIENT_COLS_FIXED : {


### PR DESCRIPTION
## Summary
- normalize staff and email keys to handle full-width characters, whitespace, and separators for non-email IDs
- add coverage ensuring staff IDs with hyphens/underscores map to billing directory entries

## Testing
- node tests/billingGet.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e620140a08325b799b52443f973a3)