### PR TITLE
Route billing preview totals through server calculation

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -35,6 +35,41 @@ function getBillingSource(billingMonth) {
   return getBillingSourceData(billingMonth);
 }
 
+/**
+ * Expose billing row total calculation for the web UI.
+ *
+ * This delegates to the shared billingLogic implementation so that
+ * browser previews stay in sync with the final server-side totals
+ * used for PDFs and exports.
+ * @param {Object} row - Merged billing row (base + edits) from the UI.
+ * @return {Object} normalized totals for preview rendering.
+ */
+function calculateBillingRowTotalsServer(row) {
+  const source = row && typeof row === 'object' ? row : {};
+  const amountCalc = calculateBillingAmounts_({
+    visitCount: source.visitCount,
+    insuranceType: source.insuranceType,
+    burdenRate: source.burdenRate,
+    manualUnitPrice: source.manualUnitPrice != null ? source.manualUnitPrice : source.unitPrice,
+    manualTransportAmount: Object.prototype.hasOwnProperty.call(source, 'manualTransportAmount')
+      ? source.manualTransportAmount
+      : source.transportAmount,
+    unitPrice: source.unitPrice,
+    medicalAssistance: source.medicalAssistance,
+    carryOverAmount: source.carryOverAmount
+  });
+
+  return {
+    visitCount: amountCalc.visits,
+    treatmentUnitPrice: amountCalc.unitPrice,
+    treatmentAmount: amountCalc.treatmentAmount,
+    transportAmount: amountCalc.transportAmount,
+    carryOverAmount: amountCalc.carryOverAmount,
+    billingAmount: amountCalc.billingAmount,
+    grandTotal: amountCalc.grandTotal
+  };
+}
+
 const BILLING_CACHE_PREFIX = 'billing_prepared_';
 const BILLING_CACHE_TTL_SECONDS = 3600; // 1 hour
 

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -356,7 +356,7 @@ function toggleBillingSort(field) {
   renderBillingResult();
 }
 
-function calculateBillingRowTotals(row) {
+function calculateBillingRowTotalsLocal(row) {
   const source = row && typeof row === 'object' ? row : {};
   const insuranceType = source.insuranceType ? String(source.insuranceType).trim() : '';
   const burdenRate = normalizeBurdenRateInt(source.burdenRate);
@@ -419,6 +419,22 @@ function calculateBillingRowTotals(row) {
   const grandTotal = carryOverAmount + treatmentAmount + transportAmount;
 
   return { visitCount, treatmentUnitPrice, treatmentAmount, transportAmount, grandTotal };
+}
+
+function normalizeServerBillingTotals(result, fallback) {
+  const payload = result && typeof result === 'object' ? result : {};
+  const base = fallback && typeof fallback === 'object' ? fallback : {};
+  return {
+    visitCount: Number(payload.visitCount != null ? payload.visitCount : payload.visits) || base.visitCount || 0,
+    treatmentUnitPrice: Number(payload.treatmentUnitPrice != null ? payload.treatmentUnitPrice : payload.unitPrice)
+      || base.treatmentUnitPrice
+      || 0,
+    treatmentAmount: Number(payload.treatmentAmount) || base.treatmentAmount || 0,
+    transportAmount: Number(payload.transportAmount) || base.transportAmount || 0,
+    carryOverAmount: Number(payload.carryOverAmount) || base.carryOverAmount || 0,
+    billingAmount: Number(payload.billingAmount) || base.billingAmount || 0,
+    grandTotal: Number(payload.grandTotal) || base.grandTotal || 0
+  };
 }
 
 function resetBillingEdits() {
@@ -499,8 +515,21 @@ function recalculateBillingRow(patientId) {
   const baseRow = baseRows.find(row => String(row && row.patientId ? row.patientId : '') === pid) || {};
   const edits = billingState.edits[pid] || {};
   const merged = Object.assign({}, baseRow, edits);
-  const calculated = calculateBillingRowTotals(merged);
-  billingState.previewTotals[pid] = calculated;
+  const fallbackTotals = calculateBillingRowTotalsLocal(merged);
+  billingState.previewTotals[pid] = fallbackTotals;
+
+  const scriptRun = typeof google !== 'undefined' && google.script && google.script.run;
+  if (scriptRun && typeof google.script.run.calculateBillingRowTotalsServer === 'function') {
+    google.script.run
+      .withSuccessHandler(function(result) {
+        billingState.previewTotals[pid] = normalizeServerBillingTotals(result, fallbackTotals);
+        renderBillingResult();
+      })
+      .withFailureHandler(function(err) {
+        console.error('Failed to calculate billing totals on server', err);
+      })
+      .calculateBillingRowTotalsServer(merged);
+  }
 }
 
 function commitBillingEdit(patientId, field, value) {


### PR DESCRIPTION
## Summary
- expose a new Apps Script service function that reuses billingLogic totals for UI previews
- update the billing UI to call the server calculation for preview totals while keeping a local fallback

## Testing
- node tests/billingGet.test.js
- node tests/billingInvoiceLayout.test.js
- node tests/billingLogic.test.js
- node tests/billingOutput.test.js
- node tests/billingUiNormalization.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69311b0359688321ab2af8b7550b7c9d)