### PR TITLE
Stop storing prepared billing payload in a single JSON cell

### DIFF
--- a/tests/preparedBillingCache.test.js
+++ b/tests/preparedBillingCache.test.js
@@ -323,12 +323,15 @@ function testPreparedBillingSheetSaveAndLoad() {
   const saveResult = ctx.savePreparedBillingToSheet_('202501', payload);
   assert.strictEqual(saveResult && saveResult.billingMonth, '202501');
   const metaSheet = sheets.PreparedBillingMeta;
+  const metaJsonSheet = sheets.PreparedBillingMetaJson;
   const jsonSheet = sheets.PreparedBillingJson;
-  assert.ok(metaSheet && jsonSheet, 'Meta/Json シートが作成される');
-  assert.deepStrictEqual(metaSheet._rows[0], ['billingMonth', 'preparedAt', 'preparedBy', 'payloadVersion', 'payloadJson', 'note'], 'メタシートのヘッダーが作成される');
+  assert.ok(metaSheet && jsonSheet && metaJsonSheet, 'Meta/Json シートが作成される');
+  assert.deepStrictEqual(metaSheet._rows[0], ['billingMonth', 'preparedAt', 'preparedBy', 'payloadVersion', 'note'], 'メタシートのヘッダーが作成される');
+  assert.deepStrictEqual(metaJsonSheet._rows[0], ['billingMonth', 'chunkIndex', 'payloadChunk'], 'メタJSONシートのヘッダーが作成される');
   assert.deepStrictEqual(jsonSheet._rows[0], ['billingMonth', 'patientId', 'billingRowJson'], '明細シートのヘッダーが作成される');
   assert.strictEqual(metaSheet._rows[1][0], '202501', 'billingMonthがメタに保存される');
   assert.ok(String(metaSheet._rows[1][2]).includes('user@example.com'), '実行ユーザーが保存される');
+  assert.strictEqual(metaJsonSheet._rows.length > 1, true, 'メタJSONが分割保存される');
   assert.strictEqual(jsonSheet._rows.length, 3, 'billingJsonの件数分保存される');
 
   const loaded = ctx.loadPreparedBillingFromSheet_('202501');


### PR DESCRIPTION
## Summary
- create a dedicated PreparedBillingMetaJson sheet and split meta payload storage into size-limited chunks to avoid single-cell JSON writes
- update sheet persistence and loading to use the chunked meta storage while keeping the meta/json row flow as the only path
- adjust prepared billing tests to reflect the new meta headers and chunked persistence

## Testing
- for f in tests/*.test.js; do echo "Running $f"; node $f || break; done


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fb53622308321b661f69fd6ea17ba)