### PR TITLE
Prevent stale patient info responses while editing patient ID

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -604,6 +604,10 @@ function waitMs(ms){
   });
 }
 
+function invalidatePatientInfoRequests(){
+  _patientInfoRequestToken++;
+}
+
 function isActivePatientInfoRequest(token){
   return token == null || token === _patientInfoRequestToken;
 }
@@ -2650,6 +2654,7 @@ function handlePatientIdKeydown(evt){
 function handlePatientIdInput(){
   unlockInitialPatientIdRender();
   pausePatientIdRender();
+  invalidatePatientInfoRequests();
   _patientIdInputEditing = true;
   const inputEl = q('pid');
   const rawValue = inputEl && inputEl.value != null ? String(inputEl.value) : '';


### PR DESCRIPTION
## Summary
- add a helper to invalidate in-flight patient info requests
- cancel stale patient info responses when typing in the patient ID field so manual edits are not overwritten

## Testing
- node tests/billingGet.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cf632807883218db5ef4dc2322dc7)