### PR TITLE
Enhance billing cache validation

### DIFF
--- a/tests/preparedBillingCache.test.js
+++ b/tests/preparedBillingCache.test.js
@@ -1,0 +1,91 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const mainCode = fs.readFileSync(path.join(__dirname, '../src/main.gs'), 'utf8');
+
+function createMainContext(overrides = {}) {
+  const baseCache = {
+    getScriptCache: () => ({
+      get: () => null,
+      remove: () => {}
+    })
+  };
+  const ctx = Object.assign({ console, CacheService: baseCache }, overrides);
+  vm.createContext(ctx);
+  vm.runInContext(mainCode, ctx);
+  return Object.assign(ctx, overrides);
+}
+
+function testValidationRequiresLedgerFields() {
+  const ctx = createMainContext();
+  const { validatePreparedBillingPayload_ } = ctx;
+  const payload = {
+    billingMonth: '202501',
+    billingJson: []
+  };
+
+  const result = validatePreparedBillingPayload_(payload, '202501');
+  assert.strictEqual(result.ok, false, 'ledger不足のpayloadはrejectされる');
+  assert.strictEqual(result.reason, 'carryOverLedger missing');
+}
+
+function testValidationAcceptsCompletePayload() {
+  const ctx = createMainContext();
+  const { validatePreparedBillingPayload_ } = ctx;
+  const payload = {
+    billingMonth: '202501',
+    billingJson: [],
+    carryOverLedger: [],
+    carryOverLedgerMeta: {},
+    carryOverLedgerByPatient: {},
+    unpaidHistory: [],
+    visitsByPatient: {},
+    totalsByPatient: {}
+  };
+
+  const result = validatePreparedBillingPayload_(payload, '202501');
+  assert.strictEqual(result.ok, true, '必須フィールドが揃えば検証OK');
+  assert.strictEqual(result.billingMonth, '202501');
+}
+
+function testBankExportRejectsNonArrayBillingJson() {
+  const ctx = createMainContext({
+    normalizeBillingMonthInput: input => ({ key: String(input) }),
+    loadPreparedBilling_: () => ({ billingJson: {} }),
+    normalizePreparedBilling_: payload => payload,
+    exportBankTransferDataForPrepared_: () => assert.fail('invalid payload should not reach exporter')
+  });
+
+  assert.throws(() => {
+    ctx.generateBankTransferDataFromCache('202501');
+  }, /CarryOverLedger シート/);
+}
+
+function testBankExportPassesWhenArrayProvided() {
+  const exportCalls = [];
+  const ctx = createMainContext({
+    normalizeBillingMonthInput: input => ({ key: String(input) }),
+    loadPreparedBilling_: () => ({ billingJson: [], billingMonth: '202501' }),
+    normalizePreparedBilling_: payload => payload,
+    exportBankTransferDataForPrepared_: prepared => {
+      exportCalls.push(prepared.billingMonth);
+      return { billingMonth: prepared.billingMonth, inserted: 1 };
+    }
+  });
+
+  const result = ctx.generateBankTransferDataFromCache('202501');
+  assert.deepStrictEqual(exportCalls, ['202501']);
+  assert.strictEqual(result.inserted, 1);
+}
+
+function run() {
+  testValidationRequiresLedgerFields();
+  testValidationAcceptsCompletePayload();
+  testBankExportRejectsNonArrayBillingJson();
+  testBankExportPassesWhenArrayProvided();
+  console.log('prepared billing cache tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- validate carry-over and totals fields when loading prepared billing cache entries
- enforce array checks for cached billing JSON before bank export generation
- add tests covering prepared payload validation and bank export cache handling

## Testing
- for f in tests/*.test.js; do echo "Running $f"; node $f; done

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69334ef2857c8321b30e94d99b8e7e24)