### PR TITLE
Improve burden rate parsing for noisy inputs

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -383,11 +383,12 @@ function normalizeBurdenRateInt_(value) {
   if (!text) return 0;
 
   const normalized = text.replace(/\s+/g, '').replace('％', '%');
-  const withoutUnits = normalized.replace(/割|分/g, '').replace('%', '');
-  const parsed = Number(withoutUnits);
+  const hasPercent = normalized.indexOf('%') >= 0;
+  const numericText = normalized.replace(/[^0-9.]/g, '');
+  const parsed = Number(numericText);
   if (Number.isFinite(parsed)) {
     if (parsed === 0) return 0;
-    if (normalized.indexOf('%') >= 0) return Math.round(parsed / 10);
+    if (hasPercent) return Math.round(parsed / 10);
     if (parsed < 1) return Math.round(parsed * 10);
     if (parsed < 10) return Math.round(parsed);
     if (parsed <= 100) return Math.round(parsed / 10);

--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -114,10 +114,12 @@ function normalizeBurdenRateInt_(burdenRate) {
   }
 
   const normalized = String(burdenRate).normalize('NFKC').replace(/\s+/g, '').replace('％', '%');
-  const withoutUnits = normalized.replace(/割|分/g, '').replace('%', '');
-  const parsed = Number(withoutUnits);
+  const hasPercent = normalized.indexOf('%') >= 0;
+  const numericText = normalized.replace(/[^0-9.]/g, '');
+  const parsed = Number(numericText);
   if (!Number.isFinite(parsed)) return 0;
-  if (normalized.indexOf('%') >= 0) return Math.round(parsed / 10);
+  if (parsed === 0) return 0;
+  if (hasPercent) return Math.round(parsed / 10);
   if (parsed > 0 && parsed < 10) return Math.round(parsed);
   if (parsed >= 10 && parsed <= 100) return Math.round(parsed / 10);
   return 0;

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -30,17 +30,19 @@ const normalizeInvoiceBurdenRateInt_ = typeof normalizeBurdenRateInt_ === 'funct
     const num = Number(burdenRate);
     if (Number.isFinite(num)) {
       if (num > 0 && num < 1) return Math.round(num * 10);
-      if (num >= 1 && num < 10) return Math.round(num);
-      if (num >= 10 && num <= 100) return Math.round(num / 10);
-    }
-    const normalized = String(burdenRate).normalize('NFKC').replace(/\s+/g, '').replace('％', '%');
-    const withoutUnits = normalized.replace(/割|分/g, '').replace('%', '');
-    const parsed = Number(withoutUnits);
-    if (!Number.isFinite(parsed)) return 0;
-    if (normalized.indexOf('%') >= 0) return Math.round(parsed / 10);
-    if (parsed > 0 && parsed < 10) return Math.round(parsed);
-    if (parsed >= 10 && parsed <= 100) return Math.round(parsed / 10);
-    return 0;
+    if (num >= 1 && num < 10) return Math.round(num);
+    if (num >= 10 && num <= 100) return Math.round(num / 10);
+  }
+  const normalized = String(burdenRate).normalize('NFKC').replace(/\s+/g, '').replace('％', '%');
+  const hasPercent = normalized.indexOf('%') >= 0;
+  const numericText = normalized.replace(/[^0-9.]/g, '');
+  const parsed = Number(numericText);
+  if (!Number.isFinite(parsed)) return 0;
+  if (parsed === 0) return 0;
+  if (hasPercent) return Math.round(parsed / 10);
+  if (parsed > 0 && parsed < 10) return Math.round(parsed);
+  if (parsed >= 10 && parsed <= 100) return Math.round(parsed / 10);
+  return 0;
   };
 
 function convertSpreadsheetToExcelBlob_(file, exportName) {


### PR DESCRIPTION
## Summary
- broaden burden rate normalization to strip non-numeric text while respecting percent inputs
- apply the more tolerant parsing across billing data retrieval, logic, and invoice output layers

## Testing
- node tests/billingGet.test.js
- node tests/billingLogic.test.js
- node tests/billingOutput.test.js
- node tests/billingInvoiceLayout.test.js
- node tests/billingUiNormalization.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e65e8b67083258779d835be3db694)