### PR TITLE
Add dashboard doGet entrypoint

### DIFF
--- a/src/dashboard/main.gs
+++ b/src/dashboard/main.gs
@@ -23,6 +23,10 @@ function handleDashboardDoGet_(e) {
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
 }
 
+function doGet(e) {
+  return handleDashboardDoGet_(e);
+}
+
 function shouldHandleDashboardRequest_(e) {
   const path = (e && e.pathInfo ? String(e.pathInfo) : '').replace(/^\/+|\/+$/g, '').toLowerCase();
   if (path === 'dashboard' || path === 'getdashboarddata') return true;

--- a/tests/dashboardDoGet.test.js
+++ b/tests/dashboardDoGet.test.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const dashboardMainCode = fs.readFileSync(
+  path.join(__dirname, '..', 'src', 'dashboard', 'main.gs'),
+  'utf8'
+);
+
+function createContext() {
+  const context = { console };
+  vm.createContext(context);
+  vm.runInContext(dashboardMainCode, context);
+  return context;
+}
+
+(function testDoGetDelegatesToHandler() {
+  const context = createContext();
+  assert.strictEqual(typeof context.doGet, 'function', 'doGet is defined');
+
+  const marker = { view: 'dashboard', mock: 'value' };
+  let received;
+  context.handleDashboardDoGet_ = e => {
+    received = e;
+    return { delegated: true, marker: e };
+  };
+
+  const response = context.doGet(marker);
+  assert.strictEqual(received, marker, 'doGet passes the request object to the handler');
+  assert.deepStrictEqual(
+    response,
+    { delegated: true, marker },
+    'doGet returns the handler response'
+  );
+})();
+
+console.log('dashboard doGet delegation test passed');


### PR DESCRIPTION
## Summary
- add a dedicated doGet entrypoint in the dashboard Apps Script bundle that delegates to the existing handler
- cover the new entrypoint with a unit test to ensure delegation behaviour

## Testing
- for f in tests/*.test.js; do echo "Running $f"; node $f || break; done


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fae6bd6ec8321a0ac99421fc96bd0)