### PR TITLE
Ensure billingMonth is preserved in billing payloads

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -755,8 +755,14 @@ function normalizeBillingResultPayload(raw) {
   function normalizeBillingPayload(payload) {
     const withDefaults = applyBillingFieldDefaults(payload);
     const billingJson = coerceBillingJson(withDefaults.billingJson) || [];
+    const fallbackBillingMonth = billingJson && billingJson.length ? billingJson[0].billingMonth : '';
+    const resolvedBillingMonth =
+      withDefaults.billingMonth ||
+      (withDefaults.month && withDefaults.month.key) ||
+      fallbackBillingMonth ||
+      '';
     const enrichedRows = mergePatientMetaIntoRows(billingJson, withDefaults.patients || {});
-    return Object.assign({}, withDefaults, { billingJson: enrichedRows });
+    return Object.assign({}, withDefaults, { billingMonth: resolvedBillingMonth, billingJson: enrichedRows });
   }
 
   function parseMaybeJson(value) {


### PR DESCRIPTION
## Summary
- add billingMonth fallbacks when normalizing billing payloads so prepared data retains the month key

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933494ce11c83218543c4c8d06c8109)