### PR TITLE
Improve dashboard warning handling for setup detection

### DIFF
--- a/src/dashboard/api/getTasks.js
+++ b/src/dashboard/api/getTasks.js
@@ -23,6 +23,9 @@ function getTasks(options) {
   if (patientInfo && Array.isArray(patientInfo.warnings)) warnings.push.apply(warnings, patientInfo.warnings);
   if (notesResult && Array.isArray(notesResult.warnings)) warnings.push.apply(warnings, notesResult.warnings);
   if (aiReports && Array.isArray(aiReports.warnings)) warnings.push.apply(warnings, aiReports.warnings);
+  const setupIncomplete = !!(patientInfo && patientInfo.setupIncomplete)
+    || !!(notesResult && notesResult.setupIncomplete)
+    || !!(aiReports && aiReports.setupIncomplete);
 
   const notesByPatient = notesResult && notesResult.notes ? notesResult.notes : {};
   const reportsByPatient = aiReports && aiReports.reports ? aiReports.reports : {};
@@ -65,7 +68,7 @@ function getTasks(options) {
     }
   });
 
-  return { tasks, warnings };
+  return { tasks, warnings, setupIncomplete };
 }
 
 function makeTask_(patientId, name, type, severity, detail) {

--- a/src/dashboard/api/getTodayVisits.js
+++ b/src/dashboard/api/getTodayVisits.js
@@ -22,6 +22,8 @@ function getTodayVisits(options) {
   const warnings = [];
   if (treatment && Array.isArray(treatment.warnings)) warnings.push.apply(warnings, treatment.warnings);
   if (notesResult && Array.isArray(notesResult.warnings)) warnings.push.apply(warnings, notesResult.warnings);
+  const setupIncomplete = !!(treatment && treatment.setupIncomplete)
+    || !!(notesResult && notesResult.setupIncomplete);
 
   const visits = [];
   logs.forEach(entry => {
@@ -44,7 +46,7 @@ function getTodayVisits(options) {
     return a.dateKey.localeCompare(b.dateKey);
   });
 
-  return { visits, warnings };
+  return { visits, warnings, setupIncomplete };
 }
 
 function resolveHandoverStatus_(dateKey, patientId, notes, tz) {

--- a/src/dashboard/data/assignResponsibleStaff.js
+++ b/src/dashboard/data/assignResponsibleStaff.js
@@ -10,6 +10,7 @@ function assignResponsibleStaff(options) {
   const patientInfo = opts.patientInfo || (typeof loadPatientInfo === 'function' ? loadPatientInfo() : null);
   const patients = patientInfo && patientInfo.patients ? patientInfo.patients : {};
   const warnings = patientInfo && Array.isArray(patientInfo.warnings) ? [].concat(patientInfo.warnings) : [];
+  const setupIncomplete = !!(patientInfo && patientInfo.setupIncomplete);
 
   const treatment = opts.treatmentLogs || (typeof loadTreatmentLogs === 'function' ? loadTreatmentLogs({ patientInfo }) : null);
   const lastStaffByPatient = treatment && treatment.lastStaffByPatient ? treatment.lastStaffByPatient : {};
@@ -31,5 +32,5 @@ function assignResponsibleStaff(options) {
     responsible[normalized] = lastStaffByPatient[pid] || null;
   });
 
-  return { responsible, warnings };
+  return { responsible, warnings, setupIncomplete: setupIncomplete || !!(treatment && treatment.setupIncomplete) };
 }

--- a/src/dashboard/data/loadAIReports.js
+++ b/src/dashboard/data/loadAIReports.js
@@ -11,12 +11,14 @@ function loadAIReports(options) {
 function loadAIReportsUncached_() {
   const reports = {};
   const warnings = [];
+  let setupIncomplete = false;
 
   const wb = dashboardGetSpreadsheet_();
   if (!wb || typeof wb.getSheetByName !== 'function') {
     warnings.push('スプレッドシートを取得できませんでした');
+    setupIncomplete = true;
     dashboardWarn_('[loadAIReports] spreadsheet unavailable');
-    return { reports, warnings };
+    return { reports, warnings, setupIncomplete };
   }
 
   const sheetName = typeof DASHBOARD_SHEET_AI_REPORTS !== 'undefined' ? DASHBOARD_SHEET_AI_REPORTS : 'AI報告書';
@@ -24,12 +26,13 @@ function loadAIReportsUncached_() {
   if (!sheet) {
     const warning = `${sheetName}シートが見つかりません`;
     warnings.push(warning);
+    setupIncomplete = true;
     dashboardWarn_(`[loadAIReports] sheet not found: ${sheetName}`);
-    return { reports, warnings };
+    return { reports, warnings, setupIncomplete };
   }
 
   const lastRow = sheet.getLastRow ? sheet.getLastRow() : 0;
-  if (lastRow < 2) return { reports, warnings };
+  if (lastRow < 2) return { reports, warnings, setupIncomplete };
 
   const lastCol = Math.max(2, sheet.getLastColumn ? sheet.getLastColumn() : (sheet.getMaxColumns ? sheet.getMaxColumns() : 2));
   const headers = sheet.getRange(1, 1, 1, lastCol).getDisplayValues()[0] || [];
@@ -60,5 +63,5 @@ function loadAIReportsUncached_() {
     reports[patientId] = dashboardFormatDate_(tsDate, tz, 'yyyy-MM-dd HH:mm');
   }
 
-  return { reports, warnings };
+  return { reports, warnings, setupIncomplete };
 }

--- a/src/dashboard/data/loadInvoices.js
+++ b/src/dashboard/data/loadInvoices.js
@@ -22,6 +22,7 @@ function loadInvoicesUncached_(options) {
   const patients = patientInfo && patientInfo.patients ? patientInfo.patients : {};
   const nameToId = opts.nameToId || (patientInfo && patientInfo.nameToId) || {};
   const warnings = patientInfo && Array.isArray(patientInfo.warnings) ? [].concat(patientInfo.warnings) : [];
+  const setupIncomplete = !!(patientInfo && patientInfo.setupIncomplete);
   const invoices = {};
   const latestMeta = {};
 
@@ -36,7 +37,7 @@ function loadInvoicesUncached_(options) {
   if (!root || typeof root.getFolders !== 'function') {
     warnings.push('請求書フォルダが取得できませんでした');
     dashboardWarn_('[loadInvoices] invoice root folder not found');
-    return { invoices, warnings };
+    return { invoices, warnings, setupIncomplete: true };
   }
 
   const tz = dashboardResolveTimeZone_();
@@ -76,7 +77,7 @@ function loadInvoicesUncached_(options) {
     }
   }
 
-  return { invoices, warnings };
+  return { invoices, warnings, setupIncomplete };
 }
 
 function isTargetInvoiceFolder_(name, targetYmDigits, targetYmKanji) {

--- a/src/dashboard/data/loadPatientInfo.js
+++ b/src/dashboard/data/loadPatientInfo.js
@@ -11,19 +11,28 @@ function loadPatientInfoUncached_(_options) {
   const patients = {};
   const nameToId = {};
   const warnings = [];
+  let setupIncomplete = false;
 
   const wb = dashboardGetSpreadsheet_();
+  if (!wb) {
+    const warning = 'スプレッドシートを取得できませんでした';
+    warnings.push(warning);
+    setupIncomplete = true;
+    dashboardWarn_('[loadPatientInfo] spreadsheet unavailable');
+    return { patients, nameToId, warnings, setupIncomplete };
+  }
   const sheetName = typeof DASHBOARD_SHEET_PATIENTS !== 'undefined' ? DASHBOARD_SHEET_PATIENTS : '患者情報';
   const sheet = wb && wb.getSheetByName ? wb.getSheetByName(sheetName) : null;
   if (!sheet) {
     const warning = `${sheetName}シートが見つかりません`;
     warnings.push(warning);
+    setupIncomplete = true;
     dashboardWarn_(`[loadPatientInfo] sheet not found: ${sheetName}`);
-    return { patients, nameToId, warnings };
+    return { patients, nameToId, warnings, setupIncomplete };
   }
 
   const lastRow = sheet.getLastRow ? sheet.getLastRow() : 0;
-  if (lastRow < 2) return { patients, nameToId, warnings };
+  if (lastRow < 2) return { patients, nameToId, warnings, setupIncomplete };
 
   const lastCol = sheet.getLastColumn ? sheet.getLastColumn() : sheet.getMaxColumns ? sheet.getMaxColumns() : 0;
   const headers = sheet.getRange(1, 1, 1, lastCol).getDisplayValues()[0] || [];
@@ -75,5 +84,5 @@ function loadPatientInfoUncached_(_options) {
     };
   }
 
-  return { patients, nameToId, warnings };
+  return { patients, nameToId, warnings, setupIncomplete };
 }

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -106,8 +106,28 @@ function testErrorIsCapturedInMeta() {
   assert.ok(result.meta.error && result.meta.error.indexOf('boom') >= 0);
 }
 
+function testWarningsAreDedupedAndSetupFlagged() {
+  const warning = '患者情報シートが見つかりません';
+  const ctx = createContext();
+  const result = ctx.getDashboardData({
+    patientInfo: { patients: {}, warnings: [warning], setupIncomplete: true },
+    notes: { notes: {}, warnings: [warning] },
+    aiReports: { reports: {}, warnings: [] },
+    invoices: { invoices: {}, warnings: [] },
+    treatmentLogs: { logs: [], warnings: [] },
+    responsible: { responsible: {}, warnings: [] },
+    tasksResult: { tasks: [], warnings: [] },
+    visitsResult: { visits: [], warnings: [] }
+  });
+
+  assert.strictEqual(result.warnings.length, 1, '同一警告は一意になる');
+  assert.strictEqual(result.warnings[0], warning);
+  assert.strictEqual(result.meta.setupIncomplete, true, 'セットアップ未完了フラグが伝搬する');
+}
+
 (function run() {
   testAggregatesDashboardData();
   testErrorIsCapturedInMeta();
+  testWarningsAreDedupedAndSetupFlagged();
   console.log('dashboardGetDashboardData tests passed');
 })();


### PR DESCRIPTION
## Summary
- deduplicate dashboard warnings and surface a setupIncomplete flag in the API response
- mark missing spreadsheets, sheets, and invoice folders as setup incomplete across dashboard data loaders
- propagate setup state through dashboard task/visit helpers and extend tests for the new behavior

## Testing
- for f in tests/*.test.js; do node $f >/tmp/testlog && tail -n +1 /tmp/testlog; done


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fb717bf7083218df3726acef7a4dd)