### PR TITLE
Make billing overrides column resolution resilient

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -669,23 +669,12 @@ function ensureBillingOverridesSheet_() {
 }
 
 function resolveBillingOverridesColumns_(headers) {
-  const colYm = resolveBillingColumn_(headers, ['ym', 'billingMonth', 'month'], 'ym', { required: true, fallbackIndex: 1 });
-  const colPid = resolveBillingColumn_(headers, BILLING_LABELS.recNo.concat(['患者ID', 'patientId']), 'patientId', {
-    required: true,
-    fallbackIndex: 2
-  });
-  const colManualUnitPrice = resolveBillingColumn_(headers, ['manualUnitPrice', 'unitPrice', '単価'], 'manualUnitPrice', {
-    fallbackIndex: 3
-  });
-  const colManualTransport = resolveBillingColumn_(headers, ['manualTransportAmount', 'transportAmount', '交通費'], 'manualTransportAmount', {
-    fallbackIndex: 4
-  });
-  const colCarryOver = resolveBillingColumn_(headers, ['carryOverAmount', 'carryOver', '未入金額', '繰越'], 'carryOverAmount', {
-    fallbackIndex: 5
-  });
-  const colAdjustedVisits = resolveBillingColumn_(headers, ['adjustedVisitCount', 'visitCount', '回数'], 'adjustedVisitCount', {
-    fallbackIndex: 6
-  });
+  const colYm = resolveBillingColumn_(headers, ['ym', 'billingMonth', 'month'], 'ym', { required: true });
+  const colPid = resolveBillingColumn_(headers, BILLING_LABELS.recNo.concat(['患者ID', 'patientId']), 'patientId', { required: true });
+  const colManualUnitPrice = resolveBillingColumn_(headers, ['manualUnitPrice', 'unitPrice', '単価'], 'manualUnitPrice', {});
+  const colManualTransport = resolveBillingColumn_(headers, ['manualTransportAmount', 'transportAmount', '交通費'], 'manualTransportAmount', {});
+  const colCarryOver = resolveBillingColumn_(headers, ['carryOverAmount', 'carryOver', '未入金額', '繰越'], 'carryOverAmount', {});
+  const colAdjustedVisits = resolveBillingColumn_(headers, ['adjustedVisitCount', 'visitCount', '回数'], 'adjustedVisitCount', {});
   return { colYm, colPid, colManualUnitPrice, colManualTransport, colCarryOver, colAdjustedVisits };
 }
 


### PR DESCRIPTION
## Summary
- cache billing header normalization results to reuse column lookups
- resolve BillingOverrides columns purely by name to tolerate extra sheet columns

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69312fe79dfc8321956e9a366491b5e7)