### PR TITLE
Add carry-over ledger aggregation

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -300,7 +300,11 @@ function buildPreparedBillingPayload_(billingMonth) {
     staffByPatient: source.staffByPatient || {},
     staffDirectory: source.staffDirectory || {},
     staffDisplayByPatient: source.staffDisplayByPatient || {},
-    billingOverrideFlags: source.billingOverrideFlags || {}
+    billingOverrideFlags: source.billingOverrideFlags || {},
+    carryOverByPatient: source.carryOverByPatient || {},
+    carryOverLedger: source.carryOverLedger || [],
+    carryOverLedgerByPatient: source.carryOverLedgerByPatient || {},
+    unpaidHistory: source.unpaidHistory || []
   };
 }
 
@@ -340,7 +344,11 @@ function toClientBillingPayload_(prepared) {
     staffByPatient: normalized.staffByPatient || {},
     staffDirectory: normalized.staffDirectory || {},
     staffDisplayByPatient: normalized.staffDisplayByPatient || {},
-    billingOverrideFlags: normalized.billingOverrideFlags || {}
+    billingOverrideFlags: normalized.billingOverrideFlags || {},
+    carryOverByPatient: normalized.carryOverByPatient || {},
+    carryOverLedger: normalized.carryOverLedger || [],
+    carryOverLedgerByPatient: normalized.carryOverLedgerByPatient || {},
+    unpaidHistory: normalized.unpaidHistory || []
   };
 }
 


### PR DESCRIPTION
## Summary
- load carry-over ledger entries from the new CarryOverLedger sheet and normalize month filtering
- merge ledger totals with unpaid history for carry-over balances returned by getBillingSourceData
- include carry-over ledger details and totals in prepared billing payloads for UI/cache consumers

## Testing
- for f in tests/*.js; do echo "Running $f"; node $f; done

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69313310fb048321b3a79858b96e03da)