### PR TITLE
Refine bank export error messaging

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -972,7 +972,11 @@ function handleBankExport() {
 
 function onBankExportCompleted(result) {
   billingState.loading = false;
-  billingState.statusMessage = '銀行データを出力しました' + (result && result.inserted ? `（${result.inserted}件）` : '');
+  if (result && result.message) {
+    billingState.statusMessage = result.message;
+  } else {
+    billingState.statusMessage = '銀行データを出力しました' + (result && result.inserted ? `（${result.inserted}件）` : '');
+  }
   billingState.errorMessage = '';
   logBillingState('onBankExportCompleted');
   renderBillingResult();


### PR DESCRIPTION
## Summary
- add validation-aware loading for prepared billing data and tailor bank export errors to ledger vs unprepared states
- return an explicit notice when billing exports have zero items and surface that message in the UI
- extend cache tests to cover the new bank export messaging paths

## Testing
- node tests/preparedBillingCache.test.js
- node tests/billingLogic.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d01b2b2d4832192a57e61dd41405a)