### PR TITLE
Add dashboard mock data and strengthen caching

### DIFF
--- a/.clasp.json
+++ b/.clasp.json
@@ -15,6 +15,7 @@
     "dashboard/api/getTodayVisits.js",
     "dashboard/api/getDashboardData.js",
     "dashboard/api/markAsRead.js",
+    "dashboard/tests/dashboardMockData.gs",
     "Code.js"
   ]
 }

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -142,11 +142,15 @@ function fetchDashboardData() {
 
   const runner = typeof google !== 'undefined' && google.script && google.script.run;
   if (runner && typeof runner.getDashboardData === 'function') {
-    runner.withSuccessHandler(onSuccess).withFailureHandler(onFailure).getDashboardData();
+    const mockFlag = resolveDashboardMockParam_();
+    const args = mockFlag ? { mock: mockFlag } : {};
+    runner.withSuccessHandler(onSuccess).withFailureHandler(onFailure).getDashboardData(args);
     return;
   }
 
-  const url = (typeof baseUrl !== 'undefined' ? baseUrl : '') + '?action=getDashboardData';
+  const mock = resolveDashboardMockParam_();
+  const mockQuery = mock ? `&mock=${encodeURIComponent(mock)}` : '';
+  const url = (typeof baseUrl !== 'undefined' ? baseUrl : '') + `?action=getDashboardData${mockQuery}`;
   fetch(url)
     .then(res => res.json())
     .then(onSuccess)
@@ -202,6 +206,13 @@ function renderWarnings() {
   const warnings = dashboardState.data && Array.isArray(dashboardState.data.warnings)
     ? dashboardState.data.warnings
     : [];
+  if (!warnings.length) {
+    const empty = document.createElement('div');
+    empty.className = 'muted';
+    empty.textContent = '警告はありません';
+    list.appendChild(empty);
+    return;
+  }
   warnings.forEach(w => {
     const item = document.createElement('div');
     item.className = 'warning-item';
@@ -219,6 +230,14 @@ function renderTasks() {
     ? dashboardState.data.tasks
     : [];
   if (count) count.textContent = tasks.length ? `${tasks.length}件` : 'タスクなし';
+
+  if (!tasks.length) {
+    const empty = document.createElement('div');
+    empty.className = 'card task-card';
+    empty.textContent = '現在対応すべきタスクはありません';
+    list.appendChild(empty);
+    return;
+  }
 
   tasks.forEach(task => {
     const card = document.createElement('div');
@@ -265,6 +284,14 @@ function renderVisits() {
   const visits = dashboardState.data && Array.isArray(dashboardState.data.todayVisits)
     ? dashboardState.data.todayVisits
     : [];
+
+  if (!visits.length) {
+    const empty = document.createElement('div');
+    empty.className = 'muted';
+    empty.textContent = '訪問データはありません';
+    list.appendChild(empty);
+    return;
+  }
 
   const grouped = visits.reduce((map, entry) => {
     const key = entry.dateKey || '不明';
@@ -326,6 +353,14 @@ function renderPatients() {
     : [];
 
   if (count) count.textContent = patients.length ? `${patients.length}名` : '患者データなし';
+
+  if (!patients.length) {
+    const empty = document.createElement('div');
+    empty.className = 'muted';
+    empty.textContent = '患者データはありません';
+    list.appendChild(empty);
+    return;
+  }
 
   patients.forEach(p => {
     const details = document.createElement('details');
@@ -411,7 +446,10 @@ function markNoteAsRead(patient) {
   if (dashboardState.marking.has(pid)) return;
 
   const runner = typeof google !== 'undefined' && google.script && google.script.run;
-  if (!runner || typeof runner.markAsRead !== 'function') return;
+  if (!runner || typeof runner.markAsRead !== 'function') {
+    markPatientNoteLocally_(pid);
+    return;
+  }
 
   dashboardState.marking.add(pid);
   runner.withSuccessHandler(res => {
@@ -427,6 +465,15 @@ function markNoteAsRead(patient) {
   }).withFailureHandler(() => {
     dashboardState.marking.delete(pid);
   }).markAsRead({ patientId: pid });
+}
+
+function markPatientNoteLocally_(pid) {
+  if (!dashboardState.data || !Array.isArray(dashboardState.data.patients)) return;
+  const target = dashboardState.data.patients.find(entry => entry.patientId === pid);
+  if (!target || !target.note) return;
+  target.note.unread = false;
+  target.note.lastReadAt = target.note.lastReadAt || new Date().toISOString();
+  renderPatients();
 }
 
 function makeBadge(text) {
@@ -466,6 +513,13 @@ function keyFromDate(date) {
   const m = String(date.getMonth() + 1).padStart(2, '0');
   const d = String(date.getDate()).padStart(2, '0');
   return `${y}-${m}-${d}`;
+}
+
+function resolveDashboardMockParam_() {
+  if (typeof dashboardMockFlag !== 'undefined' && dashboardMockFlag) return dashboardMockFlag;
+  if (typeof window === 'undefined' || !window.location || !window.location.search) return '';
+  const search = new URLSearchParams(window.location.search);
+  return search.get('mock') || '';
 }
 </script>
 </body>

--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -6,6 +6,12 @@
  */
 function getDashboardData(options) {
   const opts = options || {};
+  if (opts.mock && typeof buildDashboardMockData_ === 'function') {
+    const mockOptions = buildDashboardMockData_(opts) || {};
+    const normalized = Object.assign({}, mockOptions);
+    normalized.mock = '';
+    return getDashboardData(normalized);
+  }
   const cacheOptions = opts.cache === false ? { cache: false } : {};
   const meta = {
     generatedAt: dashboardFormatDate_(new Date(), dashboardResolveTimeZone_(), "yyyy-MM-dd'T'HH:mm:ssXXX") || new Date().toISOString(),

--- a/src/dashboard/data/loadInvoices.js
+++ b/src/dashboard/data/loadInvoices.js
@@ -9,6 +9,15 @@
  */
 function loadInvoices(options) {
   const opts = options || {};
+  const fetchFn = () => loadInvoicesUncached_(opts);
+  if (typeof dashboardCacheFetch_ === 'function') {
+    return dashboardCacheFetch_(dashboardCacheKey_('invoices:v1'), fetchFn, DASHBOARD_CACHE_TTL_SECONDS, opts);
+  }
+  return fetchFn();
+}
+
+function loadInvoicesUncached_(options) {
+  const opts = options || {};
   const patientInfo = opts.patientInfo || (typeof loadPatientInfo === 'function' ? loadPatientInfo() : null);
   const patients = patientInfo && patientInfo.patients ? patientInfo.patients : {};
   const nameToId = opts.nameToId || (patientInfo && patientInfo.nameToId) || {};

--- a/src/dashboard/data/loadTreatmentLogs.js
+++ b/src/dashboard/data/loadTreatmentLogs.js
@@ -3,6 +3,15 @@
  */
 function loadTreatmentLogs(options) {
   const opts = options || {};
+  const fetchFn = () => loadTreatmentLogsUncached_(opts);
+  if (typeof dashboardCacheFetch_ === 'function') {
+    return dashboardCacheFetch_(dashboardCacheKey_('treatmentLogs:v1'), fetchFn, DASHBOARD_CACHE_TTL_SECONDS, opts);
+  }
+  return fetchFn();
+}
+
+function loadTreatmentLogsUncached_(options) {
+  const opts = options || {};
   const patientInfo = opts.patientInfo || (typeof loadPatientInfo === 'function' ? loadPatientInfo() : null);
   const nameToId = opts.nameToId || (patientInfo && patientInfo.nameToId) || {};
   const warnings = patientInfo && Array.isArray(patientInfo.warnings) ? [].concat(patientInfo.warnings) : [];

--- a/src/dashboard/tests/dashboardMockData.gs
+++ b/src/dashboard/tests/dashboardMockData.gs
@@ -1,0 +1,120 @@
+/**
+ * ダッシュボードAPIの単体テストやデモ用に、スタブデータを生成する。
+ * スプレッドシートやDriveがなくても getDashboardData() のレスポンスを確認できる。
+ */
+function getDashboardMockData(overrides) {
+  const mock = buildDashboardMockData_(overrides);
+  return typeof getDashboardData === 'function'
+    ? getDashboardData(mock)
+    : mock;
+}
+
+function buildDashboardMockData_(overrides) {
+  const now = new Date('2025-12-15T09:30:00+09:00');
+  const mockPatients = {
+    P001: { patientId: 'P001', name: '施術 花子', consentExpiry: '2026/01/31' },
+    P002: { patientId: 'P002', name: '山田 太郎', consentExpiry: '2025/12/25' }
+  };
+
+  const patientInfo = {
+    patients: mockPatients,
+    nameToId: Object.keys(mockPatients).reduce((map, pid) => {
+      map[mockPatients[pid].name.replace(/\s+/g, '').toLowerCase()] = pid;
+      return map;
+    }, {}),
+    warnings: []
+  };
+
+  const notes = {
+    notes: {
+      P001: {
+        patientId: 'P001',
+        preview: '昨日の施術後、肩の可動域が改善。継続観察。',
+        when: '2025/12/14',
+        unread: true,
+        lastReadAt: '',
+        authorEmail: 'writer@example.com'
+      }
+    },
+    warnings: []
+  };
+
+  const aiReports = {
+    reports: {
+      P002: '2025/12/13'
+    },
+    warnings: []
+  };
+
+  const invoices = {
+    invoices: {
+      P001: 'https://example.com/invoice/P001',
+      P002: null
+    },
+    warnings: []
+  };
+
+  const treatmentLogs = {
+    logs: [
+      {
+        row: 2,
+        patientId: 'P001',
+        patientName: '施術 花子',
+        createdByEmail: 'staff@example.com',
+        timestamp: now,
+        dateKey: '2025-12-15'
+      },
+      {
+        row: 3,
+        patientId: 'P002',
+        patientName: '山田 太郎',
+        createdByEmail: 'staff@example.com',
+        timestamp: new Date('2025-12-14T10:00:00+09:00'),
+        dateKey: '2025-12-14'
+      }
+    ],
+    warnings: [],
+    lastStaffByPatient: {
+      P001: 'staff@example.com',
+      P002: 'staff@example.com'
+    }
+  };
+
+  const responsible = {
+    responsible: {
+      P001: '施術 太郎',
+      P002: '施術 次郎'
+    },
+    warnings: []
+  };
+
+  const tasksResult = {
+    tasks: [
+      { type: 'consentWarning', severity: 'warning', patientId: 'P001', name: '施術 花子', detail: '同意期限が30日以内です' },
+      { type: 'invoiceUnconfirmed', severity: 'warning', patientId: 'P002', name: '山田 太郎', detail: '請求書未確認' }
+    ],
+    warnings: []
+  };
+
+  const visitsResult = {
+    visits: [
+      { dateKey: '2025-12-15', time: '09:30', patientId: 'P001', patientName: '施術 花子', noteStatus: '◎' },
+      { dateKey: '2025-12-14', time: '10:00', patientId: 'P002', patientName: '山田 太郎', noteStatus: '×' }
+    ],
+    warnings: []
+  };
+
+  return Object.assign({
+    user: 'mock@example.com',
+    now,
+    cache: false,
+    patientInfo,
+    treatmentLogs,
+    notes,
+    aiReports,
+    invoices,
+    responsible,
+    tasksResult,
+    visitsResult
+  }, overrides || {});
+}

--- a/src/main.gs
+++ b/src/main.gs
@@ -39,7 +39,12 @@ function handleDashboardDoGet_(e) {
   if (shouldHandleDashboardApi_(e)) {
     const user = dashboardResolveRequestUser_(e);
     const cacheFlag = dashboardResolveDashboardCacheFlag_(e);
-    const data = typeof getDashboardData === 'function' ? getDashboardData({ user, cache: cacheFlag }) : {};
+    const useMock = shouldUseDashboardMockData_(e);
+    const data = useMock && typeof getDashboardMockData === 'function'
+      ? getDashboardMockData({ user, cache: cacheFlag })
+      : typeof getDashboardData === 'function'
+        ? getDashboardData({ user, cache: cacheFlag })
+        : {};
     return createJsonResponse_(data);
   }
 
@@ -82,6 +87,12 @@ function dashboardResolveDashboardCacheFlag_(e) {
   const normalized = String(raw).trim().toLowerCase();
   if (normalized === 'false' || normalized === '0' || normalized === 'off' || normalized === 'no') return false;
   return true;
+}
+
+function shouldUseDashboardMockData_(e) {
+  const raw = e && e.parameter ? e.parameter.mock : '';
+  const normalized = String(raw || '').trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes';
 }
 
 function createJsonResponse_(payload) {


### PR DESCRIPTION
## Summary
- add a reusable dashboard mock dataset to exercise getDashboardData without spreadsheets
- allow dashboard API calls to opt into mock data via query parameters and improve empty/error rendering in the dashboard UI
- wrap heavy dashboard loaders with cache-aware execution that falls back safely when CacheService is unavailable

## Testing
- for f in tests/*.test.js; do echo $f; node $f || break; done

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f8bae928483218f0b0022231a969d)