### PR TITLE
Prevent double burden multiplier in invoice calculations

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -285,10 +285,15 @@ function calculateInvoiceChargeBreakdown_(params) {
 
   const hasChargeableUnitPrice = Number.isFinite(treatmentUnitPrice) && treatmentUnitPrice !== 0;
   const treatmentAmountFull = visits > 0 && hasChargeableUnitPrice ? treatmentUnitPrice * visits : 0;
-  const burdenMultiplier = typeof normalizeBurdenMultiplier_ === 'function'
-    ? normalizeBurdenMultiplier_(burdenRateInt, insuranceType)
-    : (insuranceType === '自費' ? 1 : (burdenRateInt > 0 ? burdenRateInt / 10 : 0));
   const isSelfPaid = insuranceType === '自費' || burdenRateInt === '自費';
+  const defaultBurdenUnitPrice = INVOICE_TREATMENT_UNIT_PRICE_BY_BURDEN[burdenRateInt];
+  const usesBurdenAdjustedUnitPrice = Number.isFinite(defaultBurdenUnitPrice)
+    && treatmentUnitPrice === defaultBurdenUnitPrice;
+  const burdenMultiplier = isSelfPaid || usesBurdenAdjustedUnitPrice
+    ? 1
+    : (typeof normalizeBurdenMultiplier_ === 'function'
+      ? normalizeBurdenMultiplier_(burdenRateInt, insuranceType)
+      : (insuranceType === '自費' ? 1 : (burdenRateInt > 0 ? burdenRateInt / 10 : 0)));
   const treatmentAmount = isSelfPaid
     ? treatmentAmountFull
     : roundToNearestTen_(treatmentAmountFull * burdenMultiplier);


### PR DESCRIPTION
## Summary
- avoid applying burden multipliers when invoice unit prices are already adjusted for burden-specific rates
- ensure treatment amounts and totals use the correct rounded values for default insurance invoices

## Testing
- node tests/billingOutput.test.js
- node tests/billingInvoiceLayout.test.js
- node tests/billingUiNormalization.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eedabef048321b4ef14b698c5a198)