### PR TITLE
Add dashboard UI consuming getDashboardData

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -9609,6 +9609,7 @@ function doGet(e) {
     case 'payroll':      templateFile = 'payroll'; break;
     case 'payroll_pdf_family': templateFile = 'payroll_pdf_family'; break;
     case 'billing':      templateFile = 'billing'; break;
+    case 'dashboard':    templateFile = 'dashboard'; break;
     case 'record':       templateFile = 'app'; break;   // ★ app.html を record として表示
     case 'report':       templateFile = 'report'; break;
     default:             templateFile = 'welcome'; break;

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -1,0 +1,472 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>施術者ダッシュボード</title>
+<style>
+  :root{
+    --bg:#0b1524;
+    --card:#0f172a;
+    --panel:#111827;
+    --border:rgba(255,255,255,0.08);
+    --text:#e5e7eb;
+    --muted:#9ca3af;
+    --accent:#38bdf8;
+    --warning:#f59e0b;
+    --critical:#ef4444;
+    --success:#10b981;
+  }
+  *{ box-sizing:border-box; }
+  body{ margin:0; font-family:system-ui,-apple-system,"Segoe UI","Noto Sans JP",sans-serif; background:var(--bg); color:var(--text); }
+  a{ color:var(--accent); }
+  .page{ max-width:1080px; margin:0 auto; padding:20px 16px 64px; display:flex; flex-direction:column; gap:18px; }
+  header{ display:flex; align-items:center; gap:12px; flex-wrap:wrap; }
+  h1{ margin:0; font-size:1.4rem; letter-spacing:0.02em; }
+  .pill{ display:inline-flex; align-items:center; gap:6px; padding:6px 12px; border-radius:999px; background:var(--panel); border:1px solid var(--border); color:var(--muted); font-size:0.9rem; }
+  .tag{ display:inline-flex; align-items:center; gap:6px; padding:4px 10px; border-radius:999px; font-size:0.85rem; background:rgba(56,189,248,0.12); color:var(--accent); }
+  button{ appearance:none; border:0; border-radius:10px; padding:10px 14px; background:var(--accent); color:#0b1524; font-weight:700; cursor:pointer; box-shadow:0 10px 28px rgba(56,189,248,0.25); transition:transform .15s ease, opacity .15s ease; }
+  button:hover{ transform:translateY(-1px); }
+  button:disabled{ opacity:0.6; cursor:not-allowed; box-shadow:none; transform:none; }
+  .muted{ color:var(--muted); font-size:0.9rem; }
+  .grid{ display:grid; gap:12px; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); }
+  .card{ background:var(--card); border:1px solid var(--border); border-radius:16px; padding:14px 16px; box-shadow:0 18px 48px rgba(0,0,0,0.28); }
+  .section{ display:flex; flex-direction:column; gap:12px; }
+  .section h2{ margin:0; font-size:1.1rem; letter-spacing:0.01em; }
+  .section-header{ display:flex; align-items:center; gap:10px; }
+  .small{ font-size:0.82rem; color:var(--muted); }
+  .task-card{ display:flex; flex-direction:column; gap:6px; border-left:4px solid var(--border); padding-left:12px; }
+  .task-card.warning{ border-color:var(--warning); }
+  .task-card.critical{ border-color:var(--critical); }
+  .task-meta{ display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+  .severity-dot{ width:10px; height:10px; border-radius:50%; background:var(--muted); }
+  .severity-dot.warning{ background:var(--warning); }
+  .severity-dot.critical{ background:var(--critical); }
+  .timeline{ display:flex; flex-direction:column; gap:10px; }
+  .visit{ display:grid; grid-template-columns:70px 1fr; gap:10px; align-items:center; padding:10px 12px; border-radius:12px; border:1px solid var(--border); background:var(--panel); }
+  .visit-time{ font-variant-numeric:tabular-nums; color:#fff; font-weight:700; }
+  .visit-body{ display:flex; flex-direction:column; gap:4px; }
+  .badge{ display:inline-flex; align-items:center; gap:4px; padding:4px 8px; border-radius:8px; background:rgba(255,255,255,0.06); border:1px solid var(--border); font-size:0.85rem; color:var(--muted); }
+  .badge.success{ background:rgba(16,185,129,0.14); color:var(--success); border-color:rgba(16,185,129,0.28); }
+  .badge.warn{ background:rgba(245,158,11,0.12); color:var(--warning); border-color:rgba(245,158,11,0.32); }
+  details.patient{ border:1px solid var(--border); border-radius:16px; overflow:hidden; background:var(--panel); box-shadow:0 18px 38px rgba(0,0,0,0.22); }
+  details.patient summary{ list-style:none; cursor:pointer; padding:12px 14px; display:flex; flex-direction:column; gap:8px; }
+  details.patient summary::-webkit-details-marker{ display:none; }
+  .patient-header{ display:flex; justify-content:space-between; gap:10px; align-items:center; }
+  .patient-name{ font-weight:700; letter-spacing:0.01em; }
+  .patient-body{ border-top:1px solid var(--border); padding:12px 14px 14px; display:flex; flex-direction:column; gap:8px; background:rgba(255,255,255,0.02); }
+  .meta-row{ display:flex; flex-wrap:wrap; gap:8px; align-items:center; color:var(--muted); font-size:0.9rem; }
+  .note-preview{ background:rgba(56,189,248,0.06); border:1px solid rgba(56,189,248,0.22); border-radius:12px; padding:10px 12px; font-size:0.95rem; color:#e0f2fe; }
+  .warning-list{ display:flex; flex-direction:column; gap:6px; }
+  .warning-item{ padding:8px 10px; border-radius:10px; background:rgba(239,68,68,0.14); border:1px solid rgba(239,68,68,0.25); color:#fecdd3; font-size:0.92rem; }
+  .error-box{ padding:12px 14px; border-radius:12px; background:rgba(239,68,68,0.14); border:1px solid rgba(239,68,68,0.3); color:#fecdd3; }
+  .loading{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; background:rgba(11,21,36,0.72); z-index:20; }
+  .loading.hidden{ display:none; }
+  .spinner{ width:40px; height:40px; border-radius:50%; border:4px solid rgba(56,189,248,0.3); border-top-color:var(--accent); animation:spin 0.8s linear infinite; }
+  @keyframes spin{ to{ transform:rotate(360deg); } }
+  @media (max-width:640px){
+    .visit{ grid-template-columns:60px 1fr; }
+    header{ align-items:flex-start; }
+  }
+</style>
+</head>
+<body>
+<div class="page">
+  <header>
+    <h1>施術者ダッシュボード</h1>
+    <span class="pill" id="metaUser">-</span>
+    <span class="pill" id="metaTs">-</span>
+    <button id="refreshBtn">最新の情報を取得</button>
+  </header>
+
+  <div id="errorBox" class="error-box" style="display:none;"></div>
+
+  <div class="section">
+    <div class="section-header">
+      <h2>要注意タスク</h2>
+      <span class="small" id="taskCount"></span>
+    </div>
+    <div class="grid" id="taskList"></div>
+  </div>
+
+  <div class="section">
+    <div class="section-header">
+      <h2>今日・昨日の訪問</h2>
+      <span class="small">タイムライン</span>
+    </div>
+    <div class="timeline" id="visitList"></div>
+  </div>
+
+  <div class="section">
+    <div class="section-header">
+      <h2>担当患者一覧</h2>
+      <span class="small" id="patientCount"></span>
+    </div>
+    <div class="warning-list" id="warningList"></div>
+    <div class="section" id="patientList"></div>
+  </div>
+</div>
+
+<div class="loading hidden" id="loading">
+  <div class="spinner"></div>
+</div>
+
+<script>
+const dashboardState = {
+  loading: true,
+  data: null,
+  error: '',
+  marking: new Set()
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  const refreshBtn = document.getElementById('refreshBtn');
+  refreshBtn.addEventListener('click', fetchDashboardData);
+  fetchDashboardData();
+});
+
+function fetchDashboardData() {
+  setLoading(true);
+  dashboardState.error = '';
+
+  const onSuccess = (payload) => {
+    dashboardState.data = payload || {};
+    setLoading(false);
+    renderAll();
+  };
+  const onFailure = (err) => {
+    dashboardState.error = err && err.message ? err.message : String(err || '不明なエラー');
+    setLoading(false);
+    renderAll();
+  };
+
+  const runner = typeof google !== 'undefined' && google.script && google.script.run;
+  if (runner && typeof runner.getDashboardData === 'function') {
+    runner.withSuccessHandler(onSuccess).withFailureHandler(onFailure).getDashboardData();
+    return;
+  }
+
+  const url = (typeof baseUrl !== 'undefined' ? baseUrl : '') + '?action=getDashboardData';
+  fetch(url)
+    .then(res => res.json())
+    .then(onSuccess)
+    .catch(onFailure);
+}
+
+function setLoading(flag) {
+  dashboardState.loading = !!flag;
+  const overlay = document.getElementById('loading');
+  if (!overlay) return;
+  overlay.classList.toggle('hidden', !dashboardState.loading);
+  const refreshBtn = document.getElementById('refreshBtn');
+  if (refreshBtn) refreshBtn.disabled = dashboardState.loading;
+}
+
+function renderAll() {
+  renderMeta();
+  renderWarnings();
+  renderTasks();
+  renderVisits();
+  renderPatients();
+  renderError();
+}
+
+function renderMeta() {
+  const meta = dashboardState.data && dashboardState.data.meta ? dashboardState.data.meta : {};
+  document.getElementById('metaUser').textContent = meta.user ? `ログイン: ${meta.user}` : 'ログイン情報なし';
+  document.getElementById('metaTs').textContent = meta.generatedAt ? `生成: ${meta.generatedAt}` : '生成時刻不明';
+}
+
+function renderError() {
+  const box = document.getElementById('errorBox');
+  if (!box) return;
+  if (dashboardState.error) {
+    box.textContent = dashboardState.error;
+    box.style.display = 'block';
+    return;
+  }
+  const metaError = dashboardState.data && dashboardState.data.meta && dashboardState.data.meta.error;
+  if (metaError) {
+    box.textContent = metaError;
+    box.style.display = 'block';
+    return;
+  }
+  box.style.display = 'none';
+  box.textContent = '';
+}
+
+function renderWarnings() {
+  const list = document.getElementById('warningList');
+  if (!list) return;
+  list.innerHTML = '';
+  const warnings = dashboardState.data && Array.isArray(dashboardState.data.warnings)
+    ? dashboardState.data.warnings
+    : [];
+  warnings.forEach(w => {
+    const item = document.createElement('div');
+    item.className = 'warning-item';
+    item.textContent = w;
+    list.appendChild(item);
+  });
+}
+
+function renderTasks() {
+  const list = document.getElementById('taskList');
+  const count = document.getElementById('taskCount');
+  if (list) list.innerHTML = '';
+
+  const tasks = dashboardState.data && Array.isArray(dashboardState.data.tasks)
+    ? dashboardState.data.tasks
+    : [];
+  if (count) count.textContent = tasks.length ? `${tasks.length}件` : 'タスクなし';
+
+  tasks.forEach(task => {
+    const card = document.createElement('div');
+    card.className = `card task-card ${task.severity || ''}`;
+
+    const meta = document.createElement('div');
+    meta.className = 'task-meta';
+    const dot = document.createElement('span');
+    dot.className = `severity-dot ${task.severity || ''}`;
+    meta.appendChild(dot);
+
+    const type = document.createElement('span');
+    type.textContent = formatTaskLabel(task.type);
+    meta.appendChild(type);
+
+    const pid = document.createElement('span');
+    pid.className = 'badge';
+    pid.textContent = task.patientId || '-';
+    meta.appendChild(pid);
+
+    card.appendChild(meta);
+
+    const name = document.createElement('div');
+    name.style.fontWeight = '700';
+    name.textContent = task.name || '患者不明';
+    card.appendChild(name);
+
+    if (task.detail) {
+      const detail = document.createElement('div');
+      detail.className = 'muted';
+      detail.textContent = String(task.detail);
+      card.appendChild(detail);
+    }
+
+    list.appendChild(card);
+  });
+}
+
+function renderVisits() {
+  const list = document.getElementById('visitList');
+  if (!list) return;
+  list.innerHTML = '';
+
+  const visits = dashboardState.data && Array.isArray(dashboardState.data.todayVisits)
+    ? dashboardState.data.todayVisits
+    : [];
+
+  const grouped = visits.reduce((map, entry) => {
+    const key = entry.dateKey || '不明';
+    if (!map[key]) map[key] = [];
+    map[key].push(entry);
+    return map;
+  }, {});
+
+  Object.keys(grouped).sort().forEach(dateKey => {
+    const header = document.createElement('div');
+    header.className = 'muted';
+    header.textContent = formatDateLabel(dateKey);
+    list.appendChild(header);
+
+    grouped[dateKey].forEach(v => {
+      const row = document.createElement('div');
+      row.className = 'visit';
+      const time = document.createElement('div');
+      time.className = 'visit-time';
+      time.textContent = v.time || '--:--';
+      row.appendChild(time);
+
+      const body = document.createElement('div');
+      body.className = 'visit-body';
+      const name = document.createElement('div');
+      name.textContent = v.patientName || v.patientId || '患者不明';
+      name.style.fontWeight = '700';
+      body.appendChild(name);
+
+      const meta = document.createElement('div');
+      meta.className = 'meta-row';
+      const badge = document.createElement('span');
+      const hasNote = v.noteStatus === '◎';
+      badge.className = `badge ${hasNote ? 'success' : 'warn'}`;
+      badge.textContent = hasNote ? '申し送り済' : '申し送り未入力';
+      meta.appendChild(badge);
+      if (v.patientId) {
+        const idBadge = document.createElement('span');
+        idBadge.className = 'badge';
+        idBadge.textContent = v.patientId;
+        meta.appendChild(idBadge);
+      }
+      body.appendChild(meta);
+      row.appendChild(body);
+
+      list.appendChild(row);
+    });
+  });
+}
+
+function renderPatients() {
+  const list = document.getElementById('patientList');
+  const count = document.getElementById('patientCount');
+  if (!list) return;
+  list.innerHTML = '';
+
+  const patients = dashboardState.data && Array.isArray(dashboardState.data.patients)
+    ? dashboardState.data.patients.slice().sort((a, b) => (a.name || '').localeCompare(b.name || '', 'ja'))
+    : [];
+
+  if (count) count.textContent = patients.length ? `${patients.length}名` : '患者データなし';
+
+  patients.forEach(p => {
+    const details = document.createElement('details');
+    details.className = 'patient';
+    details.dataset.patientId = p.patientId || '';
+
+    const summary = document.createElement('summary');
+    const header = document.createElement('div');
+    header.className = 'patient-header';
+    const name = document.createElement('div');
+    name.className = 'patient-name';
+    name.textContent = p.name || '氏名未登録';
+    header.appendChild(name);
+
+    const tags = document.createElement('div');
+    tags.style.display = 'flex';
+    tags.style.gap = '6px';
+    tags.style.flexWrap = 'wrap';
+
+    if (p.note && p.note.unread) {
+      const unread = document.createElement('span');
+      unread.className = 'tag';
+      unread.textContent = '未読申し送り';
+      tags.appendChild(unread);
+    }
+    if (p.responsible) {
+      const resp = document.createElement('span');
+      resp.className = 'tag';
+      resp.textContent = p.responsible;
+      tags.appendChild(resp);
+    }
+    header.appendChild(tags);
+    summary.appendChild(header);
+
+    const meta = document.createElement('div');
+    meta.className = 'meta-row';
+    if (p.consentExpiry) meta.appendChild(makeBadge('同意期限: ' + p.consentExpiry));
+    if (p.aiReportAt) meta.appendChild(makeBadge('AI報告: ' + p.aiReportAt));
+    if (p.invoiceUrl) meta.appendChild(makeBadge('請求書リンクあり'));
+    summary.appendChild(meta);
+
+    details.appendChild(summary);
+
+    const body = document.createElement('div');
+    body.className = 'patient-body';
+
+    const fields = document.createElement('div');
+    fields.className = 'meta-row';
+    if (p.patientId) fields.appendChild(makeBadge('ID: ' + p.patientId));
+    if (p.note && p.note.when) fields.appendChild(makeBadge('最終申し送り: ' + p.note.when));
+    if (p.note && p.note.lastReadAt) fields.appendChild(makeBadge('最終既読: ' + p.note.lastReadAt));
+    body.appendChild(fields);
+
+    if (p.note && p.note.preview) {
+      const note = document.createElement('div');
+      note.className = 'note-preview';
+      note.textContent = p.note.preview;
+      body.appendChild(note);
+    }
+
+    if (p.invoiceUrl) {
+      const link = document.createElement('a');
+      link.href = p.invoiceUrl;
+      link.textContent = '請求書PDFを開く';
+      link.target = '_blank';
+      link.rel = 'noreferrer';
+      body.appendChild(link);
+    }
+
+    details.appendChild(body);
+
+    details.addEventListener('toggle', () => {
+      if (details.open) markNoteAsRead(p);
+    });
+
+    list.appendChild(details);
+  });
+}
+
+function markNoteAsRead(patient) {
+  const pid = patient && patient.patientId;
+  if (!pid || !patient.note || !patient.note.unread) return;
+  if (dashboardState.marking.has(pid)) return;
+
+  const runner = typeof google !== 'undefined' && google.script && google.script.run;
+  if (!runner || typeof runner.markAsRead !== 'function') return;
+
+  dashboardState.marking.add(pid);
+  runner.withSuccessHandler(res => {
+    dashboardState.marking.delete(pid);
+    if (res && res.ok && dashboardState.data && Array.isArray(dashboardState.data.patients)) {
+      const target = dashboardState.data.patients.find(entry => entry.patientId === pid);
+      if (target && target.note) {
+        target.note.unread = false;
+        target.note.lastReadAt = res.readAt || target.note.lastReadAt || '';
+        renderPatients();
+      }
+    }
+  }).withFailureHandler(() => {
+    dashboardState.marking.delete(pid);
+  }).markAsRead({ patientId: pid });
+}
+
+function makeBadge(text) {
+  const span = document.createElement('span');
+  span.className = 'badge';
+  span.textContent = text;
+  return span;
+}
+
+function formatTaskLabel(type) {
+  switch(type) {
+    case 'consentExpired': return '同意書期限切れ';
+    case 'consentWarning': return '同意書期限間近';
+    case 'handoverDelayed': return '申し送り遅延';
+    case 'aiReportDelayed': return '医師報告書遅延';
+    case 'invoiceUnconfirmed': return '請求書確認待ち';
+    default: return 'タスク';
+  }
+}
+
+function formatDateLabel(key) {
+  if (!key) return '日付不明';
+  const today = new Date();
+  const todayKey = keyFromDate(today);
+  const yesterdayKey = keyFromDate(new Date(today.getTime() - 86400000));
+  if (key === todayKey) return '今日';
+  if (key === yesterdayKey) return '昨日';
+  const parsed = new Date(key);
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toLocaleDateString('ja-JP', { month: 'short', day: 'numeric', weekday: 'short' });
+  }
+  return key;
+}
+
+function keyFromDate(date) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+</script>
+</body>
+</html>

--- a/src/welcome.html
+++ b/src/welcome.html
@@ -24,6 +24,7 @@
     <a class="btn" href="javascript:void(0)" onclick="window.top.location.href='<?= baseUrl ?>?view=albyte_report'">アルバイト勤怠 月次レポート</a>
     <a class="btn" href="javascript:void(0)" onclick="window.top.location.href='<?= baseUrl ?>?view=payroll'">給与マスタ</a>
     <a class="btn" href="javascript:void(0)" onclick="window.top.location.href='<?= baseUrl ?>?view=billing'">請求書作成</a>
+    <a class="btn" href="javascript:void(0)" onclick="window.top.location.href='<?= baseUrl ?>?view=dashboard'">施術者ダッシュボード</a>
     <a class="btn" href="javascript:void(0)" onclick="window.top.location.href='<?= baseUrl ?>?view=admin'">管理画面</a>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- add a new practitioner dashboard HTML view that renders tasks, visits, and patient cards from getDashboardData
- allow patient note read-state updates via markAsRead when cards are opened and surface warnings/meta info
- expose the dashboard view through doGet routing and the welcome menu

## Testing
- node tests/dashboardGetDashboardData.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e91449468832185cbdf8ac0e655e3)