### PR TITLE
Consolidate dashboard config constants

### DIFF
--- a/src/dashboard/cacheUtils.js
+++ b/src/dashboard/cacheUtils.js
@@ -15,7 +15,7 @@ function dashboardGetCache_() {
 
 function dashboardCacheFetch_(key, fetchFn, ttlSeconds) {
   const cache = dashboardGetCache_();
-  const fallbackTtl = typeof DASHBOARD_CACHE_TTL_SECONDS !== 'undefined' ? DASHBOARD_CACHE_TTL_SECONDS : 60 * 60 * 12;
+  const fallbackTtl = typeof DASHBOARD_CACHE_TTL_SECONDS !== 'undefined' ? DASHBOARD_CACHE_TTL_SECONDS : 60;
   const ttl = Math.max(5, ttlSeconds || fallbackTtl);
   if (!cache || !key || typeof fetchFn !== 'function') {
     return typeof fetchFn === 'function' ? fetchFn() : null;
@@ -50,6 +50,6 @@ function dashboardCacheInvalidate_(key) {
 }
 
 function dashboardCacheKey_(suffix) {
-  const prefix = typeof DASHBOARD_PREFIX !== 'undefined' ? DASHBOARD_PREFIX : 'dashboard';
+  const prefix = typeof DASHBOARD_PREFIX !== 'undefined' ? DASHBOARD_PREFIX : 'DASHBOARD_';
   return suffix ? `${prefix}:${suffix}` : prefix;
 }

--- a/src/dashboard/config.gs
+++ b/src/dashboard/config.gs
@@ -1,8 +1,8 @@
 /**
  * ダッシュボード共通の設定値を集約する。
  */
-const DASHBOARD_PREFIX = 'dashboard';
-const DASHBOARD_CACHE_TTL_SECONDS = 60 * 60 * 12; // 12 hours
-const DASHBOARD_DATE_FORMAT = 'yyyy-MM-dd';
-const DASHBOARD_DEBUG = false;
-const DASHBOARD_TIME_ZONE = 'Asia/Tokyo';
+const DASHBOARD_PREFIX = 'DASHBOARD_';
+const DASHBOARD_CACHE_TTL_SECONDS = 60;
+const DATE_FORMAT = 'yyyy/MM/dd';
+const DEBUG_MODE = false;
+const DEFAULT_TZ = 'Asia/Tokyo';

--- a/src/dashboard/getDashboardData.js
+++ b/src/dashboard/getDashboardData.js
@@ -22,14 +22,14 @@ if (typeof dashboardResolveTimeZone_ !== 'function') {
       const tz = Session.getScriptTimeZone();
       if (tz) return tz;
     }
-    if (typeof DASHBOARD_TIME_ZONE !== 'undefined') return DASHBOARD_TIME_ZONE;
+    if (typeof DEFAULT_TZ !== 'undefined') return DEFAULT_TZ;
     return 'Asia/Tokyo';
   };
 }
 
 if (typeof dashboardFormatDate_ !== 'function') {
   var dashboardFormatDate_ = function(date, tz, format) {
-    const targetFormat = format || 'yyyy-MM-dd';
+    const targetFormat = format || (typeof DATE_FORMAT !== 'undefined' ? DATE_FORMAT : 'yyyy/MM/dd');
     const targetTz = tz || dashboardResolveTimeZone_();
     if (typeof Utilities !== 'undefined' && Utilities && typeof Utilities.formatDate === 'function') {
       try { return Utilities.formatDate(date, targetTz, targetFormat); } catch (e) { /* ignore */ }

--- a/src/dashboard/loadAIReports.js
+++ b/src/dashboard/loadAIReports.js
@@ -50,14 +50,14 @@ if (typeof dashboardResolveTimeZone_ !== 'function') {
       const tz = Session.getScriptTimeZone();
       if (tz) return tz;
     }
-    if (typeof DASHBOARD_TIME_ZONE !== 'undefined') return DASHBOARD_TIME_ZONE;
+    if (typeof DEFAULT_TZ !== 'undefined') return DEFAULT_TZ;
     return 'Asia/Tokyo';
   };
 }
 
 if (typeof dashboardFormatDate_ !== 'function') {
   var dashboardFormatDate_ = function(date, tz, format) {
-    const targetFormat = format || 'yyyy-MM-dd';
+    const targetFormat = format || (typeof DATE_FORMAT !== 'undefined' ? DATE_FORMAT : 'yyyy/MM/dd');
     const targetTz = tz || dashboardResolveTimeZone_();
     if (typeof Utilities !== 'undefined' && Utilities && typeof Utilities.formatDate === 'function') {
       try { return Utilities.formatDate(date, targetTz, targetFormat); } catch (e) { /* ignore */ }
@@ -65,10 +65,6 @@ if (typeof dashboardFormatDate_ !== 'function') {
     if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
     return date.toISOString();
   };
-}
-
-if (typeof DASHBOARD_CACHE_TTL_SECONDS === 'undefined') {
-  var DASHBOARD_CACHE_TTL_SECONDS = 300;
 }
 
 function loadAIReports(options) {

--- a/src/dashboard/loadInvoices.js
+++ b/src/dashboard/loadInvoices.js
@@ -35,14 +35,14 @@ if (typeof dashboardResolveTimeZone_ !== 'function') {
       const tz = Session.getScriptTimeZone();
       if (tz) return tz;
     }
-    if (typeof DASHBOARD_TIME_ZONE !== 'undefined') return DASHBOARD_TIME_ZONE;
+    if (typeof DEFAULT_TZ !== 'undefined') return DEFAULT_TZ;
     return 'Asia/Tokyo';
   };
 }
 
 if (typeof dashboardFormatDate_ !== 'function') {
   var dashboardFormatDate_ = function(date, tz, format) {
-    const targetFormat = format || 'yyyy-MM-dd';
+    const targetFormat = format || (typeof DATE_FORMAT !== 'undefined' ? DATE_FORMAT : 'yyyy/MM/dd');
     const targetTz = tz || dashboardResolveTimeZone_();
     if (typeof Utilities !== 'undefined' && Utilities && typeof Utilities.formatDate === 'function') {
       try { return Utilities.formatDate(date, targetTz, targetFormat); } catch (e) { /* ignore */ }

--- a/src/dashboard/loadNotes.js
+++ b/src/dashboard/loadNotes.js
@@ -16,10 +16,6 @@ if (typeof dashboardParseTimestamp_ === 'undefined') {
   }
 }
 
-if (typeof DASHBOARD_CACHE_TTL_SECONDS === 'undefined') {
-  var DASHBOARD_CACHE_TTL_SECONDS = 60 * 60 * 12;
-}
-
 if (typeof dashboardCoerceDate_ === 'undefined') {
   function dashboardCoerceDate_(value) {
     if (value instanceof Date) return value;
@@ -50,7 +46,7 @@ if (typeof dashboardNormalizeEmail_ === 'undefined') {
 
 if (typeof dashboardFormatDate_ === 'undefined') {
   function dashboardFormatDate_(date, tz, format) {
-    const targetFormat = format || (typeof DASHBOARD_DATE_FORMAT !== 'undefined' ? DASHBOARD_DATE_FORMAT : 'yyyy-MM-dd');
+    const targetFormat = format || (typeof DATE_FORMAT !== 'undefined' ? DATE_FORMAT : 'yyyy/MM/dd');
     const targetTz = tz || (typeof dashboardResolveTimeZone_ === 'function' ? dashboardResolveTimeZone_() : 'Asia/Tokyo');
 
     if (typeof Utilities !== 'undefined' && Utilities && typeof Utilities.formatDate === 'function') {

--- a/src/dashboard/utils/cacheUtils.js
+++ b/src/dashboard/utils/cacheUtils.js
@@ -15,7 +15,7 @@ function dashboardGetCache_() {
 
 function dashboardCacheFetch_(key, fetchFn, ttlSeconds) {
   const cache = dashboardGetCache_();
-  const fallbackTtl = typeof DASHBOARD_CACHE_TTL_SECONDS !== 'undefined' ? DASHBOARD_CACHE_TTL_SECONDS : 60 * 60 * 12;
+  const fallbackTtl = typeof DASHBOARD_CACHE_TTL_SECONDS !== 'undefined' ? DASHBOARD_CACHE_TTL_SECONDS : 60;
   const ttl = Math.max(5, ttlSeconds || fallbackTtl);
   if (!cache || !key || typeof fetchFn !== 'function') {
     return typeof fetchFn === 'function' ? fetchFn() : null;
@@ -50,6 +50,6 @@ function dashboardCacheInvalidate_(key) {
 }
 
 function dashboardCacheKey_(suffix) {
-  const prefix = typeof DASHBOARD_PREFIX !== 'undefined' ? DASHBOARD_PREFIX : 'dashboard';
+  const prefix = typeof DASHBOARD_PREFIX !== 'undefined' ? DASHBOARD_PREFIX : 'DASHBOARD_';
   return suffix ? `${prefix}:${suffix}` : prefix;
 }

--- a/src/dashboard/utils/sheetUtils.js
+++ b/src/dashboard/utils/sheetUtils.js
@@ -25,12 +25,12 @@ function dashboardResolveTimeZone_() {
     const tz = Session.getScriptTimeZone();
     if (tz) return tz;
   }
-  if (typeof DASHBOARD_TIME_ZONE !== 'undefined') return DASHBOARD_TIME_ZONE;
+  if (typeof DEFAULT_TZ !== 'undefined') return DEFAULT_TZ;
   return 'Asia/Tokyo';
 }
 
 function dashboardFormatDate_(date, tz, format) {
-  const targetFormat = format || (typeof DASHBOARD_DATE_FORMAT !== 'undefined' ? DASHBOARD_DATE_FORMAT : 'yyyy-MM-dd');
+  const targetFormat = format || (typeof DATE_FORMAT !== 'undefined' ? DATE_FORMAT : 'yyyy/MM/dd');
   const targetTz = tz || dashboardResolveTimeZone_();
 
   if (typeof Utilities !== 'undefined' && Utilities && typeof Utilities.formatDate === 'function') {


### PR DESCRIPTION
## Summary
- centralize dashboard configuration constants into a single config file with standardized defaults
- remove duplicate dashboard cache TTL declarations while aligning cache key prefixes
- update dashboard utilities to consume the shared date/time settings

## Testing
- node tests/billingGet.test.js
- node tests/billingInvoiceLayout.test.js
- node tests/billingLogic.test.js
- node tests/billingOutput.test.js
- node tests/billingUiNormalization.test.js
- node tests/dashboardGetDashboardData.test.js *(fails: missing /workspace/treatment-log-app/src/dashboard/api/getDashboardData.js)*
- node tests/dashboardLoadAIReports.test.js *(fails: missing /workspace/treatment-log-app/src/dashboard/data/loadAIReports.js)*
- node tests/dashboardLoadInvoices.test.js *(fails: missing /workspace/treatment-log-app/src/dashboard/data/loadInvoices.js)*
- node tests/dashboardReadAndCache.test.js
- node tests/deleteTreatment.test.js
- node tests/preparedBillingCache.test.js
- node tests/treatmentDeleteButtonTemplate.test.js
- node tests/treatmentIdBackfill.test.js
- node tests/treatmentListOrdering.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f428dcd348321a84444295a3d01ec)