### PR TITLE
Fix numeric sorting for patient IDs

### DIFF
--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -124,6 +124,15 @@ function normalizeMoneyNumber_(value) {
   return Number.isFinite(num) ? num : 0;
 }
 
+function normalizePatientIdSortKey_(value) {
+  const num = Number(value);
+  if (Number.isFinite(num)) return num;
+  const trimmed = String(value || '').trim();
+  if (!trimmed) return 0;
+  const fallback = Number(trimmed.replace(/[^0-9]/g, ''));
+  return Number.isFinite(fallback) ? fallback : 0;
+}
+
 function normalizeBurdenRateInt_(burdenRate) {
   if (burdenRate == null || burdenRate === '') return 0;
   if (String(burdenRate).trim() === '自費') return '自費';
@@ -251,7 +260,8 @@ function generateBillingJsonFromSource(sourceData) {
     bankStatuses,
     carryOverByPatient
   } = normalizeBillingSource_(sourceData);
-  const patientIds = Object.keys(treatmentVisitCounts || {});
+  const patientIds = Object.keys(treatmentVisitCounts || {})
+    .sort((a, b) => normalizePatientIdSortKey_(a) - normalizePatientIdSortKey_(b));
   const zeroVisitDebug = [];
 
   const billingJson = patientIds.map(pid => {

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -297,6 +297,15 @@ function formatNewFlag(item) {
   return '<span class="badge">新規</span>';
 }
 
+function resolvePatientIdSortValue(value) {
+  const num = Number(value);
+  if (Number.isFinite(num)) return num;
+  const trimmed = String(value || '').trim();
+  if (!trimmed) return 0;
+  const fallback = Number(trimmed.replace(/[^0-9]/g, ''));
+  return Number.isFinite(fallback) ? fallback : 0;
+}
+
 function resolveBurdenSortValue(value) {
   if (value === '自費') return 99;
   const num = Number(value);
@@ -325,7 +334,7 @@ function resolveBillingSortValue(row, field) {
     case 'responsible':
       return getResponsibleDisplay(row);
     case 'patientId':
-      return row.patientId || '';
+      return resolvePatientIdSortValue(row.patientId);
     default:
       return null;
   }


### PR DESCRIPTION
## Summary
- sort billing generation patient IDs numerically to keep ordering consistent
- normalize patient ID sort keys in the UI to use numeric values instead of string comparison

## Testing
- not run (node command not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932c2867adc8321bcd3e861ae0c5cc9)