### PR TITLE
Harden prepared billing cache schema validation

### DIFF
--- a/tests/preparedBillingCache.test.js
+++ b/tests/preparedBillingCache.test.js
@@ -5,6 +5,28 @@ const assert = require('assert');
 
 const mainCode = fs.readFileSync(path.join(__dirname, '../src/main.gs'), 'utf8');
 
+function buildValidPreparedPayload(ctx, overrides = {}) {
+  return Object.assign({
+    schemaVersion: ctx.PREPARED_BILLING_SCHEMA_VERSION || 2,
+    billingMonth: '202501',
+    billingJson: [],
+    carryOverLedger: [],
+    carryOverLedgerMeta: {},
+    carryOverLedgerByPatient: {},
+    unpaidHistory: [],
+    visitsByPatient: {},
+    totalsByPatient: {},
+    patients: {},
+    bankInfoByName: {},
+    staffByPatient: {},
+    staffDirectory: {},
+    staffDisplayByPatient: {},
+    billingOverrideFlags: {},
+    carryOverByPatient: {},
+    bankAccountInfoByPatient: {}
+  }, overrides);
+}
+
 function createMainContext(overrides = {}) {
   const baseCache = {
     getScriptCache: () => ({
@@ -21,10 +43,7 @@ function createMainContext(overrides = {}) {
 function testValidationRequiresLedgerFields() {
   const ctx = createMainContext();
   const { validatePreparedBillingPayload_ } = ctx;
-  const payload = {
-    billingMonth: '202501',
-    billingJson: []
-  };
+  const payload = buildValidPreparedPayload(ctx, { carryOverLedger: undefined });
 
   const result = validatePreparedBillingPayload_(payload, '202501');
   assert.strictEqual(result.ok, false, 'ledger不足のpayloadはrejectされる');
@@ -34,20 +53,21 @@ function testValidationRequiresLedgerFields() {
 function testValidationAcceptsCompletePayload() {
   const ctx = createMainContext();
   const { validatePreparedBillingPayload_ } = ctx;
-  const payload = {
-    billingMonth: '202501',
-    billingJson: [],
-    carryOverLedger: [],
-    carryOverLedgerMeta: {},
-    carryOverLedgerByPatient: {},
-    unpaidHistory: [],
-    visitsByPatient: {},
-    totalsByPatient: {}
-  };
+  const payload = buildValidPreparedPayload(ctx);
 
   const result = validatePreparedBillingPayload_(payload, '202501');
   assert.strictEqual(result.ok, true, '必須フィールドが揃えば検証OK');
   assert.strictEqual(result.billingMonth, '202501');
+}
+
+function testSchemaVersionIsValidated() {
+  const ctx = createMainContext();
+  const { validatePreparedBillingPayload_ } = ctx;
+  const payload = buildValidPreparedPayload(ctx, { schemaVersion: 1 });
+
+  const result = validatePreparedBillingPayload_(payload, '202501');
+  assert.strictEqual(result.ok, false, '古いスキーマバージョンはrejectされる');
+  assert.strictEqual(result.reason, 'schemaVersion mismatch');
 }
 
 function testBankExportRejectsNonArrayBillingJson() {
@@ -83,6 +103,7 @@ function testBankExportPassesWhenArrayProvided() {
 function run() {
   testValidationRequiresLedgerFields();
   testValidationAcceptsCompletePayload();
+  testSchemaVersionIsValidated();
   testBankExportRejectsNonArrayBillingJson();
   testBankExportPassesWhenArrayProvided();
   console.log('prepared billing cache tests passed');


### PR DESCRIPTION
## Summary
- add a schema version to prepared billing payloads and propagate it through normalization
- tighten prepared billing cache validation to require schema version and core maps
- extend prepared billing cache tests to cover the new validation rules

## Testing
- node tests/*.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933514470248321ad72d410fff4537b)