### PR TITLE
Remove insurance type from billing UI and overrides

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -62,7 +62,6 @@
   .alert.danger{ border-color:#fecdd3; background:#fef2f2; color:#991b1b; }
   .field-note{ font-size:0.85rem; margin-top:6px; color:var(--muted); }
   .field-note.warn{ color:#991b1b; }
-  .insurance-editor select{ width:100%; }
   .cell-badge{ display:inline-flex; align-items:center; gap:6px; }
   .cell-badge.right{ justify-content:flex-end; width:100%; }
   .override-badge{ background:#fef3c7; color:#92400e; padding:2px 6px; border-radius:8px; font-size:0.75rem; font-weight:700; white-space:nowrap; }

--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -889,7 +889,6 @@ function loadBillingOverridesMap_(billingMonth) {
   const colManualTransport = resolveBillingColumn_(headers, ['manualTransportAmount', 'transportAmount', '交通費'], 'manualTransportAmount', {});
   const colCarryOver = resolveBillingColumn_(headers, ['carryOverAmount', 'carryOver', '未入金額', '繰越'], 'carryOverAmount', {});
   const colAdjustedVisits = resolveBillingColumn_(headers, ['adjustedVisitCount', 'visitCount', '回数'], 'adjustedVisitCount', {});
-  const colInsuranceType = resolveBillingColumn_(headers, ['insuranceType', '保険種別', '保険区分', '保険タイプ'], 'insuranceType', {});
   const colBurdenRate = resolveBillingColumn_(headers, BILLING_LABELS.share.concat(['burdenRate']), 'burdenRate', {});
   const colManualSelfPay = resolveBillingColumn_(headers, ['manualSelfPayAmount', '自費', 'selfPayAmount'], 'manualSelfPayAmount', {});
 
@@ -923,11 +922,6 @@ function loadBillingOverridesMap_(billingMonth) {
     const adjustedVisitCount = colAdjustedVisits
       ? billingNormalizeVisitCount_(row[colAdjustedVisits - 1])
       : undefined;
-    const insuranceType = colInsuranceType
-      ? (row[colInsuranceType - 1] === '' || row[colInsuranceType - 1] === null
-        ? undefined
-        : String(row[colInsuranceType - 1]).trim())
-      : undefined;
     const burdenRate = colBurdenRate
       ? (row[colBurdenRate - 1] === '' || row[colBurdenRate - 1] === null
         ? undefined
@@ -944,7 +938,6 @@ function loadBillingOverridesMap_(billingMonth) {
       manualTransportAmount,
       carryOverAmount,
       adjustedVisitCount,
-      insuranceType,
       burdenRate,
       manualSelfPayAmount
     ].some(value => value !== undefined);
@@ -955,7 +948,6 @@ function loadBillingOverridesMap_(billingMonth) {
       manualTransportAmount,
       carryOverAmount,
       adjustedVisitCount,
-      insuranceType,
       burdenRate,
       manualSelfPayAmount,
       selfPayItems: buildSelfPayItemsFromLegacy_(manualSelfPayAmount)
@@ -1183,7 +1175,6 @@ function getBillingSourceData(billingMonth) {
     if (override.manualTransportAmount !== undefined) flags.transportAmount = true;
     if (override.carryOverAmount !== undefined) flags.carryOverAmount = true;
     if (override.adjustedVisitCount !== undefined) flags.visitCount = true;
-    if (override.insuranceType !== undefined) flags.insuranceType = true;
     if (override.burdenRate !== undefined) flags.burdenRate = true;
     if (override.manualSelfPayAmount !== undefined) flags.manualSelfPayAmount = true;
     if (Object.keys(flags).length) {

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -13,8 +13,6 @@ const billingState = {
   sort: { field: null, direction: 'asc' }
 };
 
-const BILLING_INSURANCE_OPTIONS = ['後期高齢', '国保', '社保', '生保', '自費'];
-const BILLING_DEPRECATED_INSURANCE_TYPES = ['マッサージ'];
 const BILLING_BURDEN_OPTIONS = [
   { value: 1, label: '1割' },
   { value: 2, label: '2割' },
@@ -29,9 +27,9 @@ const BILLING_TRANSPORT_UNIT_PRICE_FALLBACK = 33;
 const BILLING_TRANSPORT_UNIT_PRICE = (typeof globalThis !== 'undefined' && typeof globalThis.BILLING_TRANSPORT_UNIT_PRICE === 'number')
   ? globalThis.BILLING_TRANSPORT_UNIT_PRICE
   : BILLING_TRANSPORT_UNIT_PRICE_FALLBACK;
-const BILLING_PATIENT_INFO_FIELDS = ['insuranceType', 'medicalAssistance', 'burdenRate', 'payerType', 'responsible', 'bankInfo', 'isNew'];
+const BILLING_PATIENT_INFO_FIELDS = ['medicalAssistance', 'burdenRate', 'payerType', 'responsible', 'bankInfo', 'isNew'];
 const BILLING_BILLING_OVERRIDES_FIELDS = ['unitPrice', 'transportAmount', 'carryOverAmount', 'visitCount', 'selfPayAmount'];
-const BILLING_OVERRIDE_BADGE_FIELDS = ['unitPrice', 'transportAmount', 'carryOverAmount', 'visitCount', 'selfPayAmount', 'insuranceType', 'burdenRate'];
+const BILLING_OVERRIDE_BADGE_FIELDS = ['unitPrice', 'transportAmount', 'carryOverAmount', 'visitCount', 'selfPayAmount', 'burdenRate'];
 
 function qs(id) {
   return document.getElementById(id);
@@ -217,11 +215,6 @@ function normalizeMedicalAssistanceFlag(value) {
   return 0;
 }
 
-function isDeprecatedInsuranceType(value) {
-  if (!value) return false;
-  return BILLING_DEPRECATED_INSURANCE_TYPES.includes(String(value).trim());
-}
-
 function getBillingBaseUrl() {
   return (window.APP_CONFIG && window.APP_CONFIG.baseUrl) || '';
 }
@@ -315,8 +308,6 @@ function resolveBillingSortValue(row, field) {
   switch (field) {
     case 'nameKanji':
       return row.nameKanji || '';
-    case 'insuranceType':
-      return row.insuranceType || '';
     case 'burdenRate':
       return resolveBurdenSortValue(row.burdenRate);
     case 'unitPrice':
@@ -1147,7 +1138,6 @@ function renderBillingResult() {
     { key: 'patientId', label: '患者ID', sortable: true },
     { key: 'nameKanji', label: '氏名', sortable: true },
     { key: 'responsible', label: '担当者', sortable: true },
-    { key: 'insuranceType', label: '保険種別', sortable: true },
     { key: 'medicalAssistance', label: '医療助成', sortable: false },
     { key: 'payerType', label: '保険者', sortable: false },
     { key: 'burdenRate', label: '負担', sortable: true },
@@ -1180,16 +1170,6 @@ function renderBillingResult() {
     const editClass = alignRight ? 'cell-edit inline-editor right' : 'cell-edit inline-editor';
     const viewClass = alignRight ? 'cell-edit right' : 'cell-edit';
     if (editing) {
-      if (field === 'insuranceType') {
-        const needsUpdate = isDeprecatedInsuranceType(item.insuranceType);
-        const options = BILLING_INSURANCE_OPTIONS.map(opt => `<option value="${opt}" ${opt === item.insuranceType ? 'selected' : ''}>${opt}</option>`).join('');
-        const select = `<select class="${editClass}" ${baseAttrs}>${needsUpdate ? '<option value="" disabled selected>保険種別を選択</option>' : ''}${options}</select>`;
-        if (needsUpdate) {
-          const editor = `<div class="insurance-editor">${select}<div class="field-note warn">以前の「マッサージ」種別が設定されています。現在の保険種別を選び直してください。</div></div>`;
-          return wrapWithOverrideBadge(editor, item.patientId, field, alignRight);
-        }
-        return wrapWithOverrideBadge(select, item.patientId, field, alignRight);
-      }
       if (field === 'burdenRate') {
         const editor = `<select class="${editClass}" ${baseAttrs}>${BILLING_BURDEN_OPTIONS.map(opt => `<option value="${opt.value}" ${String(opt.value) === String(item.burdenRate) ? 'selected' : ''}>${opt.label}</option>`).join('')}</select>`;
         const showSelfPay = String(item.burdenRate) === '自費' || String(item.insuranceType).trim() === '自費';
@@ -1233,9 +1213,6 @@ function renderBillingResult() {
 
     const display = (() => {
       switch (field) {
-        case 'insuranceType':
-          if (isDeprecatedInsuranceType(item.insuranceType)) return '要修正: マッサージ';
-          return item.insuranceType || '編集';
         case 'medicalAssistance':
           return normalizeMedicalAssistanceFlag(item.medicalAssistance) ? '有' : 'なし';
         case 'burdenRate':
@@ -1261,14 +1238,6 @@ function renderBillingResult() {
     return wrapWithOverrideBadge(view, item.patientId, field, alignRight);
   }
 
-  const legacyRows = rows.filter(row => isDeprecatedInsuranceType(row.insuranceType));
-  const notices = [];
-  if (legacyRows.length) {
-    const sample = legacyRows.slice(0, 3).map(r => (r.nameKanji || r.patientId || '不明')).join('／');
-    const overflow = legacyRows.length > 3 ? `、ほか ${legacyRows.length - 3} 名` : '';
-    notices.push(`<div class="alert warn">「マッサージ」保険種別は廃止されました。${sample}${overflow} に古い種別が残っています。保険種別を選び直してください。</div>`);
-  }
-
   const bodyRows = [];
   rows.forEach(item => {
     try {
@@ -1278,7 +1247,6 @@ function renderBillingResult() {
         <td>${safeItem.patientId || ''}</td>
         <td>${safeItem.nameKanji || ''}</td>
         <td>${getResponsibleDisplay(safeItem) || '—'}</td>
-        <td>${renderEditableCell(safeItem, 'insuranceType')}</td>
         <td>${renderEditableCell(safeItem, 'medicalAssistance')}</td>
         <td>${renderEditableCell(safeItem, 'payerType')}</td>
         <td>${renderEditableCell(safeItem, 'burdenRate')}</td>
@@ -1300,7 +1268,6 @@ function renderBillingResult() {
   });
 
   const tableHtml = [
-    ...notices,
     '<table><thead><tr>',
     header.map(renderSortHeaderCell).join(''),
     '</tr></thead><tbody>',

--- a/tests/billingGet.test.js
+++ b/tests/billingGet.test.js
@@ -376,13 +376,12 @@ function testBillingOverrideFlagsHighlightPatientInfoOverrides() {
   const source = getBillingSourceData('202504');
   const flags = source.billingOverrideFlags || {};
 
-  assert.strictEqual(overrides['001'].insuranceType, '生保', '上書きシートから保険種別を取得する');
+  assert.strictEqual(overrides['001'].insuranceType, undefined, '保険種別の上書きは無視される');
   assert.strictEqual(overrides['001'].burdenRate, 1, '上書きシートの負担割合を正規化する');
-  assert.strictEqual(source.patients['001'].insuranceType, '生保', '患者情報に上書き保険種別が反映される');
+  assert.strictEqual(source.patients['001'].insuranceType, '国保', '患者情報の保険種別は元データを維持する');
   assert.strictEqual(source.patients['001'].burdenRate, 1, '負担割合の上書きも正規化して適用される');
-  assert.strictEqual(flags['001'].insuranceType, true, '保険種別の上書きフラグが付与される');
   assert.strictEqual(flags['001'].burdenRate, true, '負担割合の上書きフラグが付与される');
-  assert.ok(!flags['002'] || !flags['002'].insuranceType, '上書きがない項目にはフラグが付かない');
+  assert.ok(!flags['002'] || !flags['002'].insuranceType, '保険種別の上書きフラグは付与されない');
 
   context.billingSs = originalBillingSs;
   context.getBillingPatientRecords = originalGetPatientRecords;


### PR DESCRIPTION
## Summary
- hide the insurance type column and editors in the billing UI
- stop reading insurance type overrides when loading BillingOverrides and update coverage

## Testing
- node tests/billingGet.test.js
- node tests/billingLogic.test.js
- node tests/billingOutput.test.js
- node tests/billingInvoiceLayout.test.js
- node tests/billingUiNormalization.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932c0a57250832195e3c4d96407ce49)