### PR TITLE
Fix treatment delete button escaping

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3328,7 +3328,7 @@ function renderThisMonthList(rows, options){
     const tagBlock = tagHtml ? `<div class="treatment-tag-wrap">${tagHtml}</div>` : '';
     const emailHtml = r.email ? `<div class="treatment-meta">登録者：${escapeHtml(r.email)}</div>` : '';
     const noteForEdit = JSON.stringify(r.note || '').replace(/"/g,'&quot;');
-    const treatmentIdLiteral = JSON.stringify(r.treatmentId || '');
+    const treatmentIdAttr = escapeHtml(String(r.treatmentId || ''));
     return `
         <tr>
           <td>${whenHtml}</td>
@@ -3340,7 +3340,7 @@ function renderThisMonthList(rows, options){
           <td class="actions">
             <button class="btn ghost" onclick="editRow(${r.row}, ${noteForEdit})">編集</button>
             <button class="btn ghost" onclick="editRowTime(${r.row}, '${isoWhen}')">日時</button>
-            <button class="btn warn" onclick="delRow(${treatmentIdLiteral})">削除</button>
+            <button class="btn warn" data-treatment-id="${treatmentIdAttr}" onclick="delRow(this.dataset.treatmentId)">削除</button>
 
           </td>
         </tr>`;

--- a/tests/treatmentDeleteButtonTemplate.test.js
+++ b/tests/treatmentDeleteButtonTemplate.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+const html = fs.readFileSync(path.join(__dirname, '../src/app.html'), 'utf8');
+
+const match = html.match(/function renderThisMonthList[\s\S]*?return `\n        <tr>[\s\S]*?<\/tr>`;/);
+assert.ok(match, 'renderThisMonthList template should be present');
+
+const template = match[0];
+
+assert.ok(
+  template.includes('data-treatment-id="${treatmentIdAttr}"'),
+  'delete button should carry treatment id via data attribute'
+);
+
+assert.ok(
+  template.includes('onclick="delRow(this.dataset.treatmentId)"'),
+  'delete button should read treatment id from dataset'
+);
+
+assert.ok(
+  template.includes("const treatmentIdAttr = escapeHtml(String(r.treatmentId || ''))"),
+  'treatment id should be escaped when embedded in markup'
+);
+
+console.log('treatmentDeleteButtonTemplate test passed');


### PR DESCRIPTION
## Summary
- escape the treatment ID when rendering delete buttons and pass it via data attributes to avoid inline script syntax errors
- add a regression test to ensure the delete button template uses the escaped dataset-based handler

## Testing
- for f in tests/*.js; do echo "running $f"; node $f; done


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d0f6a6be4832196f225dd2768609d)