### PR TITLE
Add dashboard data API endpoint

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -9587,6 +9587,12 @@ function ensureIntakeScaffolding_() {
 /***** ── 差し替え：doGet ──*****/
 function doGet(e) {
   e = e || {};
+
+  if (shouldHandleDashboardApi_(e)) {
+    const data = getDashboardData();
+    return createJsonResponse_(data);
+  }
+
   const view = e.parameter ? (e.parameter.view || 'welcome') : 'welcome';
   let templateFile = '';
 
@@ -9626,6 +9632,24 @@ function doGet(e) {
   return t.evaluate()
            .setTitle('受付アプリ')
            .addMetaTag('viewport','width=device-width, initial-scale=1.0');
+}
+
+function shouldHandleDashboardApi_(e) {
+  const path = (e && e.pathInfo ? String(e.pathInfo) : '').replace(/^\/+|\/+$/g, '').toLowerCase();
+  if (path === 'getdashboarddata') return true;
+  const action = e && e.parameter ? (e.parameter.action || e.parameter.api) : '';
+  return String(action || '').toLowerCase() === 'getdashboarddata';
+}
+
+function createJsonResponse_(payload) {
+  if (typeof ContentService === 'undefined' || !ContentService || typeof ContentService.createTextOutput !== 'function') {
+    return JSON.stringify(payload || {});
+  }
+  const output = ContentService.createTextOutput(JSON.stringify(payload || {}));
+  if (output && typeof output.setMimeType === 'function' && ContentService && ContentService.MimeType) {
+    output.setMimeType(ContentService.MimeType.JSON);
+  }
+  return output;
 }
 
 function notifyChat_(message){

--- a/src/dashboard/getDashboardData.js
+++ b/src/dashboard/getDashboardData.js
@@ -1,0 +1,192 @@
+/**
+ * ダッシュボードの主要データをまとめて取得し、JSON 形式で返す。
+ * エラーが発生した場合は meta.error にメッセージを格納する。
+ *
+ * @param {Object} [options]
+ * @param {Object} [options.patientInfo] - 事前に取得した患者情報を差し込む場合に利用。
+ * @param {Object} [options.notes] - 申し送りデータを差し込む場合に利用。
+ * @param {Object} [options.aiReports] - AI報告書データを差し込む場合に利用。
+ * @param {Object} [options.invoices] - 請求書リンクデータを差し込む場合に利用。
+ * @param {Object} [options.treatmentLogs] - 施術録データを差し込む場合に利用。
+ * @param {Object} [options.responsible] - 担当者マッピングを差し込む場合に利用。
+ * @param {Object} [options.tasksResult] - タスク抽出結果を差し込む場合に利用。
+ * @param {Object} [options.visitsResult] - 今日の訪問抽出結果を差し込む場合に利用。
+ * @param {Object<string, boolean>} [options.invoiceConfirmations] - 請求書確認フラグを直接指定する場合に利用。
+ * @param {Date} [options.now] - テスト用に現在日時を差し替え。
+ * @param {string} [options.user] - セッションユーザーを明示的に指定する場合に利用。
+ * @return {{tasks: Object[], todayVisits: Object[], patients: Object[], warnings: string[], meta: Object}}
+ */
+function getDashboardData(options) {
+  const opts = options || {};
+  const meta = {
+    generatedAt: dashboardFormatDate_(new Date(), dashboardResolveTimeZone_(), "yyyy-MM-dd'T'HH:mm:ssXXX") || new Date().toISOString(),
+    user: opts.user || dashboardResolveUser_()
+  };
+
+  try {
+    const patientInfo = opts.patientInfo || (typeof loadPatientInfo === 'function' ? loadPatientInfo() : { patients: {}, nameToId: {}, warnings: [] });
+    const notes = opts.notes || (typeof loadNotes === 'function' ? loadNotes({ email: meta.user }) : { notes: {}, warnings: [] });
+    const aiReports = opts.aiReports || (typeof loadAIReports === 'function' ? loadAIReports() : { reports: {}, warnings: [] });
+    const invoices = opts.invoices || (typeof loadInvoices === 'function' ? loadInvoices({ patientInfo }) : { invoices: {}, warnings: [] });
+    const treatmentLogs = opts.treatmentLogs || (typeof loadTreatmentLogs === 'function' ? loadTreatmentLogs({ patientInfo }) : { logs: [], warnings: [] });
+    const responsible = opts.responsible || (typeof assignResponsibleStaff === 'function' ? assignResponsibleStaff({ patientInfo, treatmentLogs }) : { responsible: {}, warnings: [] });
+
+    const tasksResult = opts.tasksResult || (typeof getTasks === 'function' ? getTasks({
+      patientInfo,
+      notes,
+      aiReports,
+      invoiceConfirmations: opts.invoiceConfirmations,
+      now: opts.now
+    }) : { tasks: [], warnings: [] });
+
+    const visitsResult = opts.visitsResult || (typeof getTodayVisits === 'function' ? getTodayVisits({
+      treatmentLogs,
+      notes,
+      now: opts.now
+    }) : { visits: [], warnings: [] });
+
+    const patients = buildDashboardPatients_(patientInfo, {
+      notes,
+      aiReports,
+      invoices,
+      responsible,
+      treatmentLogs
+    });
+
+    const warnings = collectDashboardWarnings_([
+      patientInfo,
+      notes,
+      aiReports,
+      invoices,
+      treatmentLogs,
+      responsible,
+      tasksResult,
+      visitsResult
+    ]);
+
+    return {
+      tasks: tasksResult && tasksResult.tasks ? tasksResult.tasks : [],
+      todayVisits: visitsResult && visitsResult.visits ? visitsResult.visits : [],
+      patients,
+      warnings,
+      meta
+    };
+  } catch (err) {
+    meta.error = err && err.message ? err.message : String(err);
+    return { tasks: [], todayVisits: [], patients: [], warnings: [], meta };
+  }
+}
+
+function buildDashboardPatients_(patientInfo, sources) {
+  const patients = [];
+  const basePatients = patientInfo && patientInfo.patients ? patientInfo.patients : {};
+  const notes = sources && sources.notes && sources.notes.notes ? sources.notes.notes : {};
+  const aiReports = sources && sources.aiReports && sources.aiReports.reports ? sources.aiReports.reports : {};
+  const invoices = sources && sources.invoices && sources.invoices.invoices ? sources.invoices.invoices : {};
+  const responsible = sources && sources.responsible && sources.responsible.responsible ? sources.responsible.responsible : {};
+
+  const seen = new Set();
+  const addPatient = (pid, payload) => {
+    const patientId = dashboardNormalizePatientId_(pid);
+    if (!patientId || seen.has(patientId)) return;
+    seen.add(patientId);
+
+    const base = payload || {};
+    const entry = {
+      patientId,
+      name: base.name || base.patientName || '',
+      consentExpiry: base.consentExpiry || (base.raw && (base.raw['同意期限'] || base.raw['同意有効期限'])) || '',
+      responsible: Object.prototype.hasOwnProperty.call(responsible, patientId) ? responsible[patientId] : null,
+      invoiceUrl: Object.prototype.hasOwnProperty.call(invoices, patientId) ? invoices[patientId] : null,
+      aiReportAt: Object.prototype.hasOwnProperty.call(aiReports, patientId) ? aiReports[patientId] : null,
+      note: normalizeDashboardNote_(notes[patientId], patientId)
+    };
+    patients.push(entry);
+  };
+
+  Object.keys(basePatients).forEach(pid => addPatient(pid, basePatients[pid]));
+
+  const additionalIds = new Set([
+    ...Object.keys(notes || {}),
+    ...Object.keys(aiReports || {}),
+    ...Object.keys(invoices || {}),
+    ...Object.keys(responsible || {})
+  ]);
+  additionalIds.forEach(pid => {
+    if (!pid || Object.prototype.hasOwnProperty.call(basePatients, pid)) return;
+    addPatient(pid, {});
+  });
+
+  return patients;
+}
+
+function normalizeDashboardNote_(note, patientId) {
+  if (!note) return null;
+  return {
+    patientId: patientId || note.patientId || '',
+    preview: note.preview || '',
+    when: note.when || '',
+    unread: !!note.unread,
+    lastReadAt: note.lastReadAt || '',
+    authorEmail: note.authorEmail || '',
+    row: note.row || null
+  };
+}
+
+function collectDashboardWarnings_(results) {
+  const warnings = [];
+  (results || []).forEach(entry => {
+    if (entry && Array.isArray(entry.warnings)) {
+      warnings.push.apply(warnings, entry.warnings);
+    }
+  });
+  return warnings;
+}
+
+function dashboardResolveUser_() {
+  if (typeof Session !== 'undefined' && Session && typeof Session.getActiveUser === 'function') {
+    try {
+      const email = Session.getActiveUser().getEmail();
+      if (email) return String(email).trim();
+    } catch (e) { /* ignore */ }
+  }
+  return '';
+}
+
+if (typeof dashboardNormalizePatientId_ === 'undefined') {
+  function dashboardNormalizePatientId_(value) { // eslint-disable-line no-inner-declarations
+    const raw = value == null ? '' : value;
+    return String(raw).trim();
+  }
+}
+
+if (typeof dashboardResolveTimeZone_ === 'undefined') {
+  function dashboardResolveTimeZone_() { // eslint-disable-line no-inner-declarations
+    if (typeof Session !== 'undefined' && Session && typeof Session.getScriptTimeZone === 'function') {
+      const tz = Session.getScriptTimeZone();
+      if (tz) return tz;
+    }
+    return 'Asia/Tokyo';
+  }
+}
+
+if (typeof dashboardFormatDate_ === 'undefined') {
+  function dashboardFormatDate_(date, tz, format) { // eslint-disable-line no-inner-declarations
+    if (typeof Utilities !== 'undefined' && Utilities && typeof Utilities.formatDate === 'function') {
+      try { return Utilities.formatDate(date, tz, format); } catch (e) { /* ignore */ }
+    }
+    if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
+    return date.toISOString();
+  }
+}
+
+if (typeof dashboardWarn_ === 'undefined') {
+  function dashboardWarn_(message) { // eslint-disable-line no-inner-declarations
+    if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+      try { Logger.log(message); return; } catch (e) { /* ignore */ }
+    }
+    if (typeof console !== 'undefined' && console && typeof console.warn === 'function') {
+      console.warn(message);
+    }
+  }
+}

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -1,0 +1,100 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const dashboardCode = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'getDashboardData.js'), 'utf8');
+
+function createContext(overrides = {}) {
+  const context = {
+    console,
+    JSON,
+    Date,
+    Set,
+    Utilities: {
+      formatDate: (date, _tz, _fmt) => date.toISOString()
+    },
+    Session: {
+      getScriptTimeZone: () => 'Asia/Tokyo',
+      getActiveUser: () => ({ getEmail: () => overrides.activeEmail || 'session@example.com' })
+    }
+  };
+  Object.assign(context, overrides);
+  vm.createContext(context);
+  vm.runInContext(dashboardCode, context);
+  return context;
+}
+
+function testAggregatesDashboardData() {
+  const patientInfo = {
+    patients: { '001': { name: '山田太郎', consentExpiry: '2025-01-31' } },
+    warnings: ['p1']
+  };
+  const notes = {
+    notes: { '001': { preview: '最新メモ', when: '2025-02-01', unread: true, authorEmail: 'note@example.com', lastReadAt: '2025-01-01T00:00:00Z', row: 5 } },
+    warnings: ['n1']
+  };
+  const aiReports = { reports: { '001': '2025-01-15 10:00' }, warnings: ['a1'] };
+  const invoices = { invoices: { '001': 'https://example.com/invoice.pdf' }, warnings: ['i1'] };
+  const treatmentLogs = { logs: [], warnings: ['t1'] };
+  const responsible = { responsible: { '001': 'staff@example.com' }, warnings: ['r1'] };
+  const tasksResult = { tasks: [{ type: 'consentWarning', patientId: '001' }], warnings: ['task'] };
+  const visitsResult = { visits: [{ patientId: '001', time: '10:00' }], warnings: ['visit'] };
+
+  const ctx = createContext();
+  const result = ctx.getDashboardData({
+    user: 'user@example.com',
+    patientInfo,
+    notes,
+    aiReports,
+    invoices,
+    treatmentLogs,
+    responsible,
+    tasksResult,
+    visitsResult
+  });
+
+  assert.strictEqual(result.meta.user, 'user@example.com');
+  assert.ok(result.meta.generatedAt, 'generatedAt should be present');
+  assert.deepStrictEqual(result.tasks, tasksResult.tasks);
+  assert.deepStrictEqual(result.todayVisits, visitsResult.visits);
+  assert.strictEqual(result.patients.length, 1);
+  const normalizedPatient = JSON.parse(JSON.stringify(result.patients[0]));
+  assert.deepStrictEqual(normalizedPatient, {
+    patientId: '001',
+    name: '山田太郎',
+    consentExpiry: '2025-01-31',
+    responsible: 'staff@example.com',
+    invoiceUrl: 'https://example.com/invoice.pdf',
+    aiReportAt: '2025-01-15 10:00',
+    note: {
+      patientId: '001',
+      preview: '最新メモ',
+      when: '2025-02-01',
+      unread: true,
+      lastReadAt: '2025-01-01T00:00:00Z',
+      authorEmail: 'note@example.com',
+      row: 5
+    }
+  });
+  const warnings = JSON.parse(JSON.stringify(result.warnings)).sort();
+  assert.deepStrictEqual(warnings, ['a1', 'i1', 'n1', 'p1', 'r1', 't1', 'task', 'visit'].sort());
+}
+
+function testErrorIsCapturedInMeta() {
+  const ctx = createContext({
+    loadPatientInfo: () => { throw new Error('boom'); }
+  });
+
+  const result = ctx.getDashboardData();
+  assert.strictEqual(result.tasks.length, 0);
+  assert.strictEqual(result.todayVisits.length, 0);
+  assert.strictEqual(result.patients.length, 0);
+  assert.ok(result.meta.error && result.meta.error.indexOf('boom') >= 0);
+}
+
+(function run() {
+  testAggregatesDashboardData();
+  testErrorIsCapturedInMeta();
+  console.log('dashboardGetDashboardData tests passed');
+})();


### PR DESCRIPTION
## Summary
- add a `getDashboardData` aggregator that combines cached loaders, tasks, visits, and metadata for dashboard consumption
- expose the dashboard data as a JSON response when `/getDashboardData` is requested via `doGet`
- add coverage to verify aggregation output and error handling

## Testing
- `for f in tests/*.test.js; do echo "Running $f"; node "$f"; done`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e6c45dd8c8321bc5b6faadc7e31f8)