### PR TITLE
Add unread tracking and caching for dashboard data

### DIFF
--- a/src/dashboard/cacheUtils.js
+++ b/src/dashboard/cacheUtils.js
@@ -1,0 +1,61 @@
+/**
+ * ダッシュボード用のシンプルなキャッシュユーティリティ。
+ * CacheService が利用可能な場合のみ動作し、利用できない場合は透過的にバイパスする。
+ */
+const DASHBOARD_CACHE_TTL_SECONDS = 60 * 60 * 12; // 12h
+
+function dashboardGetCache_() {
+  if (typeof CacheService === 'undefined' || !CacheService || typeof CacheService.getScriptCache !== 'function') return null;
+  try {
+    return CacheService.getScriptCache();
+  } catch (e) {
+    dashboardWarn_('[dashboardGetCache] unavailable: ' + (e && e.message ? e.message : e));
+    return null;
+  }
+}
+
+function dashboardCacheFetch_(key, fetchFn, ttlSeconds) {
+  const cache = dashboardGetCache_();
+  const ttl = Math.max(5, ttlSeconds || DASHBOARD_CACHE_TTL_SECONDS);
+  if (!cache || !key || typeof fetchFn !== 'function') {
+    return typeof fetchFn === 'function' ? fetchFn() : null;
+  }
+
+  try {
+    const hit = cache.get(key);
+    if (hit) {
+      return JSON.parse(hit);
+    }
+  } catch (e) {
+    dashboardWarn_('[dashboardCacheFetch] failed to read: ' + (e && e.message ? e.message : e));
+  }
+
+  const fresh = fetchFn();
+  try {
+    cache.put(key, JSON.stringify(fresh), ttl);
+  } catch (e) {
+    dashboardWarn_('[dashboardCacheFetch] failed to write: ' + (e && e.message ? e.message : e));
+  }
+  return fresh;
+}
+
+function dashboardCacheInvalidate_(key) {
+  const cache = dashboardGetCache_();
+  if (!cache || !key || typeof cache.remove !== 'function') return;
+  try {
+    cache.remove(key);
+  } catch (e) {
+    dashboardWarn_('[dashboardCacheInvalidate] failed: ' + (e && e.message ? e.message : e));
+  }
+}
+
+if (typeof dashboardWarn_ === 'undefined') {
+  function dashboardWarn_(message) {
+    if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+      try { Logger.log(message); return; } catch (e) { /* ignore */ }
+    }
+    if (typeof console !== 'undefined' && console && typeof console.warn === 'function') {
+      console.warn(message);
+    }
+  }
+}

--- a/src/dashboard/loadAIReports.js
+++ b/src/dashboard/loadAIReports.js
@@ -2,7 +2,14 @@
  * AI報告書シートから患者ごとの最終発行日時を取得する。
  * @return {{reports: Object<string, string>, warnings: string[]}}
  */
-function loadAIReports() {
+function loadAIReports(options) {
+  const opts = options || {};
+  const fetchFn = () => loadAIReportsUncached_();
+  if (opts && opts.cache === false) return fetchFn();
+  return dashboardCacheFetch_('dashboard:aiReports:v1', fetchFn, DASHBOARD_CACHE_TTL_SECONDS);
+}
+
+function loadAIReportsUncached_() {
   const reports = {};
   const warnings = [];
 

--- a/src/dashboard/loadPatientInfo.js
+++ b/src/dashboard/loadPatientInfo.js
@@ -1,7 +1,14 @@
 /**
  * 患者情報シートを読み込み、患者IDを主キーとした情報と氏名マッピングを返す。
  */
-function loadPatientInfo() {
+function loadPatientInfo(options) {
+  const opts = options || {};
+  const fetchFn = () => loadPatientInfoUncached_(opts);
+  if (opts && opts.cache === false) return fetchFn();
+  return dashboardCacheFetch_('dashboard:patientInfo:v1', fetchFn, DASHBOARD_CACHE_TTL_SECONDS);
+}
+
+function loadPatientInfoUncached_(_options) {
   const patients = {};
   const nameToId = {};
   const warnings = [];

--- a/src/dashboard/markAsRead.js
+++ b/src/dashboard/markAsRead.js
@@ -1,0 +1,64 @@
+/**
+ * 患者カード展開時に最終既読日時を更新する。
+ * @param {string|Object} patientIdOrPayload - 患者ID、または { patientId, email, readAt } を含むオブジェクト。
+ * @param {string} [email]
+ * @param {Date|string} [readAt]
+ * @return {{ ok: boolean, patientId: string|null, readAt: string|null, reason?: string }}
+ */
+function markAsRead(patientIdOrPayload, email, readAt) {
+  const payload = typeof patientIdOrPayload === 'object' && patientIdOrPayload
+    ? patientIdOrPayload
+    : { patientId: patientIdOrPayload, email, readAt };
+
+  const pid = dashboardNormalizePatientId_(payload.patientId);
+  const normalizedEmail = dashboardNormalizeEmail_(payload.email || getActiveUserEmail_());
+  const ts = payload.readAt || new Date();
+
+  if (!pid) {
+    return { ok: false, patientId: null, readAt: null, reason: 'patientId required' };
+  }
+
+  const ok = updateHandoverLastRead(pid, ts, normalizedEmail);
+  return { ok: !!ok, patientId: pid, readAt: ok ? dashboardCoerceDate_(ts).toISOString() : null };
+}
+
+function getActiveUserEmail_() {
+  if (typeof Session !== 'undefined' && Session && typeof Session.getActiveUser === 'function') {
+    try {
+      const user = Session.getActiveUser();
+      if (user && typeof user.getEmail === 'function') {
+        const email = user.getEmail();
+        if (email) return email;
+      }
+    } catch (e) { /* ignore */ }
+  }
+  return '';
+}
+
+if (typeof dashboardNormalizePatientId_ === 'undefined') {
+  function dashboardNormalizePatientId_(value) {
+    const raw = value == null ? '' : value;
+    return String(raw).trim();
+  }
+}
+
+if (typeof dashboardNormalizeEmail_ === 'undefined') {
+  function dashboardNormalizeEmail_(email) {
+    const raw = email == null ? '' : email;
+    const normalized = String(raw).trim().toLowerCase();
+    return normalized || '';
+  }
+}
+
+if (typeof dashboardCoerceDate_ === 'undefined') {
+  function dashboardCoerceDate_(value) {
+    if (value instanceof Date) return value;
+    if (value && typeof value.getTime === 'function') {
+      const ts = value.getTime();
+      if (Number.isFinite(ts)) return new Date(ts);
+    }
+    if (value === null || value === undefined) return null;
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+}

--- a/tests/dashboardReadAndCache.test.js
+++ b/tests/dashboardReadAndCache.test.js
@@ -1,0 +1,102 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+function loadDashboardScripts(ctx, files) {
+  files.forEach(file => {
+    const code = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', file), 'utf8');
+    vm.runInContext(code, ctx);
+  });
+}
+
+function createBaseContext() {
+  const cacheStore = {};
+  const propertyStore = {
+    data: {},
+    getProperty(key) { return this.data[key] || null; },
+    setProperty(key, value) { this.data[key] = value; }
+  };
+
+  const ctx = {
+    console,
+    CacheService: {
+      getScriptCache: () => ({
+        get: key => cacheStore[key] || null,
+        put: (key, value) => { cacheStore[key] = value; },
+        remove: key => { delete cacheStore[key]; }
+      })
+    },
+    PropertiesService: {
+      getScriptProperties: () => propertyStore
+    },
+    cacheStore,
+    propertyStore,
+    dashboardWarn_: () => {},
+    dashboardResolveTimeZone_: () => 'Asia/Tokyo'
+  };
+
+  vm.createContext(ctx);
+  return ctx;
+}
+
+function createNotesContext() {
+  const ctx = createBaseContext();
+  const values = [
+    [new Date('2025-01-02T09:00:00Z'), 'P001', 'author1', 'latest note'],
+    [new Date('2024-12-31T00:00:00Z'), 'P002', 'author2', 'old note']
+  ];
+  const displays = values.map(row => row.map(cell => cell instanceof Date ? cell.toISOString() : cell));
+  let rangeCalls = 0;
+  const sheet = {
+    getLastRow: () => values.length + 1,
+    getLastColumn: () => 5,
+    getRange: () => {
+      rangeCalls++;
+      return {
+        getValues: () => values,
+        getDisplayValues: () => displays
+      };
+    }
+  };
+  ctx.dashboardGetSpreadsheet_ = () => ({ getSheetByName: () => sheet });
+  ctx.rangeCalls = () => rangeCalls;
+  loadDashboardScripts(ctx, ['cacheUtils.js', 'loadNotes.js', 'markAsRead.js']);
+  return ctx;
+}
+
+function testMarkAsReadStoresPerUser() {
+  const ctx = createBaseContext();
+  loadDashboardScripts(ctx, ['cacheUtils.js', 'loadNotes.js', 'markAsRead.js']);
+  const ts = new Date('2025-01-01T00:00:00Z');
+
+  const res = ctx.markAsRead('P001', 'User@example.com', ts);
+  assert.strictEqual(res.ok, true);
+  const stored = JSON.parse(ctx.propertyStore.getProperty('HANDOVER_LAST_READ'));
+  assert.strictEqual(stored.P001['user@example.com'], ts.toISOString());
+}
+
+function testLoadNotesUsesCacheAndUpdatesUnreadByUser() {
+  const ctx = createNotesContext();
+  ctx.propertyStore.setProperty('HANDOVER_LAST_READ', JSON.stringify({
+    P001: { 'user@example.com': '2025-01-02T12:00:00.000Z' }
+  }));
+
+  const first = ctx.loadNotes({ email: 'user@example.com' });
+  assert.strictEqual(ctx.rangeCalls(), 2, 'should read sheet once (values + display)');
+  assert.strictEqual(first.notes.P001.unread, false, 'latest note is older than last read');
+
+  // update lastRead to older timestamp -> unread should flip, without additional sheet reads
+  ctx.propertyStore.setProperty('HANDOVER_LAST_READ', JSON.stringify({
+    P001: { 'user@example.com': '2024-12-30T00:00:00.000Z' }
+  }));
+
+  const second = ctx.loadNotes({ email: 'user@example.com' });
+  assert.strictEqual(ctx.rangeCalls(), 2, 'cache should prevent extra sheet reads');
+  assert.strictEqual(second.notes.P001.unread, true, 'note should become unread when lastRead is older');
+}
+
+testMarkAsReadStoresPerUser();
+testLoadNotesUsesCacheAndUpdatesUnreadByUser();
+
+console.log('dashboard read/cache tests passed');


### PR DESCRIPTION
## Summary
- add dashboard cache utilities and apply 12h caching to patient info, AI reports, and notes
- track per-user handover read timestamps and expose a markAsRead API for dashboard cards
- add regression tests covering unread detection and cache reuse

## Testing
- node tests/dashboardReadAndCache.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e638ffbe083219562b9c8d6c1def4)