### PR TITLE
Improve bank export diagnostics

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1094,6 +1094,23 @@ function applyBillingEditsAndGenerateInvoices(billingMonth, options) {
       ? normalizeBillingMonthInput(normalizedPrepared.billingMonth)
       : null);
 
+    try {
+      billingLogger_.log('[bankExport] generateBankTransferDataFromCache summary=' + JSON.stringify({
+        requestedMonth: monthInput || null,
+        resolvedMonthKey: resolvedMonth ? resolvedMonth.key : null,
+        cacheMonthKey: resolvedMonthKey || null,
+        hasPrepared: !!prepared,
+        preparedBillingJsonLength: prepared && Array.isArray(prepared.billingJson) ? prepared.billingJson.length : null,
+        normalizedBillingJsonLength: normalizedPrepared && Array.isArray(normalizedPrepared.billingJson)
+          ? normalizedPrepared.billingJson.length
+          : null,
+        validationReason: validation && validation.reason ? validation.reason : null,
+        validationOk: validation && validation.hasOwnProperty('ok') ? validation.ok : null
+      }));
+    } catch (err) {
+      // ignore logging errors in non-GAS environments
+    }
+
     if (!resolvedMonth) {
       throw new Error('銀行データを生成できません。請求月が指定されていません。先に「請求データを集計」を実行してください。');
     }
@@ -1124,6 +1141,11 @@ function resolveBankExportErrorMessage_(validation) {
   const reason = validation && validation.reason ? String(validation.reason) : '';
   const ledgerReasons = ['carryOverLedger missing', 'carryOverLedgerByPatient missing', 'carryOverLedgerMeta missing', 'carryOverByPatient missing', 'unpaidHistory missing'];
   const missingReasons = ['cache key missing', 'cache unavailable', 'cache miss', 'parse error'];
+  try {
+    billingLogger_.log('[bankExport] resolveBankExportErrorMessage_ reason=' + reason);
+  } catch (err) {
+    // ignore logging errors in non-GAS environments
+  }
   if (ledgerReasons.indexOf(reason) >= 0) {
     return '銀行データを生成できません。繰越金データを確認してください。';
   }

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -632,10 +632,18 @@ function exportBankTransferRows_(billingMonth, rowObjects, bankStatuses) {
   function exportBankTransferDataForPrepared_(prepared) {
     const normalized = normalizePreparedBilling_(prepared);
     if (!normalized) {
+      billingLogger_.log('[billing] exportBankTransferDataForPrepared_: normalized payload missing', {
+        hasPrepared: !!prepared,
+        preparedKeys: prepared && typeof prepared === 'object' ? Object.keys(prepared) : null
+      });
       throw new Error('銀行データを生成できません。請求データが未生成です。先に「請求データを集計」を実行してください。');
     }
 
     if (!Array.isArray(normalized.billingJson)) {
+      billingLogger_.log('[billing] exportBankTransferDataForPrepared_: billingJson missing or invalid', {
+        billingJsonType: typeof normalized.billingJson,
+        hasBillingJson: !!normalized.billingJson
+      });
       throw new Error('銀行データを生成できません。請求データの形式が不正です。先に「請求データを集計」を実行してください。');
     }
     logPreparedBankPayloadStatus_(normalized);


### PR DESCRIPTION
## Summary
- add detailed logging around bank transfer cache lookups and validation reasons
- emit logs when bank export fails due to missing prepared payload or billing data
- keep bank export flows unchanged while improving observability for the reported error

## Testing
- node tests/preparedBillingCache.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f775bcac08321a4cf26662ad4d3f5)