### PR TITLE
Unify staff key normalization

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -136,6 +136,12 @@ const billingNormalizeEmailKey_ = typeof normalizeEmailKey_ === 'function'
     return normalized.replace(/[-_]/g, '');
   };
 
+const billingNormalizeStaffKey_ = typeof normalizeStaffKey_ === 'function'
+  ? normalizeStaffKey_
+  : function normalizeStaffKeyFallback_(value) {
+    return billingNormalizeEmailKey_(value);
+  };
+
 const BILLING_PATIENT_COLS_FIXED = typeof PATIENT_COLS_FIXED !== 'undefined' ? PATIENT_COLS_FIXED : {
   recNo: 3,
   name: 4,
@@ -358,7 +364,7 @@ function buildStaffDisplayByPatient_(staffByPatient, staffDirectory) {
     const seen = new Set();
     const names = [];
     emails.forEach(email => {
-      const key = billingNormalizeEmailKey_(email);
+      const key = billingNormalizeStaffKey_(email);
       if (!key || seen.has(key)) return;
       seen.add(key);
       const resolved = directory[key] || '';
@@ -452,7 +458,7 @@ function extractNormalizedStaffKey_(raw, displayValue) {
   const candidate = extractEmailFallback_(raw, displayValue);
   return {
     raw: candidate,
-    normalized: billingNormalizeEmailKey_(candidate)
+    normalized: billingNormalizeStaffKey_(candidate)
   };
 }
 
@@ -658,7 +664,7 @@ function buildVisitCountMap_(billingMonth) {
     counts[pid] = current;
 
     if (log && log.createdByEmail) {
-      const normalizedEmail = log.createdByKey || billingNormalizeEmailKey_(log.createdByEmail);
+      const normalizedEmail = log.createdByKey || billingNormalizeStaffKey_(log.createdByEmail);
       if (!normalizedEmail) return;
       if (!staffHistoryByPatient[pid]) {
         staffHistoryByPatient[pid] = {};

--- a/tests/billingGet.test.js
+++ b/tests/billingGet.test.js
@@ -272,6 +272,76 @@ function testStaffDirectorySkipsDisabledRows() {
   assert.strictEqual(directory['staff002'], '有効ユーザー', '他の有効行は辞書に含める');
 }
 
+function testStaffKeyNormalizationIsSharedAcrossSources() {
+  const staffHeaders = ['氏名', 'スタッフID'];
+  const staffValues = [
+    ['山田太郎', ' STAFF-001 ']
+  ];
+
+  const staffSheet = {
+    getLastRow: () => staffValues.length + 1,
+    getLastColumn: () => staffHeaders.length,
+    getMaxColumns: () => staffHeaders.length,
+    getRange: (row, col, numRows, numCols) => {
+      if (row === 1 && numRows === 1) {
+        return { getDisplayValues: () => [staffHeaders.slice(col - 1, col - 1 + numCols)] };
+      }
+      const startIdx = Math.max(0, row - 2);
+      return {
+        getValues: () => staffValues
+          .slice(startIdx, startIdx + numRows)
+          .map(r => r.slice(col - 1, col - 1 + numCols)),
+        getDisplayValues: () => staffValues
+          .slice(startIdx, startIdx + numRows)
+          .map(r => r.slice(col - 1, col - 1 + numCols))
+      };
+    }
+  };
+
+  const logHeaders = ['日付', '患者ID', '作成者', '担当者ID'];
+  const logRows = [
+    [new Date('2024-12-01T00:00:00Z'), '001', 'staff_001', ''],
+    [new Date('2024-12-02T00:00:00Z'), '002', '', ' staff-001 ']
+  ];
+  const logValues = [logHeaders, ...logRows];
+  const logDisplayValues = [
+    logHeaders,
+    ['2024/12/01 00:00', '001', 'staff_001', ''],
+    ['2024/12/02 00:00', '002', '', ' staff-001 ']
+  ];
+
+  const logSheet = {
+    getLastRow: () => logValues.length,
+    getLastColumn: () => logHeaders.length,
+    getMaxColumns: () => logHeaders.length,
+    getRange: (row, col, numRows, numCols) => {
+      const sliceValues = rows => rows.map(r => r.slice(col - 1, col - 1 + numCols));
+      if (row === 1 && numRows === 1) {
+        return { getDisplayValues: () => [logDisplayValues[0]] };
+      }
+      return {
+        getValues: () => sliceValues(logValues.slice(row - 1, row - 1 + numRows)),
+        getDisplayValues: () => sliceValues(logDisplayValues.slice(row - 1, row - 1 + numRows))
+      };
+    }
+  };
+
+  workbook = {
+    getSheetByName: name => {
+      if (name === 'スタッフ一覧') return staffSheet;
+      if (name === '施術録') return logSheet;
+      return null;
+    }
+  };
+
+  const directory = loadBillingStaffDirectory_();
+  const logs = loadTreatmentLogs_();
+
+  assert.strictEqual(logs[0].createdByKey, 'staff001', '作成者欄でもスタッフIDと同じ正規化を使う');
+  assert.strictEqual(logs[1].createdByKey, 'staff001', '担当者ID欄でも同じ正規化を使う');
+  assert.strictEqual(directory[logs[0].createdByKey], '山田太郎', 'スタッフ一覧と同じ正規化結果で名前を取得できる');
+}
+
 function run() {
   testFullWidthDigitsAreParsed();
   testAsciiInputsRemainCompatible();
@@ -283,6 +353,7 @@ function run() {
   testStaffDirectoryUsesStaffIdWhenEmailMissing();
   testStaffDirectoryNormalizesNonEmailIds();
   testStaffDirectorySkipsDisabledRows();
+  testStaffKeyNormalizationIsSharedAcrossSources();
   console.log('billingGet burden rate tests passed');
 }
 


### PR DESCRIPTION
## Summary
- add a shared staff key normalizer and reuse it for staff directory and treatment log extraction
- normalize staff-by-patient display and visit history with the same staff key logic
- add coverage to confirm createdBy and staffId values resolve via the unified normalization

## Testing
- node tests/billingGet.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e731171fc8325bce4bc8b705b63d1)