### PR TITLE
Fix insurance persistence and bank transfer export

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -452,6 +452,7 @@ function normalizeDisabledFlag_(value) {
 
 function normalizeBurdenRateInt_(value) {
   if (value == null || value === '') return 0;
+  if (String(value).trim() === '自費') return '自費';
   if (typeof value === 'number') {
     if (!isFinite(value)) return 0;
     if (value === 0) return 0;
@@ -827,13 +828,17 @@ function getBillingPatientRecords() {
   return values.map(row => {
     const pid = billingNormalizePatientId_(row[colPid - 1]);
     if (!pid) return null;
+    const insuranceType = colInsurance ? String(row[colInsurance - 1] || '').trim() : '';
+    const normalizedBurden = insuranceType === '自費'
+      ? '自費'
+      : (colBurden ? normalizeBurdenRateInt_(row[colBurden - 1]) : 0);
     return {
       patientId: pid,
       raw: buildPatientRawObject_(headers, row),
       nameKanji: colName ? String(row[colName - 1] || '').trim() : '',
       nameKana: colKana ? String(row[colKana - 1] || '').trim() : '',
-      insuranceType: colInsurance ? String(row[colInsurance - 1] || '').trim() : '',
-      burdenRate: colBurden ? normalizeBurdenRateInt_(row[colBurden - 1]) : 0,
+      insuranceType,
+      burdenRate: normalizedBurden,
       unitPrice: colUnitPrice ? normalizeMoneyValue_(row[colUnitPrice - 1]) : 0,
       address: colAddress ? String(row[colAddress - 1] || '').trim() : '',
       payerType: colPayer ? String(row[colPayer - 1] || '').trim() : '',

--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -106,6 +106,7 @@ function normalizeMoneyNumber_(value) {
 
 function normalizeBurdenRateInt_(burdenRate) {
   if (burdenRate == null || burdenRate === '') return 0;
+  if (String(burdenRate).trim() === '自費') return '自費';
   const num = Number(burdenRate);
   if (Number.isFinite(num)) {
     if (num > 0 && num < 1) return Math.round(num * 10);


### PR DESCRIPTION
## Summary
- ensure patient insurance type, burden ratio, and medical assistance flags are read with self-pay preservation so billing JSON mirrors patient sheet edits
- allow burden normalization to keep self-pay markers for UI/display consistency while leaving zero-charge logic intact
- normalize prepared payload before bank export and upsert transfer rows by billing month/patient ID instead of replacing whole months

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ed7984f7c8325acf5a6de54d33cae)