### PR TITLE
Add dashboard sheet name config

### DIFF
--- a/src/dashboard/config.gs
+++ b/src/dashboard/config.gs
@@ -9,3 +9,8 @@ const DEFAULT_TZ = 'Asia/Tokyo';
 // ダッシュボードが参照するスプレッドシートと請求書フォルダ
 const DASHBOARD_SPREADSHEET_ID = '1ajnW9Fuvu0YzUUkfTmw0CrbhrM3lM5tt5OA1dK2_CoQ';
 const DASHBOARD_INVOICE_FOLDER_ID = '1EG-GB3PbaUr9C1LJWlaf_idqoYF-19Ux';
+// ダッシュボードが参照する各シート名
+const DASHBOARD_SHEET_PATIENTS = '患者情報';
+const DASHBOARD_SHEET_TREATMENTS = '施術録';
+const DASHBOARD_SHEET_NOTES = '申し送り';
+const DASHBOARD_SHEET_AI_REPORTS = 'AI報告書';

--- a/src/dashboard/data/loadAIReports.js
+++ b/src/dashboard/data/loadAIReports.js
@@ -19,10 +19,12 @@ function loadAIReportsUncached_() {
     return { reports, warnings };
   }
 
-  const sheet = wb.getSheetByName('AI報告書');
+  const sheetName = typeof DASHBOARD_SHEET_AI_REPORTS !== 'undefined' ? DASHBOARD_SHEET_AI_REPORTS : 'AI報告書';
+  const sheet = wb.getSheetByName(sheetName);
   if (!sheet) {
-    warnings.push('AI報告書シートが見つかりません');
-    dashboardWarn_('[loadAIReports] sheet not found');
+    const warning = `${sheetName}シートが見つかりません`;
+    warnings.push(warning);
+    dashboardWarn_(`[loadAIReports] sheet not found: ${sheetName}`);
     return { reports, warnings };
   }
 

--- a/src/dashboard/data/loadNotes.js
+++ b/src/dashboard/data/loadNotes.js
@@ -28,10 +28,12 @@ function loadNotesUncached_(_options) {
   const latestByPatient = {};
 
   const wb = dashboardGetSpreadsheet_();
-  const sheet = wb && wb.getSheetByName ? wb.getSheetByName('申し送り') : null;
+  const sheetName = typeof DASHBOARD_SHEET_NOTES !== 'undefined' ? DASHBOARD_SHEET_NOTES : '申し送り';
+  const sheet = wb && wb.getSheetByName ? wb.getSheetByName(sheetName) : null;
   if (!sheet) {
-    warnings.push('申し送りシートが見つかりません');
-    dashboardWarn_('[loadNotes] sheet not found');
+    const warning = `${sheetName}シートが見つかりません`;
+    warnings.push(warning);
+    dashboardWarn_(`[loadNotes] sheet not found: ${sheetName}`);
     return { notes: latestByPatient, warnings };
   }
 

--- a/src/dashboard/data/loadPatientInfo.js
+++ b/src/dashboard/data/loadPatientInfo.js
@@ -13,10 +13,12 @@ function loadPatientInfoUncached_(_options) {
   const warnings = [];
 
   const wb = dashboardGetSpreadsheet_();
-  const sheet = wb && wb.getSheetByName ? wb.getSheetByName('患者情報') : null;
+  const sheetName = typeof DASHBOARD_SHEET_PATIENTS !== 'undefined' ? DASHBOARD_SHEET_PATIENTS : '患者情報';
+  const sheet = wb && wb.getSheetByName ? wb.getSheetByName(sheetName) : null;
   if (!sheet) {
-    warnings.push('患者情報シートが見つかりません');
-    dashboardWarn_('[loadPatientInfo] sheet not found');
+    const warning = `${sheetName}シートが見つかりません`;
+    warnings.push(warning);
+    dashboardWarn_(`[loadPatientInfo] sheet not found: ${sheetName}`);
     return { patients, nameToId, warnings };
   }
 

--- a/src/dashboard/data/loadTreatmentLogs.js
+++ b/src/dashboard/data/loadTreatmentLogs.js
@@ -19,10 +19,12 @@ function loadTreatmentLogsUncached_(options) {
   const lastStaffByPatient = {};
 
   const wb = dashboardGetSpreadsheet_();
-  const sheet = wb && wb.getSheetByName ? wb.getSheetByName('施術録') : null;
+  const sheetName = typeof DASHBOARD_SHEET_TREATMENTS !== 'undefined' ? DASHBOARD_SHEET_TREATMENTS : '施術録';
+  const sheet = wb && wb.getSheetByName ? wb.getSheetByName(sheetName) : null;
   if (!sheet) {
-    warnings.push('施術録シートが見つかりません');
-    dashboardWarn_('[loadTreatmentLogs] sheet not found');
+    const warning = `${sheetName}シートが見つかりません`;
+    warnings.push(warning);
+    dashboardWarn_(`[loadTreatmentLogs] sheet not found: ${sheetName}`);
     return { logs, warnings, lastStaffByPatient };
   }
 


### PR DESCRIPTION
## Summary
- add dashboard sheet name constants for dashboard data sources
- update dashboard load functions to read sheet names from config and report missing sheets safely

## Testing
- for f in tests/*.test.js; do echo "Running $f"; node "$f"; done

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fb615a7608321a4707b64dea37369)