### PR TITLE
Normalize staff directory keys using display values

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -312,17 +312,21 @@ function loadBillingStaffDirectory_() {
   if (!colName || (!colEmail && !colStaffId)) return {};
 
   const values = sheet.getRange(2, 1, lastRow - 1, lastCol).getValues();
-  const directory = values.reduce((map, row) => {
+  const displayValues = sheet.getRange(2, 1, lastRow - 1, lastCol).getDisplayValues();
+  const directory = values.reduce((map, row, idx) => {
+    const displayRow = displayValues[idx] || [];
     const name = colName ? String(row[colName - 1] || '').trim() : '';
     if (!name) return map;
 
     const keys = [];
     if (colEmail) {
-      const emailKey = billingNormalizeEmailKey_(row[colEmail - 1]);
+      const emailCandidate = extractEmailFallback_(row[colEmail - 1], displayRow[colEmail - 1]);
+      const emailKey = billingNormalizeEmailKey_(emailCandidate);
       if (emailKey) keys.push(emailKey);
     }
     if (colStaffId) {
-      const staffKey = billingNormalizeEmailKey_(row[colStaffId - 1]);
+      const staffIdCandidate = extractEmailFallback_(row[colStaffId - 1], displayRow[colStaffId - 1]);
+      const staffKey = billingNormalizeEmailKey_(staffIdCandidate);
       if (staffKey) keys.push(staffKey);
     }
 


### PR DESCRIPTION
## Summary
- normalize staff directory email/staff ID keys using display values with fallback extraction
- ensure staff directory keys align with staff history logs for display

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e6cd6641883258666f77ed7a0de06)