### PR TITLE
Connect dashboard data retrieval to production resources

### DIFF
--- a/src/dashboard/config.gs
+++ b/src/dashboard/config.gs
@@ -6,3 +6,6 @@ const DASHBOARD_CACHE_TTL_SECONDS = 60;
 const DATE_FORMAT = 'yyyy/MM/dd';
 const DEBUG_MODE = false;
 const DEFAULT_TZ = 'Asia/Tokyo';
+// ダッシュボードが参照するスプレッドシートと請求書フォルダ
+const DASHBOARD_SPREADSHEET_ID = '1ajnW9Fuvu0YzUUkfTmw0CrbhrM3lM5tt5OA1dK2_CoQ';
+const DASHBOARD_INVOICE_FOLDER_ID = '1EG-GB3PbaUr9C1LJWlaf_idqoYF-19Ux';

--- a/src/dashboard/utils/sheetUtils.js
+++ b/src/dashboard/utils/sheetUtils.js
@@ -11,6 +11,18 @@ function dashboardWarn_(message) {
 }
 
 function dashboardGetSpreadsheet_() {
+  if (typeof DASHBOARD_SPREADSHEET_ID !== 'undefined' && DASHBOARD_SPREADSHEET_ID) {
+    try {
+      if (typeof SpreadsheetApp !== 'undefined'
+        && SpreadsheetApp
+        && typeof SpreadsheetApp.openById === 'function') {
+        return SpreadsheetApp.openById(DASHBOARD_SPREADSHEET_ID);
+      }
+    } catch (e) {
+      dashboardWarn_('[dashboardGetSpreadsheet] failed to open by ID: ' + (e && e.message ? e.message : e));
+    }
+  }
+
   if (typeof ss === 'function') {
     try { return ss(); } catch (e) { /* ignore */ }
   }
@@ -21,6 +33,26 @@ function dashboardGetSpreadsheet_() {
 }
 
 function dashboardGetInvoiceRootFolder_() {
+  if (typeof DASHBOARD_INVOICE_FOLDER_ID !== 'undefined' && DASHBOARD_INVOICE_FOLDER_ID) {
+    try {
+      if (typeof DriveApp !== 'undefined' && DriveApp && typeof DriveApp.getFolderById === 'function') {
+        return DriveApp.getFolderById(DASHBOARD_INVOICE_FOLDER_ID);
+      }
+    } catch (e) {
+      dashboardWarn_('[dashboardGetInvoiceRootFolder] failed to open by ID: ' + (e && e.message ? e.message : e));
+    }
+  }
+
+  if (typeof INVOICE_PARENT_FOLDER_ID !== 'undefined' && INVOICE_PARENT_FOLDER_ID) {
+    try {
+      if (typeof DriveApp !== 'undefined' && DriveApp && typeof DriveApp.getFolderById === 'function') {
+        return DriveApp.getFolderById(INVOICE_PARENT_FOLDER_ID);
+      }
+    } catch (e) {
+      dashboardWarn_('[dashboardGetInvoiceRootFolder] failed to open fallback ID: ' + (e && e.message ? e.message : e));
+    }
+  }
+
   return null;
 }
 


### PR DESCRIPTION
## Summary
- bind the dashboard data fetcher to the production spreadsheet ID and invoice folder
- add Drive/Spreadsheet fallbacks with warnings when bindings fail

## Testing
- node tests/dashboardLoadInvoices.test.js
- node tests/dashboardGetDashboardData.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fb2b1fa988321b4c5d5166c96df87)