### PR TITLE
Implement dashboard loaders for AI reports and invoice PDFs

### DIFF
--- a/src/dashboard/loadAIReports.js
+++ b/src/dashboard/loadAIReports.js
@@ -1,0 +1,137 @@
+/**
+ * AI報告書シートから患者ごとの最終発行日時を取得する。
+ * @return {{reports: Object<string, string>, warnings: string[]}}
+ */
+function loadAIReports() {
+  const reports = {};
+  const warnings = [];
+
+  const wb = dashboardGetSpreadsheet_();
+  if (!wb || typeof wb.getSheetByName !== 'function') {
+    warnings.push('スプレッドシートを取得できませんでした');
+    dashboardWarn_('[loadAIReports] spreadsheet unavailable');
+    return { reports, warnings };
+  }
+
+  const sheet = wb.getSheetByName('AI報告書');
+  if (!sheet) {
+    warnings.push('AI報告書シートが見つかりません');
+    dashboardWarn_('[loadAIReports] sheet not found');
+    return { reports, warnings };
+  }
+
+  const lastRow = sheet.getLastRow ? sheet.getLastRow() : 0;
+  if (lastRow < 2) return { reports, warnings };
+
+  const lastCol = Math.max(2, sheet.getLastColumn ? sheet.getLastColumn() : (sheet.getMaxColumns ? sheet.getMaxColumns() : 2));
+  const headers = sheet.getRange(1, 1, 1, lastCol).getDisplayValues()[0] || [];
+  const tsCol = dashboardResolveColumn_(headers, ['ts', 'timestamp', '日時'], 1);
+  const patientCol = dashboardResolveColumn_(headers, ['患者id', '患者ＩＤ', '患者ID', 'patientId', 'id'], 2);
+
+  const values = sheet.getRange(2, 1, lastRow - 1, lastCol).getValues();
+  const displays = sheet.getRange(2, 1, lastRow - 1, lastCol).getDisplayValues();
+  const tz = dashboardResolveTimeZone_();
+  const latestTs = {};
+
+  for (let i = 0; i < values.length; i++) {
+    const row = values[i] || [];
+    const disp = displays[i] || [];
+
+    const patientId = dashboardNormalizePatientId_(disp[patientCol - 1] || row[patientCol - 1]);
+    if (!patientId) continue;
+
+    const tsValue = row[tsCol - 1] != null && row[tsCol - 1] !== '' ? row[tsCol - 1] : disp[tsCol - 1];
+    const tsDate = dashboardParseTimestamp_(tsValue);
+    if (!tsDate) continue;
+
+    const ts = tsDate.getTime();
+    const currentTs = latestTs[patientId] || 0;
+    if (ts <= currentTs) continue;
+
+    latestTs[patientId] = ts;
+    reports[patientId] = dashboardFormatDate_(tsDate, tz, 'yyyy-MM-dd HH:mm');
+  }
+
+  return { reports, warnings };
+}
+
+if (typeof dashboardGetSpreadsheet_ === 'undefined') {
+  function dashboardGetSpreadsheet_() {
+    if (typeof ss === 'function') {
+      try { return ss(); } catch (e) { /* ignore */ }
+    }
+    if (typeof SpreadsheetApp !== 'undefined' && SpreadsheetApp.getActiveSpreadsheet) {
+      return SpreadsheetApp.getActiveSpreadsheet();
+    }
+    return null;
+  }
+}
+
+if (typeof dashboardParseTimestamp_ === 'undefined') {
+  function dashboardParseTimestamp_(value) {
+    if (value instanceof Date) return value;
+    if (typeof value === 'number' && Number.isFinite(value)) return new Date(value);
+    const str = String(value == null ? '' : value).trim();
+    if (!str) return null;
+    const parsed = new Date(str);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+}
+
+if (typeof dashboardResolveTimeZone_ === 'undefined') {
+  function dashboardResolveTimeZone_() {
+    if (typeof Session !== 'undefined' && Session && typeof Session.getScriptTimeZone === 'function') {
+      const tz = Session.getScriptTimeZone();
+      if (tz) return tz;
+    }
+    return 'Asia/Tokyo';
+  }
+}
+
+if (typeof dashboardFormatDate_ === 'undefined') {
+  function dashboardFormatDate_(date, tz, format) {
+    if (typeof Utilities !== 'undefined' && Utilities && typeof Utilities.formatDate === 'function') {
+      try { return Utilities.formatDate(date, tz, format); } catch (e) { /* ignore */ }
+    }
+    if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
+    const iso = date.toISOString();
+    if (format && format.indexOf('HH') >= 0) {
+      return iso.replace('T', ' ').slice(0, 16);
+    }
+    return iso.slice(0, 10);
+  }
+}
+
+if (typeof dashboardNormalizePatientId_ === 'undefined') {
+  function dashboardNormalizePatientId_(value) {
+    const raw = value == null ? '' : value;
+    return String(raw).trim();
+  }
+}
+
+if (typeof dashboardResolveColumn_ === 'undefined') {
+  function dashboardResolveColumn_(headers, candidates, fallbackIndex) {
+    if (Array.isArray(candidates)) {
+      const normalizedHeaders = (headers || []).map(h => String(h || '').trim().toLowerCase());
+      for (let i = 0; i < normalizedHeaders.length; i++) {
+        const header = normalizedHeaders[i];
+        if (!header) continue;
+        if (candidates.some(c => header === String(c || '').trim().toLowerCase())) {
+          return i + 1;
+        }
+      }
+    }
+    return fallbackIndex || 0;
+  }
+}
+
+if (typeof dashboardWarn_ === 'undefined') {
+  function dashboardWarn_(message) {
+    if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+      try { Logger.log(message); return; } catch (e) { /* ignore */ }
+    }
+    if (typeof console !== 'undefined' && console && typeof console.warn === 'function') {
+      console.warn(message);
+    }
+  }
+}

--- a/src/dashboard/loadInvoices.js
+++ b/src/dashboard/loadInvoices.js
@@ -1,0 +1,179 @@
+/**
+ * 当月の請求書PDFリンクを患者IDと紐付けて返す。
+ * @param {Object} [options]
+ * @param {Object} [options.patientInfo] - loadPatientInfo() の戻り値を差し込む場合に利用。
+ * @param {Object} [options.nameToId] - 氏名から患者IDへのマップを直接指定する場合に利用。
+ * @param {Object} [options.rootFolder] - 請求書フォルダのルートを直接指定する場合に利用。
+ * @param {Date} [options.now] - テスト用に現在日時を差し替える。
+ * @return {{invoices: Object<string, string|null>, warnings: string[]}}
+ */
+function loadInvoices(options) {
+  const opts = options || {};
+  const patientInfo = opts.patientInfo || (typeof loadPatientInfo === 'function' ? loadPatientInfo() : null);
+  const patients = patientInfo && patientInfo.patients ? patientInfo.patients : {};
+  const nameToId = opts.nameToId || (patientInfo && patientInfo.nameToId) || {};
+  const warnings = patientInfo && Array.isArray(patientInfo.warnings) ? [].concat(patientInfo.warnings) : [];
+  const invoices = {};
+  const latestMeta = {};
+
+  Object.keys(patients).forEach(pid => {
+    const normalized = dashboardNormalizePatientId_(pid);
+    if (normalized) {
+      invoices[normalized] = null;
+    }
+  });
+
+  const root = opts.rootFolder || dashboardGetInvoiceRootFolder_();
+  if (!root || typeof root.getFolders !== 'function') {
+    warnings.push('請求書フォルダが取得できませんでした');
+    dashboardWarn_('[loadInvoices] invoice root folder not found');
+    return { invoices, warnings };
+  }
+
+  const tz = dashboardResolveTimeZone_();
+  const now = dashboardCoerceDate_(opts.now) || new Date();
+  const targetYmDigits = dashboardFormatDate_(now, tz, 'yyyyMM');
+  const targetYmHyphen = dashboardFormatDate_(now, tz, 'yyyy-MM');
+  const targetYmKanji = dashboardFormatDate_(now, tz, 'yyyy年MM月');
+
+  const folders = root.getFolders();
+  while (folders && typeof folders.hasNext === 'function' && folders.hasNext()) {
+    const folder = folders.next();
+    const name = folder && typeof folder.getName === 'function' ? folder.getName() : '';
+    if (!isTargetInvoiceFolder_(name, targetYmDigits, targetYmKanji)) continue;
+
+    const files = folder.getFiles && folder.getFiles();
+    while (files && typeof files.hasNext === 'function' && files.hasNext()) {
+      const file = files.next();
+      const fileName = file && typeof file.getName === 'function' ? file.getName() : '';
+      const parsed = parseInvoiceFileName_(fileName, targetYmDigits, targetYmHyphen);
+      if (!parsed) continue;
+
+      const pid = dashboardResolvePatientIdFromName_(parsed.patientName, nameToId);
+      if (!pid) {
+        warnings.push(`患者名をIDに紐付けできません: ${parsed.patientName}`);
+        continue;
+      }
+
+      const updated = file && typeof file.getLastUpdated === 'function' ? file.getLastUpdated() : null;
+      const updatedDate = dashboardCoerceDate_(updated);
+      const updatedTs = updatedDate ? updatedDate.getTime() : 0;
+      const current = latestMeta[pid];
+      if (current && current.updatedTs >= updatedTs) continue;
+
+      const url = file && typeof file.getUrl === 'function' ? file.getUrl() : '';
+      latestMeta[pid] = { updatedTs, url };
+      invoices[pid] = url || null;
+    }
+  }
+
+  return { invoices, warnings };
+}
+
+function isTargetInvoiceFolder_(name, targetYmDigits, targetYmKanji) {
+  const trimmed = String(name == null ? '' : name).trim();
+  if (!trimmed) return false;
+  const digitPrefix = targetYmDigits ? targetYmDigits + '請求書_' : '';
+  const kanjiPrefix = targetYmKanji ? targetYmKanji + '請求書_' : '';
+  return (digitPrefix && trimmed.indexOf(digitPrefix) === 0)
+    || (kanjiPrefix && trimmed.indexOf(kanjiPrefix) === 0);
+}
+
+function parseInvoiceFileName_(fileName, targetYmDigits, targetYmHyphen) {
+  const trimmed = String(fileName == null ? '' : fileName).trim();
+  const match = trimmed.match(/^(.+?)_([0-9]{4}-[0-9]{2}|[0-9]{6,8})_請求書\.pdf$/i);
+  if (!match) return null;
+  const rawMonth = match[2];
+  const matchesDigits = targetYmDigits && rawMonth.replace(/[^0-9]/g, '').slice(0, 6) === targetYmDigits;
+  const matchesHyphen = targetYmHyphen && rawMonth === targetYmHyphen;
+  if (!matchesDigits && !matchesHyphen) return null;
+  return { patientName: match[1] };
+}
+
+if (typeof dashboardCoerceDate_ === 'undefined') {
+  function dashboardCoerceDate_(value) {
+    if (value instanceof Date) return value;
+    if (value && typeof value.getTime === 'function') {
+      const ts = value.getTime();
+      if (Number.isFinite(ts)) return new Date(ts);
+    }
+    if (value === null || value === undefined) return null;
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+}
+
+if (typeof dashboardGetInvoiceRootFolder_ === 'undefined') {
+  function dashboardGetInvoiceRootFolder_() {
+    const folderId = typeof INVOICE_PARENT_FOLDER_ID !== 'undefined' ? INVOICE_PARENT_FOLDER_ID : '';
+    if (folderId && typeof DriveApp !== 'undefined' && DriveApp && typeof DriveApp.getFolderById === 'function') {
+      try { return DriveApp.getFolderById(folderId); } catch (e) { /* ignore */ }
+    }
+    return null;
+  }
+}
+
+if (typeof dashboardResolvePatientIdFromName_ === 'undefined') {
+  function dashboardResolvePatientIdFromName_(name, nameToId) {
+    const key = dashboardNormalizeNameKey_(name);
+    return key && nameToId ? nameToId[key] : '';
+  }
+}
+
+if (typeof dashboardNormalizeNameKey_ === 'undefined') {
+  function dashboardNormalizeNameKey_(name) {
+    return String(name == null ? '' : name)
+      .replace(/\s+/g, '')
+      .toLowerCase();
+  }
+}
+
+if (typeof dashboardNormalizePatientId_ === 'undefined') {
+  function dashboardNormalizePatientId_(value) {
+    const raw = value == null ? '' : value;
+    return String(raw).trim();
+  }
+}
+
+if (typeof dashboardResolveTimeZone_ === 'undefined') {
+  function dashboardResolveTimeZone_() {
+    if (typeof Session !== 'undefined' && Session && typeof Session.getScriptTimeZone === 'function') {
+      const tz = Session.getScriptTimeZone();
+      if (tz) return tz;
+    }
+    return 'Asia/Tokyo';
+  }
+}
+
+if (typeof dashboardFormatDate_ === 'undefined') {
+  function dashboardFormatDate_(date, tz, format) {
+    if (typeof Utilities !== 'undefined' && Utilities && typeof Utilities.formatDate === 'function') {
+      try { return Utilities.formatDate(date, tz, format); } catch (e) { /* ignore */ }
+    }
+    if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
+    const iso = date.toISOString();
+    if (format === 'yyyy年MM月') {
+      const y = iso.slice(0, 4);
+      const m = iso.slice(5, 7);
+      return `${y}年${m}月`;
+    }
+    if (format && format.indexOf('HH') >= 0) {
+      return iso.replace('T', ' ').slice(0, 16);
+    }
+    if (format && format.indexOf('-') >= 0) {
+      return iso.slice(0, 10);
+    }
+    return iso.replace(/-/g, '').slice(0, 6);
+  }
+}
+
+if (typeof dashboardWarn_ === 'undefined') {
+  function dashboardWarn_(message) {
+    if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+      try { Logger.log(message); return; } catch (e) { /* ignore */ }
+    }
+    if (typeof console !== 'undefined' && console && typeof console.warn === 'function') {
+      console.warn(message);
+    }
+  }
+}

--- a/tests/dashboardLoadAIReports.test.js
+++ b/tests/dashboardLoadAIReports.test.js
@@ -1,0 +1,89 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const aiReportCode = fs.readFileSync(path.join(__dirname, '../src/dashboard/loadAIReports.js'), 'utf8');
+
+function createSheet(rows) {
+  const headers = ['TS', '患者ID', 'memo'];
+  const data = rows || [];
+  return {
+    getLastRow: () => 1 + data.length,
+    getLastColumn: () => headers.length,
+    getRange: (row, col, numRows, numCols) => {
+      if (row === 1) {
+        return { getDisplayValues: () => [headers.slice(col - 1, col - 1 + numCols)] };
+      }
+      const slice = data.slice(row - 2, row - 2 + numRows).map(r => {
+        const rowData = [];
+        for (let i = 0; i < numCols; i++) {
+          rowData[i] = r[col - 1 + i];
+        }
+        return rowData;
+      });
+      return {
+        getValues: () => slice,
+        getDisplayValues: () => slice
+      };
+    }
+  };
+}
+
+function createAiContext(sheet) {
+  const workbook = {
+    getSheetByName: name => (name === 'AI報告書' ? sheet : null)
+  };
+  const Utilities = {
+    formatDate: (date, tz, format) => {
+      const iso = date.toISOString();
+      if (format === 'yyyy-MM-dd HH:mm') return iso.replace('T', ' ').slice(0, 16);
+      if (format === 'yyyy-MM-dd') return iso.slice(0, 10);
+      return iso;
+    }
+  };
+
+  const context = { console, Utilities, Session: { getScriptTimeZone: () => 'Asia/Tokyo' }, dashboardGetSpreadsheet_: () => workbook };
+  vm.createContext(context);
+  vm.runInContext(aiReportCode, context);
+  return context;
+}
+
+function testLatestReportPerPatientIsReturned() {
+  const sheet = createSheet([
+    [new Date('2025-02-01T00:00:00Z'), '001', 'old'],
+    [new Date('2025-03-05T09:00:00Z'), '001', 'new'],
+    [new Date('2025-01-10T12:00:00Z'), '002', 'other'],
+  ]);
+  const ctx = createAiContext(sheet);
+  const result = ctx.loadAIReports();
+  const reports = Object.assign({}, result.reports);
+
+  assert.deepStrictEqual(reports, {
+    '001': '2025-03-05 09:00',
+    '002': '2025-01-10 12:00'
+  }, '患者ごとに最新TSが取り出される');
+}
+
+function testMissingSheetReturnsWarning() {
+  const workbook = { getSheetByName: () => null };
+  const context = {
+    console,
+    Utilities: { formatDate: () => '' },
+    Session: { getScriptTimeZone: () => 'Asia/Tokyo' },
+    dashboardGetSpreadsheet_: () => workbook
+  };
+  vm.createContext(context);
+  vm.runInContext(aiReportCode, context);
+  const result = context.loadAIReports();
+  const reports = Object.assign({}, result.reports);
+
+  assert.deepStrictEqual(reports, {}, 'シートなしの場合は空オブジェクト');
+  assert.ok(result.warnings.some(w => w.includes('AI報告書')), 'シート欠如の警告が含まれる');
+}
+
+(function run() {
+  testLatestReportPerPatientIsReturned();
+  testMissingSheetReturnsWarning();
+  console.log('dashboardLoadAIReports tests passed');
+})();

--- a/tests/dashboardLoadInvoices.test.js
+++ b/tests/dashboardLoadInvoices.test.js
@@ -1,0 +1,93 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const loadInvoicesCode = fs.readFileSync(path.join(__dirname, '../src/dashboard/loadInvoices.js'), 'utf8');
+
+function createIterator(items) {
+  let idx = 0;
+  return {
+    hasNext: () => idx < items.length,
+    next: () => items[idx++]
+  };
+}
+
+function createFile(name, url, updatedAt) {
+  return {
+    getName: () => name,
+    getUrl: () => url,
+    getLastUpdated: () => updatedAt
+  };
+}
+
+function createFolder(name, files = [], subFolders = []) {
+  return {
+    getName: () => name,
+    getFiles: () => createIterator(files),
+    getFolders: () => createIterator(subFolders)
+  };
+}
+
+function createContext() {
+  const Utilities = {
+    formatDate: (date, tz, format) => {
+      const iso = date.toISOString();
+      if (format === 'yyyy-MM') return iso.slice(0, 7);
+      if (format === 'yyyy年MM月') {
+        const y = iso.slice(0, 4);
+        const m = iso.slice(5, 7);
+        return `${y}年${m}月`;
+      }
+      return iso.replace(/-/g, '').slice(0, 6);
+    }
+  };
+  const context = { console, Utilities, Session: { getScriptTimeZone: () => 'Asia/Tokyo' } };
+  vm.createContext(context);
+  vm.runInContext(loadInvoicesCode, context);
+  return context;
+}
+
+function testLoadsInvoiceLinksForCurrentMonth() {
+  const now = new Date('2025-03-15T00:00:00Z');
+  const files = [
+    createFile('山田太郎_2025-03_請求書.pdf', 'https://example.com/yamada-old', new Date('2025-03-05T00:00:00Z')),
+    createFile('山田太郎_20250312_請求書.pdf', 'https://example.com/yamada-new', new Date('2025-03-12T00:00:00Z')),
+    createFile('田中花子_2025-03_請求書.pdf', 'https://example.com/tanaka', new Date('2025-03-08T00:00:00Z')),
+    createFile('山田太郎_2024-12_請求書.pdf', 'https://example.com/old', new Date('2024-12-01T00:00:00Z'))
+  ];
+  const targetFolder = createFolder('202503請求書_山田', files);
+  const otherFolder = createFolder('202402請求書_佐藤', [
+    createFile('佐藤次郎_2024-02_請求書.pdf', 'https://example.com/sato', new Date('2024-02-10T00:00:00Z'))
+  ]);
+  const rootFolder = createFolder('root', [], [targetFolder, otherFolder]);
+
+  const patientInfo = {
+    patients: {
+      '001': { name: '山田太郎' },
+      '002': { name: '田中花子' },
+      '003': { name: '未作成患者' }
+    },
+    nameToId: {
+      '山田太郎': '001',
+      '田中花子': '002'
+    },
+    warnings: []
+  };
+
+  const ctx = createContext();
+  const result = ctx.loadInvoices({ patientInfo, rootFolder, now });
+  const invoices = Object.assign({}, result.invoices);
+
+  assert.deepStrictEqual(invoices, {
+    '001': 'https://example.com/yamada-new',
+    '002': 'https://example.com/tanaka',
+    '003': null
+  }, '当月フォルダのPDFを患者IDに紐付け、最新のものを選択する');
+  assert.strictEqual(result.warnings.length, 0, '警告は発生しない');
+}
+
+(function run() {
+  testLoadsInvoiceLinksForCurrentMonth();
+  console.log('dashboardLoadInvoices tests passed');
+})();


### PR DESCRIPTION
## Summary
- add an AI report loader that reads the latest TS per patient from the AI報告書 sheet
- implement invoice PDF discovery for the current month, mapping patient names to IDs and selecting the newest file per patient
- cover both loaders with node-based unit tests

## Testing
- node tests/dashboardLoadAIReports.test.js
- node tests/dashboardLoadInvoices.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dfa91db388321b598d39bdf6bed76)