### PR TITLE
Ensure bank transfer cache export receives billing month

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -965,7 +965,9 @@ function handleBankExport() {
   google.script.run
     .withSuccessHandler(onBankExportCompleted)
     .withFailureHandler(onBillingFailed)
-    .generateBankTransferDataFromCache(billingState.prepared.billingMonth, {});
+    .generateBankTransferDataFromCache(billingState.prepared.billingMonth, {
+      billingMonth: billingState.prepared.billingMonth
+    });
 }
 
 function onBankExportCompleted(result) {


### PR DESCRIPTION
## Summary
- add defensive billingMonth resolution in generateBankTransferDataFromCache, including normalization of cached payloads
- propagate billingMonth through the web UI bank export call to avoid missing values
- preserve billingMonth on the server-side export payload before invoking bank transfer generation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69334a9d1ed883219d7b91077fb41253)