### PR TITLE
Fix dashboard tests for reorganized files

### DIFF
--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -3,7 +3,14 @@ const path = require('path');
 const vm = require('vm');
 const assert = require('assert');
 
-const dashboardCode = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'getDashboardData.js'), 'utf8');
+const sheetUtilsCode = fs.readFileSync(
+  path.join(__dirname, '..', 'src', 'dashboard', 'utils', 'sheetUtils.js'),
+  'utf8'
+);
+const dashboardCode = fs.readFileSync(
+  path.join(__dirname, '..', 'src', 'dashboard', 'api', 'getDashboardData.js'),
+  'utf8'
+);
 
 function createContext(overrides = {}) {
   const context = {
@@ -21,6 +28,7 @@ function createContext(overrides = {}) {
   };
   Object.assign(context, overrides);
   vm.createContext(context);
+  vm.runInContext(sheetUtilsCode, context);
   vm.runInContext(dashboardCode, context);
   return context;
 }

--- a/tests/dashboardLoadInvoices.test.js
+++ b/tests/dashboardLoadInvoices.test.js
@@ -3,7 +3,14 @@ const path = require('path');
 const vm = require('vm');
 const assert = require('assert');
 
-const loadInvoicesCode = fs.readFileSync(path.join(__dirname, '../src/dashboard/loadInvoices.js'), 'utf8');
+const sheetUtilsCode = fs.readFileSync(
+  path.join(__dirname, '../src/dashboard/utils/sheetUtils.js'),
+  'utf8'
+);
+const loadInvoicesCode = fs.readFileSync(
+  path.join(__dirname, '../src/dashboard/data/loadInvoices.js'),
+  'utf8'
+);
 
 function createIterator(items) {
   let idx = 0;
@@ -44,6 +51,7 @@ function createContext() {
   };
   const context = { console, Utilities, Session: { getScriptTimeZone: () => 'Asia/Tokyo' } };
   vm.createContext(context);
+  vm.runInContext(sheetUtilsCode, context);
   vm.runInContext(loadInvoicesCode, context);
   return context;
 }

--- a/tests/dashboardReadAndCache.test.js
+++ b/tests/dashboardReadAndCache.test.js
@@ -33,7 +33,8 @@ function createBaseContext() {
     cacheStore,
     propertyStore,
     dashboardWarn_: () => {},
-    dashboardResolveTimeZone_: () => 'Asia/Tokyo'
+    dashboardResolveTimeZone_: () => 'Asia/Tokyo',
+    DASHBOARD_CACHE_TTL_SECONDS: 60 * 60
   };
 
   vm.createContext(ctx);
@@ -59,15 +60,15 @@ function createNotesContext() {
       };
     }
   };
-  ctx.dashboardGetSpreadsheet_ = () => ({ getSheetByName: () => sheet });
   ctx.rangeCalls = () => rangeCalls;
-  loadDashboardScripts(ctx, ['cacheUtils.js', 'loadNotes.js', 'markAsRead.js']);
+  loadDashboardScripts(ctx, ['utils/sheetUtils.js', 'utils/cacheUtils.js', 'data/loadNotes.js', 'api/markAsRead.js']);
+  ctx.dashboardGetSpreadsheet_ = () => ({ getSheetByName: () => sheet });
   return ctx;
 }
 
 function testMarkAsReadStoresPerUser() {
   const ctx = createBaseContext();
-  loadDashboardScripts(ctx, ['cacheUtils.js', 'loadNotes.js', 'markAsRead.js']);
+  loadDashboardScripts(ctx, ['utils/sheetUtils.js', 'utils/cacheUtils.js', 'data/loadNotes.js', 'api/markAsRead.js']);
   const ts = new Date('2025-01-01T00:00:00Z');
 
   const res = ctx.markAsRead('P001', 'User@example.com', ts);


### PR DESCRIPTION
## Summary
- update dashboard-related tests to load modules from their new api/data/utils locations
- include shared utility scripts and stubs so GAS helpers resolve during testing
- ensure spreadsheet stubs are applied after utility loading in dashboard tests

## Testing
- node --test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f3d4b56588321a75e3d8a52557951)