### PR TITLE
Add skip reason summary to bank transfer export

### DIFF
--- a/src/dashboard/loadAIReports.js
+++ b/src/dashboard/loadAIReports.js
@@ -74,6 +74,17 @@ if (typeof dashboardGetSpreadsheet_ === 'undefined') {
   }
 }
 
+if (typeof DASHBOARD_CACHE_TTL_SECONDS === 'undefined') {
+  var DASHBOARD_CACHE_TTL_SECONDS = 60 * 60 * 12;
+}
+
+if (typeof dashboardCacheFetch_ === 'undefined') {
+  function dashboardCacheFetch_(cacheKey, fetchFn) {
+    if (typeof fetchFn === 'function') return fetchFn();
+    return null;
+  }
+}
+
 if (typeof dashboardParseTimestamp_ === 'undefined') {
   function dashboardParseTimestamp_(value) {
     if (value instanceof Date) return value;


### PR DESCRIPTION
## Summary
- count bank transfer export skip reasons and include them in the message when no rows are produced
- cover the new skip reason reporting with tests for invalid bank data scenarios
- add default cache helpers to the AI report loader so it can run in isolation

## Testing
- for f in tests/*.test.js; do node $f; done

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e65cb9ec08321bc8122af3acfb72f)