### PR TITLE
Support dashboard cache controls and explicit user passing

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -6,15 +6,16 @@
  */
 function getDashboardData(options) {
   const opts = options || {};
+  const cacheOptions = opts.cache === false ? { cache: false } : {};
   const meta = {
     generatedAt: dashboardFormatDate_(new Date(), dashboardResolveTimeZone_(), "yyyy-MM-dd'T'HH:mm:ssXXX") || new Date().toISOString(),
     user: opts.user || dashboardResolveUser_()
   };
 
   try {
-    const patientInfo = opts.patientInfo || (typeof loadPatientInfo === 'function' ? loadPatientInfo() : { patients: {}, nameToId: {}, warnings: [] });
-    const notes = opts.notes || (typeof loadNotes === 'function' ? loadNotes({ email: meta.user }) : { notes: {}, warnings: [] });
-    const aiReports = opts.aiReports || (typeof loadAIReports === 'function' ? loadAIReports() : { reports: {}, warnings: [] });
+    const patientInfo = opts.patientInfo || (typeof loadPatientInfo === 'function' ? loadPatientInfo(cacheOptions) : { patients: {}, nameToId: {}, warnings: [] });
+    const notes = opts.notes || (typeof loadNotes === 'function' ? loadNotes(Object.assign({ email: meta.user }, cacheOptions)) : { notes: {}, warnings: [] });
+    const aiReports = opts.aiReports || (typeof loadAIReports === 'function' ? loadAIReports(cacheOptions) : { reports: {}, warnings: [] });
     const invoices = opts.invoices || (typeof loadInvoices === 'function' ? loadInvoices({ patientInfo }) : { invoices: {}, warnings: [] });
     const treatmentLogs = opts.treatmentLogs || (typeof loadTreatmentLogs === 'function' ? loadTreatmentLogs({ patientInfo }) : { logs: [], warnings: [] });
     const responsible = opts.responsible || (typeof assignResponsibleStaff === 'function' ? assignResponsibleStaff({ patientInfo, treatmentLogs }) : { responsible: {}, warnings: [] });

--- a/src/dashboard/data/loadAIReports.js
+++ b/src/dashboard/data/loadAIReports.js
@@ -5,11 +5,7 @@
 function loadAIReports(options) {
   const opts = options || {};
   const fetchFn = () => loadAIReportsUncached_();
-  if (opts && opts.cache === false) return fetchFn();
-  if (typeof dashboardCacheFetch_ !== 'function' || typeof dashboardCacheKey_ !== 'function') {
-    return fetchFn();
-  }
-  return dashboardCacheFetch_(dashboardCacheKey_('aiReports:v1'), fetchFn, DASHBOARD_CACHE_TTL_SECONDS);
+  return dashboardCacheFetch_(dashboardCacheKey_('aiReports:v1'), fetchFn, DASHBOARD_CACHE_TTL_SECONDS, opts);
 }
 
 function loadAIReportsUncached_() {

--- a/src/dashboard/data/loadNotes.js
+++ b/src/dashboard/data/loadNotes.js
@@ -5,9 +5,7 @@ function loadNotes(options) {
   const opts = options || {};
   const email = opts.email;
   const fetchFn = () => loadNotesUncached_(opts);
-  const base = opts && opts.cache === false
-    ? fetchFn()
-    : dashboardCacheFetch_(dashboardCacheKey_('notes:v1'), fetchFn, DASHBOARD_CACHE_TTL_SECONDS);
+  const base = dashboardCacheFetch_(dashboardCacheKey_('notes:v1'), fetchFn, DASHBOARD_CACHE_TTL_SECONDS, opts);
 
   const lastReadAt = loadHandoverLastRead_(email);
   const notes = {};

--- a/src/dashboard/data/loadPatientInfo.js
+++ b/src/dashboard/data/loadPatientInfo.js
@@ -4,8 +4,7 @@
 function loadPatientInfo(options) {
   const opts = options || {};
   const fetchFn = () => loadPatientInfoUncached_(opts);
-  if (opts && opts.cache === false) return fetchFn();
-  return dashboardCacheFetch_(dashboardCacheKey_('patientInfo:v1'), fetchFn, DASHBOARD_CACHE_TTL_SECONDS);
+  return dashboardCacheFetch_(dashboardCacheKey_('patientInfo:v1'), fetchFn, DASHBOARD_CACHE_TTL_SECONDS, opts);
 }
 
 function loadPatientInfoUncached_(_options) {

--- a/src/dashboard/utils/cacheUtils.js
+++ b/src/dashboard/utils/cacheUtils.js
@@ -13,7 +13,12 @@ function dashboardGetCache_() {
   }
 }
 
-function dashboardCacheFetch_(key, fetchFn, ttlSeconds) {
+function dashboardCacheFetch_(key, fetchFn, ttlSeconds, options) {
+  const opts = options || {};
+  if (opts.cache === false) {
+    return typeof fetchFn === 'function' ? fetchFn() : null;
+  }
+
   const cache = dashboardGetCache_();
   const fallbackTtl = typeof DASHBOARD_CACHE_TTL_SECONDS !== 'undefined' ? DASHBOARD_CACHE_TTL_SECONDS : 60;
   const ttl = Math.max(5, ttlSeconds || fallbackTtl);

--- a/src/main.gs
+++ b/src/main.gs
@@ -37,7 +37,9 @@ function handleDashboardDoGet_(e) {
   if (!shouldHandleDashboardRequest_(e)) return null;
 
   if (shouldHandleDashboardApi_(e)) {
-    const data = typeof getDashboardData === 'function' ? getDashboardData() : {};
+    const user = dashboardResolveRequestUser_(e);
+    const cacheFlag = dashboardResolveDashboardCacheFlag_(e);
+    const data = typeof getDashboardData === 'function' ? getDashboardData({ user, cache: cacheFlag }) : {};
     return createJsonResponse_(data);
   }
 
@@ -65,6 +67,21 @@ function shouldHandleDashboardApi_(e) {
   if (path === 'getdashboarddata') return true;
   const action = e && e.parameter ? (e.parameter.action || e.parameter.api) : '';
   return String(action || '').toLowerCase() === 'getdashboarddata';
+}
+
+function dashboardResolveRequestUser_(e) {
+  const paramUser = e && e.parameter ? (e.parameter.user || e.parameter.email) : '';
+  if (paramUser) return String(paramUser || '').trim();
+  if (typeof dashboardResolveUser_ === 'function') return dashboardResolveUser_();
+  return '';
+}
+
+function dashboardResolveDashboardCacheFlag_(e) {
+  const raw = e && e.parameter ? e.parameter.cache : undefined;
+  if (raw === undefined || raw === null || raw === '') return undefined;
+  const normalized = String(raw).trim().toLowerCase();
+  if (normalized === 'false' || normalized === '0' || normalized === 'off' || normalized === 'no') return false;
+  return true;
 }
 
 function createJsonResponse_(payload) {


### PR DESCRIPTION
## Summary
- allow dashboard cache helpers and loaders to honor an explicit cache=false option
- pass resolved user and cache flags from doGet into getDashboardData for safer webapp execution

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f89a560a48321bf5e933dd4eeec63)