### PR TITLE
Adjust bank export billingJson guard

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -630,9 +630,8 @@ function exportBankTransferRows_(billingMonth, rowObjects, bankStatuses) {
   }
 
   function exportBankTransferDataForPrepared_(prepared) {
-    const hasBillingJson = prepared && Object.prototype.hasOwnProperty.call(prepared, 'billingJson');
     const normalized = normalizePreparedBilling_(prepared);
-    if (!normalized || !hasBillingJson) {
+    if (!normalized) {
       throw new Error('銀行データを生成できません。請求データが未生成です。先に「請求データを集計」を実行してください。');
     }
 


### PR DESCRIPTION
## Summary
- rely on normalized prepared billing data instead of raw payload for bank export billingJson checks
- add coverage ensuring normalized billingJson still flows through export and null payloads are rejected

## Testing
- node tests/billingOutput.test.js
- for f in tests/*.test.js; do echo "Running $f"; node "$f"; done


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e951f22708321bcca1b4144f71a1c)