### PR TITLE
Normalize billing month for prepared cache

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -551,9 +551,13 @@ function serializeBillingPayload_(payload) {
 }
 
 function prepareBillingData(billingMonth) {
-  const prepared = buildPreparedBillingPayload_(billingMonth);
+  const normalizedMonth = normalizeBillingMonthInput(billingMonth);
+  const prepared = buildPreparedBillingPayload_(normalizedMonth);
   const clientPayload = toClientBillingPayload_(prepared);
-  const serialized = serializeBillingPayload_(clientPayload) || clientPayload;
+  const payloadWithMonth = clientPayload
+    ? Object.assign({}, clientPayload, { billingMonth: normalizedMonth.key })
+    : clientPayload;
+  const serialized = serializeBillingPayload_(payloadWithMonth) || payloadWithMonth;
   const payloadJson = serialized ? JSON.stringify(serialized) : '';
   const payloadPreview = payloadJson.length > 50000 ? payloadJson.slice(0, 50000) + '…<truncated>' : payloadJson;
 
@@ -569,8 +573,11 @@ function prepareBillingData(billingMonth) {
       '\n[billing] prepareBillingData payloadRaw=' + payloadPreview
   );
 
-  savePreparedBilling_(serialized);
-  return serialized;
+  const cachePayload = serialized
+    ? Object.assign({}, serialized, { billingMonth: normalizedMonth.key })
+    : { billingMonth: normalizedMonth.key };
+  savePreparedBilling_(cachePayload);
+  return cachePayload;
 }
 
 /**


### PR DESCRIPTION
## Summary
- normalize billing months in `prepareBillingData` before saving prepared billing payloads
- ensure cached payloads always use the YYYYMM key and cover regression with a prepared billing cache test

## Testing
- for f in tests/*.test.js; do node $f; done

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d16dde9b08321ad0cf126753c65f9)