### PR TITLE
Ensure billing UI shows saved insurance settings

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -815,7 +815,12 @@ function getBillingPatientRecords() {
   const colKana = resolveBillingColumn_(headers, BILLING_LABELS.furigana, 'フリガナ', { fallbackIndex: BILLING_PATIENT_COLS_FIXED.furigana });
   const colInsurance = resolveBillingColumn_(headers, ['保険区分', '保険種別', '保険タイプ', '保険'], '保険区分', {});
   const colBurden = resolveBillingColumn_(headers, BILLING_LABELS.share, '負担割合', { fallbackIndex: BILLING_PATIENT_COLS_FIXED.share });
-  const colUnitPrice = resolveBillingColumn_(headers, ['単価', '請求単価', '自費単価', '単価(自費)', '単価（自費）'], '単価', {});
+  const colUnitPrice = resolveBillingColumn_(
+    headers,
+    ['単価', '請求単価', '自費単価', '単価(自費)', '単価（自費）', '単価（手動上書き）', '単価(手動上書き)'],
+    '単価',
+    {}
+  );
   const colAddress = resolveBillingColumn_(headers, ['住所', '住所1', '住所２', '住所2', 'address', 'Address'], '住所', {});
   const colPayer = resolveBillingColumn_(headers, ['保険者', '支払区分', '保険/自費', '保険区分種別'], '保険者', {});
   const colBank = resolveBillingColumn_(headers, ['銀行コード', '銀行CD', '銀行番号', 'bankCode'], '銀行コード', { fallbackLetter: 'N' });
@@ -832,6 +837,11 @@ function getBillingPatientRecords() {
     const normalizedBurden = insuranceType === '自費'
       ? '自費'
       : (colBurden ? normalizeBurdenRateInt_(row[colBurden - 1]) : 0);
+    const unitPriceRaw = colUnitPrice ? row[colUnitPrice - 1] : '';
+    const manualUnitPrice = unitPriceRaw === '' || unitPriceRaw === null
+      ? ''
+      : normalizeMoneyValue_(unitPriceRaw);
+
     return {
       patientId: pid,
       raw: buildPatientRawObject_(headers, row),
@@ -839,7 +849,8 @@ function getBillingPatientRecords() {
       nameKana: colKana ? String(row[colKana - 1] || '').trim() : '',
       insuranceType,
       burdenRate: normalizedBurden,
-      unitPrice: colUnitPrice ? normalizeMoneyValue_(row[colUnitPrice - 1]) : 0,
+      unitPrice: colUnitPrice ? normalizeMoneyValue_(unitPriceRaw) : 0,
+      manualUnitPrice,
       address: colAddress ? String(row[colAddress - 1] || '').trim() : '',
       payerType: colPayer ? String(row[colPayer - 1] || '').trim() : '',
       medicalAssistance: colMedical ? normalizeZeroOneFlag_(row[colMedical - 1]) : 0,

--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -41,13 +41,14 @@ function normalizeBurdenMultiplier_(burdenRate, insuranceType) {
 }
 
 function normalizeMedicalAssistanceFlag_(value) {
-  if (value === true) return true;
-  if (value === false) return false;
+  if (value === null || value === undefined) return 0;
   const num = Number(value);
-  if (Number.isFinite(num)) return !!num;
+  if (Number.isFinite(num)) return num ? 1 : 0;
+  if (value === true) return 1;
+  if (value === false) return 0;
   const text = String(value || '').trim().toLowerCase();
-  if (!text) return false;
-  return ['1', 'true', 'yes', 'y', 'on', '有', 'あり', '〇', '○', '◯'].indexOf(text) >= 0;
+  if (!text) return 0;
+  return ['1', 'true', 'yes', 'y', 'on', '有', 'あり', '〇', '○', '◯'].indexOf(text) >= 0 ? 1 : 0;
 }
 
 function normalizeBillingSource_(source) {

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -179,13 +179,14 @@ function normalizeBurdenRateDisplay(value) {
 }
 
 function normalizeMedicalAssistanceFlag(value) {
-  if (value === true) return true;
-  if (value === false) return false;
+  if (value === null || value === undefined) return 0;
   const num = Number(value);
-  if (Number.isFinite(num)) return !!num;
+  if (Number.isFinite(num)) return num ? 1 : 0;
+  if (value === true) return 1;
+  if (value === false) return 0;
   const text = String(value || '').trim().toLowerCase();
-  if (!text) return false;
-  return ['1', 'true', 'yes', 'y', 'on', '有', 'あり', '〇', '○', '◯'].includes(text);
+  if (!text) return 0;
+  return ['1', 'true', 'yes', 'y', 'on', '有', 'あり', '〇', '○', '◯'].includes(text) ? 1 : 0;
 }
 
 function isDeprecatedInsuranceType(value) {
@@ -390,6 +391,49 @@ function normalizeBillingResultPayload(raw) {
     );
   }
 
+  function normalizeMedicalAssistanceNumber(value) {
+    return normalizeMedicalAssistanceFlag(value);
+  }
+
+  function normalizeManualUnitPriceValue(value) {
+    if (value === null || value === undefined || value === '') return '';
+    return normalizeMoneyNumber(value);
+  }
+
+  function mergePatientMetaIntoRows(rows, patients) {
+    if (!Array.isArray(rows)) return [];
+    return rows.map(row => {
+      const merged = Object.assign({}, row);
+      const pid = merged && merged.patientId ? String(merged.patientId).trim() : '';
+      const patient = pid && patients ? patients[pid] || {} : {};
+
+      if (!merged.insuranceType && patient.insuranceType) {
+        merged.insuranceType = patient.insuranceType;
+      }
+
+      const patientBurden = patient.burdenRate;
+      if ((merged.burdenRate == null || merged.burdenRate === '') && patientBurden !== undefined) {
+        merged.burdenRate = patientBurden === '自費' ? '自費' : normalizeBurdenRateInt(patientBurden);
+      } else if (merged.burdenRate !== undefined) {
+        merged.burdenRate = merged.burdenRate === '自費' ? '自費' : normalizeBurdenRateInt(merged.burdenRate);
+      }
+
+      const assistanceSource = merged.medicalAssistance !== undefined ? merged.medicalAssistance : patient.medicalAssistance;
+      merged.medicalAssistance = normalizeMedicalAssistanceNumber(assistanceSource);
+
+      const manualPriceSource = merged.manualUnitPrice !== undefined ? merged.manualUnitPrice : patient.manualUnitPrice;
+      merged.manualUnitPrice = normalizeManualUnitPriceValue(manualPriceSource);
+
+      return merged;
+    });
+  }
+
+  function finalizeBillingPayload(payload) {
+    const withDefaults = applyBillingFieldDefaults(payload);
+    const enrichedRows = mergePatientMetaIntoRows(withDefaults.billingJson || [], withDefaults.patients || {});
+    return Object.assign({}, withDefaults, { billingJson: enrichedRows });
+  }
+
   function parseMaybeJson(value) {
     if (typeof value !== 'string') return value;
     try {
@@ -497,19 +541,19 @@ function normalizeBillingResultPayload(raw) {
   if (result == null) return null;
 
   if (Array.isArray(result)) {
-    return applyBillingFieldDefaults({ billingJson: result, billingMonth: '', preparedAt: null });
+    return finalizeBillingPayload({ billingJson: result, billingMonth: '', preparedAt: null });
   }
 
   const found = findBillingPayload(result, result);
   if (found && found.billingJson) {
-    return applyBillingFieldDefaults(found);
+    return finalizeBillingPayload(found);
   }
 
   const billingJson = coerceBillingJson(result.billingJson) || [];
   if (!billingJson.length) {
     console.warn('[billing] billingJson not found in payload; returning empty array');
   }
-  return applyBillingFieldDefaults(Object.assign({}, result, { billingJson }));
+  return finalizeBillingPayload(Object.assign({}, result, { billingJson }));
 }
 
 function handleBillingAggregation() {


### PR DESCRIPTION
## Summary
- include manual unit price and numeric medical assistance data when loading billing patient records
- normalize billing payload rows with saved insurance, burden rate, assistance, and manual unit price for UI initialization

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ee117a8f48325a7ac8fa076c74523)