### PR TITLE
Add override badges to billing rows

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -63,6 +63,9 @@
   .field-note{ font-size:0.85rem; margin-top:6px; color:var(--muted); }
   .field-note.warn{ color:#991b1b; }
   .insurance-editor select{ width:100%; }
+  .cell-badge{ display:inline-flex; align-items:center; gap:6px; }
+  .cell-badge.right{ justify-content:flex-end; width:100%; }
+  .override-badge{ background:#fef3c7; color:#92400e; padding:2px 6px; border-radius:8px; font-size:0.75rem; font-weight:700; white-space:nowrap; }
   .action-footer{ margin-top:12px; padding:12px 14px; border:1px dashed var(--border); border-radius:12px; display:flex; flex-wrap:wrap; gap:10px; align-items:center; justify-content:space-between; background:#f8fafc; }
   .action-buttons{ display:flex; gap:8px; flex-wrap:wrap; }
   @media (max-width: 900px){

--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -1077,12 +1077,23 @@ function getBillingSourceData(billingMonth) {
   const visitCountsResult = buildVisitCountMap_(month);
   const treatmentVisitCounts = visitCountsResult.counts;
   const billingOverrides = loadBillingOverridesMap_(month);
+  const billingOverrideFlags = {};
   const mergedPatients = Object.assign({}, patientMap);
   Object.keys(billingOverrides).forEach(pid => {
     const override = billingOverrides[pid];
     if (!override) return;
     const target = Object.assign({}, mergedPatients[pid] || {}, override);
     mergedPatients[pid] = target;
+    const flags = billingOverrideFlags[pid] || {};
+    if (override.manualUnitPrice !== undefined) flags.unitPrice = true;
+    if (override.manualTransportAmount !== undefined) flags.transportAmount = true;
+    if (override.carryOverAmount !== undefined) flags.carryOverAmount = true;
+    if (override.adjustedVisitCount !== undefined) flags.visitCount = true;
+    if (override.insuranceType !== undefined) flags.insuranceType = true;
+    if (override.burdenRate !== undefined) flags.burdenRate = true;
+    if (Object.keys(flags).length) {
+      billingOverrideFlags[pid] = flags;
+    }
     if (override.adjustedVisitCount !== undefined) {
       treatmentVisitCounts[pid] = override.adjustedVisitCount;
     }
@@ -1127,7 +1138,8 @@ function getBillingSourceData(billingMonth) {
     staffDirectory,
     staffDisplayByPatient,
     unpaidHistory,
-    carryOverByPatient
+    carryOverByPatient,
+    billingOverrideFlags
   };
 }
 

--- a/src/main.gs
+++ b/src/main.gs
@@ -299,7 +299,8 @@ function buildPreparedBillingPayload_(billingMonth) {
     bankInfoByName: source.bankInfoByName || {},
     staffByPatient: source.staffByPatient || {},
     staffDirectory: source.staffDirectory || {},
-    staffDisplayByPatient: source.staffDisplayByPatient || {}
+    staffDisplayByPatient: source.staffDisplayByPatient || {},
+    billingOverrideFlags: source.billingOverrideFlags || {}
   };
 }
 
@@ -338,7 +339,8 @@ function toClientBillingPayload_(prepared) {
     bankInfoByName: normalized.bankInfoByName || {},
     staffByPatient: normalized.staffByPatient || {},
     staffDirectory: normalized.staffDirectory || {},
-    staffDisplayByPatient: normalized.staffDisplayByPatient || {}
+    staffDisplayByPatient: normalized.staffDisplayByPatient || {},
+    billingOverrideFlags: normalized.billingOverrideFlags || {}
   };
 }
 

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -31,6 +31,7 @@ const BILLING_TRANSPORT_UNIT_PRICE = (typeof globalThis !== 'undefined' && typeo
   : BILLING_TRANSPORT_UNIT_PRICE_FALLBACK;
 const BILLING_PATIENT_INFO_FIELDS = ['insuranceType', 'medicalAssistance', 'burdenRate', 'payerType', 'responsible', 'bankInfo', 'isNew'];
 const BILLING_BILLING_OVERRIDES_FIELDS = ['unitPrice', 'transportAmount', 'carryOverAmount', 'visitCount'];
+const BILLING_OVERRIDE_BADGE_FIELDS = ['unitPrice', 'transportAmount', 'carryOverAmount', 'visitCount', 'insuranceType', 'burdenRate'];
 
 function qs(id) {
   return document.getElementById(id);
@@ -223,6 +224,31 @@ function isDeprecatedInsuranceType(value) {
 
 function getBillingBaseUrl() {
   return (window.APP_CONFIG && window.APP_CONFIG.baseUrl) || '';
+}
+
+function getBillingOverrideFlags() {
+  const source = billingState.prepared || billingState.result || {};
+  return (source && source.billingOverrideFlags) || {};
+}
+
+function shouldShowBillingOverrideBadge(field) {
+  return BILLING_OVERRIDE_BADGE_FIELDS.indexOf(field) >= 0;
+}
+
+function hasBillingOverride(patientId, field) {
+  if (!patientId || !shouldShowBillingOverrideBadge(field)) return false;
+  const flags = getBillingOverrideFlags();
+  const entry = flags && flags[patientId];
+  return !!(entry && entry[field]);
+}
+
+function wrapWithOverrideBadge(content, patientId, field, alignRight) {
+  if (!shouldShowBillingOverrideBadge(field) || !hasBillingOverride(patientId, field)) {
+    return content;
+  }
+  const badge = '<span class="override-badge" title="月次編集されています">※上書き</span>';
+  const klass = alignRight ? 'cell-badge right' : 'cell-badge';
+  return `<div class="${klass}">${content}${badge}</div>`;
 }
 
 function getMergedBillingRows() {
@@ -611,7 +637,8 @@ function normalizeBillingResultPayload(raw) {
         patients: {},
         bankInfoByName: {},
         bankStatuses: {},
-        carryOverByPatient: {}
+        carryOverByPatient: {},
+        billingOverrideFlags: {}
       },
       payload,
       {
@@ -621,7 +648,8 @@ function normalizeBillingResultPayload(raw) {
         patients: payload.patients || payload.patientMap || {},
         bankInfoByName: payload.bankInfoByName || {},
         bankStatuses: payload.bankStatuses || {},
-        carryOverByPatient: payload.carryOverByPatient || {}
+        carryOverByPatient: payload.carryOverByPatient || {},
+        billingOverrideFlags: payload.billingOverrideFlags || {}
       }
     );
   }
@@ -1132,30 +1160,36 @@ function renderBillingResult() {
         const options = BILLING_INSURANCE_OPTIONS.map(opt => `<option value="${opt}" ${opt === item.insuranceType ? 'selected' : ''}>${opt}</option>`).join('');
         const select = `<select class="${editClass}" ${baseAttrs}>${needsUpdate ? '<option value="" disabled selected>保険種別を選択</option>' : ''}${options}</select>`;
         if (needsUpdate) {
-          return `<div class="insurance-editor">${select}<div class="field-note warn">以前の「マッサージ」種別が設定されています。現在の保険種別を選び直してください。</div></div>`;
+          const editor = `<div class="insurance-editor">${select}<div class="field-note warn">以前の「マッサージ」種別が設定されています。現在の保険種別を選び直してください。</div></div>`;
+          return wrapWithOverrideBadge(editor, item.patientId, field, alignRight);
         }
-        return select;
+        return wrapWithOverrideBadge(select, item.patientId, field, alignRight);
       }
       if (field === 'burdenRate') {
-        return `<select class="${editClass}" ${baseAttrs}>${BILLING_BURDEN_OPTIONS.map(opt => `<option value="${opt.value}" ${String(opt.value) === String(item.burdenRate) ? 'selected' : ''}>${opt.label}</option>`).join('')}</select>`;
+        const editor = `<select class="${editClass}" ${baseAttrs}>${BILLING_BURDEN_OPTIONS.map(opt => `<option value="${opt.value}" ${String(opt.value) === String(item.burdenRate) ? 'selected' : ''}>${opt.label}</option>`).join('')}</select>`;
+        return wrapWithOverrideBadge(editor, item.patientId, field, alignRight);
       }
       if (field === 'payerType') {
-        return `<select class="${editClass}" ${baseAttrs}>${BILLING_PAYER_OPTIONS.map(opt => `<option value="${opt}" ${opt === item.payerType ? 'selected' : ''}>${opt}</option>`).join('')}</select>`;
+        const editor = `<select class="${editClass}" ${baseAttrs}>${BILLING_PAYER_OPTIONS.map(opt => `<option value="${opt}" ${opt === item.payerType ? 'selected' : ''}>${opt}</option>`).join('')}</select>`;
+        return wrapWithOverrideBadge(editor, item.patientId, field, alignRight);
       }
       if (field === 'medicalAssistance') {
         const checked = normalizeMedicalAssistanceFlag(item.medicalAssistance) ? 'checked' : '';
-        return `<label class="${editClass}" style="display:flex;align-items:center;gap:6px;"><input type="checkbox" ${baseAttrs} ${checked} />医療助成</label>`;
+        const editor = `<label class="${editClass}" style="display:flex;align-items:center;gap:6px;"><input type="checkbox" ${baseAttrs} ${checked} />医療助成</label>`;
+        return wrapWithOverrideBadge(editor, item.patientId, field, alignRight);
       }
       if (field === 'unitPrice' || field === 'carryOverAmount') {
         const val = normalizeEditNumber(item[field]);
-        return `<input class="${editClass}" ${baseAttrs} type="number" step="10" value="${val}" />`;
+        const editor = `<input class="${editClass}" ${baseAttrs} type="number" step="10" value="${val}" />`;
+        return wrapWithOverrideBadge(editor, item.patientId, field, alignRight);
       }
       if (field === 'transportAmount') {
         const val = item.manualTransportAmount === '' || item.manualTransportAmount === null || item.manualTransportAmount === undefined
           ? ''
           : normalizeEditNumber(item.manualTransportAmount);
         const placeholder = Number.isFinite(item.transportAmount) ? formatCurrency(item.transportAmount) : '';
-        return `<input class="${editClass}" ${baseAttrs} type="number" step="10" value="${val}" placeholder="${placeholder}" />`;
+        const editor = `<input class="${editClass}" ${baseAttrs} type="number" step="10" value="${val}" placeholder="${placeholder}" />`;
+        return wrapWithOverrideBadge(editor, item.patientId, field, alignRight);
       }
     }
 
@@ -1180,7 +1214,8 @@ function renderBillingResult() {
           return item[field] || '';
       }
     })();
-    return `<button type="button" class="${viewClass}" ${baseAttrs} aria-label="${field} を編集">${display}</button>`;
+    const view = `<button type="button" class="${viewClass}" ${baseAttrs} aria-label="${field} を編集">${display}</button>`;
+    return wrapWithOverrideBadge(view, item.patientId, field, alignRight);
   }
 
   const legacyRows = rows.filter(row => isDeprecatedInsuranceType(row.insuranceType));
@@ -1204,7 +1239,7 @@ function renderBillingResult() {
         <td>${renderEditableCell(safeItem, 'medicalAssistance')}</td>
         <td>${renderEditableCell(safeItem, 'payerType')}</td>
         <td>${renderEditableCell(safeItem, 'burdenRate')}</td>
-        <td>${safeItem.visitCount || 0}</td>
+        <td>${wrapWithOverrideBadge(safeItem.visitCount || 0, safeItem.patientId, 'visitCount')}</td>
         <td class="right">${renderEditableCell(safeItem, 'unitPrice', true)}</td>
         <td class="right">${formatCurrency(safeItem.treatmentAmount)}</td>
         <td class="right">${renderEditableCell(safeItem, 'transportAmount', true)}</td>


### PR DESCRIPTION
## Summary
- surface billing override flags from the server and include them in prepared payloads
- add UI badges to highlight overridden billing and patient info fields in the billing table
- style the override badge for visibility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69311cbfd078832183b7ddff6f42385b)