### PR TITLE
Add dashboard data loaders for patients, treatments, and handovers

### DIFF
--- a/src/dashboard/loadNotes.js
+++ b/src/dashboard/loadNotes.js
@@ -1,0 +1,167 @@
+/**
+ * 申し送りシートを読み込み、患者IDごとの最新申し送りを返す。
+ */
+function loadNotes(options) {
+  const warnings = [];
+  const latestByPatient = {};
+  const lastReadAt = loadHandoverLastRead_();
+
+  const wb = dashboardGetSpreadsheet_();
+  const sheet = wb && wb.getSheetByName ? wb.getSheetByName('申し送り') : null;
+  if (!sheet) {
+    warnings.push('申し送りシートが見つかりません');
+    dashboardWarn_('[loadNotes] sheet not found');
+    return { notes: latestByPatient, warnings, lastReadAt };
+  }
+
+  const lastRow = sheet.getLastRow ? sheet.getLastRow() : 0;
+  if (lastRow < 2) return { notes: latestByPatient, warnings, lastReadAt };
+
+  const lastCol = Math.max(5, sheet.getLastColumn ? sheet.getLastColumn() : (sheet.getMaxColumns ? sheet.getMaxColumns() : 0));
+  const values = sheet.getRange(2, 1, lastRow - 1, lastCol).getValues();
+  const displayValues = sheet.getRange(2, 1, lastRow - 1, lastCol).getDisplayValues();
+  const tz = dashboardResolveTimeZone_();
+
+  for (let i = 0; i < values.length; i++) {
+    const row = values[i] || [];
+    const rowDisplay = displayValues[i] || [];
+    const rowNumber = i + 2;
+
+    const patientId = dashboardNormalizePatientId_(row[1] || rowDisplay[1]);
+    if (!patientId) {
+      warnings.push(`患者IDが未入力の申し送りをスキップしました (row:${rowNumber})`);
+      continue;
+    }
+
+    const ts = dashboardParseTimestamp_(row[0] || rowDisplay[0]);
+    if (!ts) {
+      warnings.push(`申し送りの日時を解釈できません (row:${rowNumber})`);
+      continue;
+    }
+
+    const authorEmail = String(row[2] || rowDisplay[2] || '').trim();
+    const body = String(rowDisplay[3] || row[3] || '').trim();
+    const preview = dashboardTrimPreview_(body, 20);
+    const when = dashboardFormatDate_(ts, tz, 'yyyy-MM-dd HH:mm');
+
+    const existing = latestByPatient[patientId];
+    if (!existing || (existing.timestamp && existing.timestamp < ts)) {
+      latestByPatient[patientId] = {
+        patientId,
+        authorEmail,
+        note: body,
+        preview,
+        when,
+        timestamp: ts,
+        row: rowNumber,
+        lastReadAt: lastReadAt[patientId] || ''
+      };
+    }
+  }
+
+  return { notes: latestByPatient, warnings, lastReadAt };
+}
+
+function dashboardTrimPreview_(text, limit) {
+  const raw = String(text == null ? '' : text).replace(/\s+/g, ' ').trim();
+  if (!limit || raw.length <= limit) return raw;
+  return raw.slice(0, limit);
+}
+
+function loadHandoverLastRead_() {
+  const key = 'HANDOVER_LAST_READ';
+  if (typeof PropertiesService === 'undefined' || !PropertiesService.getScriptProperties) return {};
+  try {
+    const raw = PropertiesService.getScriptProperties().getProperty(key) || '{}';
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch (e) {
+    dashboardWarn_('[loadHandoverLastRead] parse failed: ' + (e && e.message ? e.message : e));
+    return {};
+  }
+}
+
+function updateHandoverLastRead(patientId, readAt) {
+  const key = 'HANDOVER_LAST_READ';
+  const pid = dashboardNormalizePatientId_(patientId);
+  if (!pid) return false;
+  if (typeof PropertiesService === 'undefined' || !PropertiesService.getScriptProperties) return false;
+  const store = PropertiesService.getScriptProperties();
+  let current = {};
+  try {
+    current = JSON.parse(store.getProperty(key) || '{}');
+    if (!current || typeof current !== 'object') current = {};
+  } catch (e) {
+    current = {};
+  }
+  const ts = readAt instanceof Date ? readAt : (readAt ? dashboardParseTimestamp_(readAt) : new Date());
+  if (!(ts instanceof Date) || Number.isNaN(ts.getTime())) return false;
+  current[pid] = ts.toISOString();
+  try {
+    store.setProperty(key, JSON.stringify(current));
+    return true;
+  } catch (e) {
+    dashboardWarn_('[updateHandoverLastRead] failed to save: ' + (e && e.message ? e.message : e));
+    return false;
+  }
+}
+
+if (typeof dashboardGetSpreadsheet_ === 'undefined') {
+  function dashboardGetSpreadsheet_() {
+    if (typeof ss === 'function') {
+      try { return ss(); } catch (e) { /* ignore */ }
+    }
+    if (typeof SpreadsheetApp !== 'undefined' && SpreadsheetApp.getActiveSpreadsheet) {
+      return SpreadsheetApp.getActiveSpreadsheet();
+    }
+    return null;
+  }
+}
+
+if (typeof dashboardNormalizePatientId_ === 'undefined') {
+  function dashboardNormalizePatientId_(value) {
+    const raw = value == null ? '' : value;
+    return String(raw).trim();
+  }
+}
+
+if (typeof dashboardResolveTimeZone_ === 'undefined') {
+  function dashboardResolveTimeZone_() {
+    if (typeof Session !== 'undefined' && Session && typeof Session.getScriptTimeZone === 'function') {
+      const tz = Session.getScriptTimeZone();
+      if (tz) return tz;
+    }
+    return 'Asia/Tokyo';
+  }
+}
+
+if (typeof dashboardParseTimestamp_ === 'undefined') {
+  function dashboardParseTimestamp_(value) {
+    if (value instanceof Date) return value;
+    if (typeof value === 'number' && Number.isFinite(value)) return new Date(value);
+    const str = String(value == null ? '' : value).trim();
+    if (!str) return null;
+    const parsed = new Date(str);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+}
+
+if (typeof dashboardFormatDate_ === 'undefined') {
+  function dashboardFormatDate_(date, tz, format) {
+    if (typeof Utilities !== 'undefined' && Utilities && typeof Utilities.formatDate === 'function') {
+      try { return Utilities.formatDate(date, tz, format); } catch (e) { /* ignore */ }
+    }
+    return date.toISOString();
+  }
+}
+
+if (typeof dashboardWarn_ === 'undefined') {
+  function dashboardWarn_(message) {
+    if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+      try { Logger.log(message); return; } catch (e) { /* ignore */ }
+    }
+    if (typeof console !== 'undefined' && console && typeof console.warn === 'function') {
+      console.warn(message);
+    }
+  }
+}

--- a/src/dashboard/loadPatientInfo.js
+++ b/src/dashboard/loadPatientInfo.js
@@ -1,0 +1,126 @@
+/**
+ * 患者情報シートを読み込み、患者IDを主キーとした情報と氏名マッピングを返す。
+ */
+function loadPatientInfo() {
+  const patients = {};
+  const nameToId = {};
+  const warnings = [];
+
+  const wb = dashboardGetSpreadsheet_();
+  const sheet = wb && wb.getSheetByName ? wb.getSheetByName('患者情報') : null;
+  if (!sheet) {
+    warnings.push('患者情報シートが見つかりません');
+    dashboardWarn_('[loadPatientInfo] sheet not found');
+    return { patients, nameToId, warnings };
+  }
+
+  const lastRow = sheet.getLastRow ? sheet.getLastRow() : 0;
+  if (lastRow < 2) return { patients, nameToId, warnings };
+
+  const lastCol = sheet.getLastColumn ? sheet.getLastColumn() : sheet.getMaxColumns ? sheet.getMaxColumns() : 0;
+  const headers = sheet.getRange(1, 1, 1, lastCol).getDisplayValues()[0] || [];
+  const values = sheet.getRange(2, 1, lastRow - 1, lastCol).getValues();
+  const displayValues = sheet.getRange(2, 1, lastRow - 1, lastCol).getDisplayValues();
+
+  const colPid = dashboardResolveColumn_(headers, ['患者ID', 'patientId', 'ID', 'id', '施術録番号'], 1);
+  const colName = dashboardResolveColumn_(headers, ['氏名', '名前', '患者名'], 2);
+  const colConsent = dashboardResolveColumn_(headers, ['同意期限', '同意書期限', '同意有効期限', '同意期限日'], 0);
+
+  for (let i = 0; i < values.length; i++) {
+    const row = values[i] || [];
+    const rowDisplay = displayValues[i] || [];
+    const rowNumber = i + 2;
+
+    const patientId = dashboardNormalizePatientId_(rowDisplay[colPid - 1] || row[colPid - 1]);
+    const name = String(rowDisplay[colName - 1] || row[colName - 1] || '').trim();
+    const consentExpiry = colConsent
+      ? String(rowDisplay[colConsent - 1] || row[colConsent - 1] || '').trim()
+      : '';
+
+    if (!patientId) {
+      warnings.push(`患者IDが空です (row:${rowNumber})`);
+      dashboardWarn_(`[loadPatientInfo] missing patientId at row ${rowNumber}`);
+      continue;
+    }
+    if (!name) {
+      warnings.push(`氏名が未入力の患者があります (患者ID:${patientId})`);
+      dashboardWarn_(`[loadPatientInfo] missing name for patientId ${patientId}`);
+    }
+
+    const normalizedNameKey = dashboardNormalizeNameKey_(name);
+    if (normalizedNameKey && !nameToId[normalizedNameKey]) {
+      nameToId[normalizedNameKey] = patientId;
+    }
+
+    const raw = {};
+    headers.forEach((h, idx) => {
+      const key = String(h || '').trim();
+      if (!key) return;
+      raw[key] = row[idx];
+    });
+
+    patients[patientId] = {
+      patientId,
+      name,
+      consentExpiry,
+      raw
+    };
+  }
+
+  return { patients, nameToId, warnings };
+}
+
+if (typeof dashboardGetSpreadsheet_ === 'undefined') {
+  function dashboardGetSpreadsheet_() {
+    if (typeof ss === 'function') {
+      try { return ss(); } catch (e) { /* ignore */ }
+    }
+    if (typeof SpreadsheetApp !== 'undefined' && SpreadsheetApp.getActiveSpreadsheet) {
+      return SpreadsheetApp.getActiveSpreadsheet();
+    }
+    return null;
+  }
+}
+
+if (typeof dashboardNormalizePatientId_ === 'undefined') {
+  function dashboardNormalizePatientId_(value) {
+    const raw = value == null ? '' : value;
+    const normalized = String(raw).trim();
+    return normalized;
+  }
+}
+
+if (typeof dashboardNormalizeNameKey_ === 'undefined') {
+  function dashboardNormalizeNameKey_(name) {
+    return String(name == null ? '' : name)
+      .replace(/\s+/g, '')
+      .toLowerCase();
+  }
+}
+
+if (typeof dashboardResolveColumn_ === 'undefined') {
+  function dashboardResolveColumn_(headers, candidates, fallbackIndex) {
+    if (Array.isArray(candidates)) {
+      const normalizedHeaders = (headers || []).map(h => String(h || '').trim().toLowerCase());
+      for (let i = 0; i < normalizedHeaders.length; i++) {
+        const header = normalizedHeaders[i];
+        if (!header) continue;
+        if (candidates.some(c => header === String(c || '').trim().toLowerCase())) {
+          return i + 1;
+        }
+      }
+    }
+    return fallbackIndex || 0;
+  }
+}
+
+if (typeof dashboardWarn_ === 'undefined') {
+  function dashboardWarn_(message) {
+    if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+      try { Logger.log(message); return; } catch (e) { /* ignore */ }
+    }
+    if (typeof console !== 'undefined' && console && typeof console.warn === 'function') {
+      console.warn(message);
+    }
+  }
+}

--- a/src/dashboard/loadTreatmentLogs.js
+++ b/src/dashboard/loadTreatmentLogs.js
@@ -1,0 +1,182 @@
+/**
+ * 施術録を読み込み、患者名を患者IDへマッピングした結果を返す。
+ */
+function loadTreatmentLogs(options) {
+  const opts = options || {};
+  const patientInfo = opts.patientInfo || (typeof loadPatientInfo === 'function' ? loadPatientInfo() : null);
+  const nameToId = opts.nameToId || (patientInfo && patientInfo.nameToId) || {};
+  const warnings = patientInfo && Array.isArray(patientInfo.warnings) ? [].concat(patientInfo.warnings) : [];
+  const logs = [];
+  const lastStaffByPatient = {};
+
+  const wb = dashboardGetSpreadsheet_();
+  const sheet = wb && wb.getSheetByName ? wb.getSheetByName('施術録') : null;
+  if (!sheet) {
+    warnings.push('施術録シートが見つかりません');
+    dashboardWarn_('[loadTreatmentLogs] sheet not found');
+    return { logs, warnings, lastStaffByPatient };
+  }
+
+  const lastRow = sheet.getLastRow ? sheet.getLastRow() : 0;
+  if (lastRow < 2) return { logs, warnings, lastStaffByPatient };
+
+  const lastCol = sheet.getLastColumn ? sheet.getLastColumn() : sheet.getMaxColumns ? sheet.getMaxColumns() : 0;
+  const headers = sheet.getRange(1, 1, 1, lastCol).getDisplayValues()[0] || [];
+  const values = sheet.getRange(2, 1, lastRow - 1, lastCol).getValues();
+  const displayValues = sheet.getRange(2, 1, lastRow - 1, lastCol).getDisplayValues();
+
+  const colTimestamp = dashboardResolveColumn_(headers, ['日時', '日付', 'timestamp', 'ts', 'タイムスタンプ'], 1);
+  const colPatientId = dashboardResolveColumn_(headers, ['患者ID', 'patientId', 'id'], 0);
+  const colPatientName = dashboardResolveColumn_(headers, ['氏名', '名前', '患者名'], colPatientId ? 0 : 2);
+  const colEmail = dashboardResolveColumn_(headers, ['作成者', '担当者', 'email', 'createdbyemail'], 0);
+
+  const tz = dashboardResolveTimeZone_();
+  const monthStart = dashboardStartOfMonth_(tz, new Date());
+  const prevMonthEnd = dashboardEndOfPreviousMonth_(monthStart);
+
+  for (let i = 0; i < values.length; i++) {
+    const row = values[i] || [];
+    const rowDisplay = displayValues[i] || [];
+    const rowNumber = i + 2;
+
+    const timestamp = dashboardParseTimestamp_(row[colTimestamp - 1] || rowDisplay[colTimestamp - 1]);
+    if (!timestamp) {
+      warnings.push(`施術日時を解釈できません (row:${rowNumber})`);
+      continue;
+    }
+
+    const patientIdRaw = colPatientId ? dashboardNormalizePatientId_(row[colPatientId - 1] || rowDisplay[colPatientId - 1]) : '';
+    const patientName = String((colPatientName && (rowDisplay[colPatientName - 1] || row[colPatientName - 1])) || '').trim();
+    const mappedPatientId = patientIdRaw || dashboardResolvePatientIdFromName_(patientName, nameToId);
+    const createdByEmail = colEmail ? String(rowDisplay[colEmail - 1] || row[colEmail - 1] || '').trim() : '';
+    const dateKey = dashboardFormatDate_(timestamp, tz, 'yyyy-MM-dd');
+
+    if (!mappedPatientId) {
+      warnings.push(`患者名をIDに紐付けできません: ${patientName || '(空白)'} (row:${rowNumber})`);
+    }
+
+    const entry = {
+      row: rowNumber,
+      patientId: mappedPatientId || '',
+      patientName,
+      createdByEmail,
+      timestamp,
+      dateKey
+    };
+    if (!mappedPatientId) {
+      entry.unmapped = true;
+      entry.unmappedName = patientName || '';
+    }
+
+    logs.push(entry);
+
+    if (mappedPatientId && timestamp <= prevMonthEnd) {
+      const prev = lastStaffByPatient[mappedPatientId];
+      if (!prev || (prev.timestamp && prev.timestamp < timestamp)) {
+        lastStaffByPatient[mappedPatientId] = { email: createdByEmail, timestamp };
+      }
+    }
+  }
+
+  Object.keys(lastStaffByPatient).forEach(pid => {
+    const entry = lastStaffByPatient[pid];
+    lastStaffByPatient[pid] = entry ? entry.email || '' : '';
+  });
+
+  return { logs, warnings, lastStaffByPatient };
+}
+
+function dashboardResolvePatientIdFromName_(name, nameToId) {
+  const key = dashboardNormalizeNameKey_(name);
+  return key && nameToId ? nameToId[key] : '';
+}
+
+function dashboardParseTimestamp_(value) {
+  if (value instanceof Date) return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return new Date(value);
+  const str = String(value == null ? '' : value).trim();
+  if (!str) return null;
+  const parsed = new Date(str);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function dashboardResolveTimeZone_() {
+  if (typeof Session !== 'undefined' && Session && typeof Session.getScriptTimeZone === 'function') {
+    const tz = Session.getScriptTimeZone();
+    if (tz) return tz;
+  }
+  return 'Asia/Tokyo';
+}
+
+function dashboardFormatDate_(date, tz, format) {
+  if (typeof Utilities !== 'undefined' && Utilities && typeof Utilities.formatDate === 'function') {
+    try { return Utilities.formatDate(date, tz, format); } catch (e) { /* ignore */ }
+  }
+  return date.toISOString().slice(0, 10);
+}
+
+function dashboardStartOfMonth_(tz, now) {
+  const ref = now instanceof Date ? now : new Date();
+  const y = ref.getFullYear();
+  const m = ref.getMonth();
+  return new Date(y, m, 1, 0, 0, 0, 0);
+}
+
+function dashboardEndOfPreviousMonth_(monthStart) {
+  const base = monthStart instanceof Date ? monthStart : new Date();
+  return new Date(base.getFullYear(), base.getMonth(), 0, 23, 59, 59, 999);
+}
+
+if (typeof dashboardGetSpreadsheet_ === 'undefined') {
+  function dashboardGetSpreadsheet_() {
+    if (typeof ss === 'function') {
+      try { return ss(); } catch (e) { /* ignore */ }
+    }
+    if (typeof SpreadsheetApp !== 'undefined' && SpreadsheetApp.getActiveSpreadsheet) {
+      return SpreadsheetApp.getActiveSpreadsheet();
+    }
+    return null;
+  }
+}
+
+if (typeof dashboardNormalizePatientId_ === 'undefined') {
+  function dashboardNormalizePatientId_(value) {
+    const raw = value == null ? '' : value;
+    return String(raw).trim();
+  }
+}
+
+if (typeof dashboardNormalizeNameKey_ === 'undefined') {
+  function dashboardNormalizeNameKey_(name) {
+    return String(name == null ? '' : name)
+      .replace(/\s+/g, '')
+      .toLowerCase();
+  }
+}
+
+if (typeof dashboardResolveColumn_ === 'undefined') {
+  function dashboardResolveColumn_(headers, candidates, fallbackIndex) {
+    if (Array.isArray(candidates)) {
+      const normalizedHeaders = (headers || []).map(h => String(h || '').trim().toLowerCase());
+      for (let i = 0; i < normalizedHeaders.length; i++) {
+        const header = normalizedHeaders[i];
+        if (!header) continue;
+        if (candidates.some(c => header === String(c || '').trim().toLowerCase())) {
+          return i + 1;
+        }
+      }
+    }
+    return fallbackIndex || 0;
+  }
+}
+
+if (typeof dashboardWarn_ === 'undefined') {
+  function dashboardWarn_(message) {
+    if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+      try { Logger.log(message); return; } catch (e) { /* ignore */ }
+    }
+    if (typeof console !== 'undefined' && console && typeof console.warn === 'function') {
+      console.warn(message);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a patient info loader that maps names to IDs and captures consent details with warnings
- add treatment log loader that converts names to patient IDs and tracks previous month staff assignments
- add handover loader that normalizes note rows and persists last-read timestamps

## Testing
- for f in tests/*.test.js; do node "$f"; done


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693df6ed6740832189d2de00e86df782)