### PR TITLE
Propagate dashboard options and isolate monthly cache keys

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -23,9 +23,15 @@ function getDashboardData(options) {
     const patientInfo = opts.patientInfo || (typeof loadPatientInfo === 'function' ? loadPatientInfo(cacheOptions) : { patients: {}, nameToId: {}, warnings: [] });
     const notes = opts.notes || (typeof loadNotes === 'function' ? loadNotes(Object.assign({ email: meta.user }, cacheOptions)) : { notes: {}, warnings: [] });
     const aiReports = opts.aiReports || (typeof loadAIReports === 'function' ? loadAIReports(cacheOptions) : { reports: {}, warnings: [] });
-    const invoices = opts.invoices || (typeof loadInvoices === 'function' ? loadInvoices({ patientInfo }) : { invoices: {}, warnings: [] });
-    const treatmentLogs = opts.treatmentLogs || (typeof loadTreatmentLogs === 'function' ? loadTreatmentLogs({ patientInfo }) : { logs: [], warnings: [] });
-    const responsible = opts.responsible || (typeof assignResponsibleStaff === 'function' ? assignResponsibleStaff({ patientInfo, treatmentLogs }) : { responsible: {}, warnings: [] });
+    const invoices = opts.invoices || (typeof loadInvoices === 'function'
+      ? loadInvoices(Object.assign({ patientInfo, now: opts.now }, cacheOptions))
+      : { invoices: {}, warnings: [] });
+    const treatmentLogs = opts.treatmentLogs || (typeof loadTreatmentLogs === 'function'
+      ? loadTreatmentLogs(Object.assign({ patientInfo, now: opts.now }, cacheOptions))
+      : { logs: [], warnings: [] });
+    const responsible = opts.responsible || (typeof assignResponsibleStaff === 'function'
+      ? assignResponsibleStaff(Object.assign({ patientInfo, treatmentLogs, now: opts.now }, cacheOptions))
+      : { responsible: {}, warnings: [] });
 
     const tasksResult = opts.tasksResult || (typeof getTasks === 'function' ? getTasks({
       patientInfo,

--- a/src/dashboard/data/assignResponsibleStaff.js
+++ b/src/dashboard/data/assignResponsibleStaff.js
@@ -12,7 +12,7 @@ function assignResponsibleStaff(options) {
   const warnings = patientInfo && Array.isArray(patientInfo.warnings) ? [].concat(patientInfo.warnings) : [];
   const setupIncomplete = !!(patientInfo && patientInfo.setupIncomplete);
 
-  const treatment = opts.treatmentLogs || (typeof loadTreatmentLogs === 'function' ? loadTreatmentLogs({ patientInfo }) : null);
+  const treatment = opts.treatmentLogs || (typeof loadTreatmentLogs === 'function' ? loadTreatmentLogs({ patientInfo, cache: opts.cache, now: opts.now }) : null);
   const lastStaffByPatient = treatment && treatment.lastStaffByPatient ? treatment.lastStaffByPatient : {};
   if (treatment && Array.isArray(treatment.warnings)) {
     warnings.push.apply(warnings, treatment.warnings);

--- a/src/dashboard/data/loadInvoices.js
+++ b/src/dashboard/data/loadInvoices.js
@@ -9,9 +9,12 @@
  */
 function loadInvoices(options) {
   const opts = options || {};
-  const fetchFn = () => loadInvoicesUncached_(opts);
+  const now = dashboardCoerceDate_(opts.now) || new Date();
+  const fetchOptions = Object.assign({}, opts, { now });
+  const fetchFn = () => loadInvoicesUncached_(fetchOptions);
   if (typeof dashboardCacheFetch_ === 'function') {
-    return dashboardCacheFetch_(dashboardCacheKey_('invoices:v1'), fetchFn, DASHBOARD_CACHE_TTL_SECONDS, opts);
+    const keyMonth = dashboardFormatDate_(now, dashboardResolveTimeZone_(), 'yyyyMM');
+    return dashboardCacheFetch_(dashboardCacheKey_(`invoices:v1:${keyMonth}`), fetchFn, DASHBOARD_CACHE_TTL_SECONDS, fetchOptions);
   }
   return fetchFn();
 }

--- a/src/dashboard/data/loadTreatmentLogs.js
+++ b/src/dashboard/data/loadTreatmentLogs.js
@@ -3,9 +3,12 @@
  */
 function loadTreatmentLogs(options) {
   const opts = options || {};
-  const fetchFn = () => loadTreatmentLogsUncached_(opts);
+  const now = dashboardCoerceDate_(opts.now) || new Date();
+  const fetchOptions = Object.assign({}, opts, { now });
+  const fetchFn = () => loadTreatmentLogsUncached_(fetchOptions);
   if (typeof dashboardCacheFetch_ === 'function') {
-    return dashboardCacheFetch_(dashboardCacheKey_('treatmentLogs:v1'), fetchFn, DASHBOARD_CACHE_TTL_SECONDS, opts);
+    const keyMonth = dashboardFormatDate_(now, dashboardResolveTimeZone_(), 'yyyyMM');
+    return dashboardCacheFetch_(dashboardCacheKey_(`treatmentLogs:v1:${keyMonth}`), fetchFn, DASHBOARD_CACHE_TTL_SECONDS, fetchOptions);
   }
   return fetchFn();
 }
@@ -50,7 +53,8 @@ function loadTreatmentLogsUncached_(options) {
   const colEmail = dashboardResolveColumn_(headers, ['作成者', '担当者', 'email', 'createdbyemail'], 0);
 
   const tz = dashboardResolveTimeZone_();
-  const monthStart = dashboardStartOfMonth_(tz, new Date());
+  const now = dashboardCoerceDate_(opts.now) || new Date();
+  const monthStart = dashboardStartOfMonth_(tz, now);
   const prevMonthEnd = dashboardEndOfPreviousMonth_(monthStart);
 
   for (let i = 0; i < values.length; i++) {

--- a/tests/dashboardCacheKeyIsolation.test.js
+++ b/tests/dashboardCacheKeyIsolation.test.js
@@ -1,0 +1,74 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const sheetUtilsCode = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'utils', 'sheetUtils.js'), 'utf8');
+const cacheUtilsCode = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'utils', 'cacheUtils.js'), 'utf8');
+const configCode = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'config.gs'), 'utf8');
+const loadInvoicesCode = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'data', 'loadInvoices.js'), 'utf8');
+const loadTreatmentLogsCode = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'data', 'loadTreatmentLogs.js'), 'utf8');
+
+function createContext(overrides = {}) {
+  const context = {
+    console,
+    JSON,
+    Date,
+    Set,
+    Utilities: {
+      formatDate: (date, _tz, fmt) => {
+        if (fmt === 'yyyyMM') return date.toISOString().slice(0, 7).replace('-', '');
+        if (fmt === 'yyyy年MM月') {
+          const iso = date.toISOString();
+          return `${iso.slice(0, 4)}年${iso.slice(5, 7)}月`;
+        }
+        return date.toISOString();
+      }
+    },
+    Session: { getScriptTimeZone: () => 'Asia/Tokyo' }
+  };
+  vm.createContext(context);
+  vm.runInContext(configCode, context);
+  vm.runInContext(sheetUtilsCode, context);
+  vm.runInContext(cacheUtilsCode, context);
+  vm.runInContext(loadInvoicesCode, context);
+  vm.runInContext(loadTreatmentLogsCode, context);
+  Object.assign(context, overrides);
+  return context;
+}
+
+function testInvoiceCacheKeyIncludesMonth() {
+  const keys = [];
+  const ctx = createContext({
+    dashboardCacheFetch_: (key, fetchFn) => { keys.push(key); return fetchFn(); },
+    dashboardGetInvoiceRootFolder_: () => null
+  });
+
+  ctx.loadInvoices({ patientInfo: { patients: {}, warnings: [] }, now: new Date('2025-03-01T00:00:00Z') });
+  ctx.loadInvoices({ patientInfo: { patients: {}, warnings: [] }, now: new Date('2025-04-01T00:00:00Z') });
+
+  assert.notStrictEqual(keys[0], keys[1], '月が異なる場合はキャッシュキーも変わる');
+  assert.ok(keys[0].includes('202503'), 'キャッシュキーが対象月を含む');
+  assert.ok(keys[1].includes('202504'), 'キャッシュキーが対象月を含む');
+}
+
+function testTreatmentLogsCacheKeyIncludesMonth() {
+  const keys = [];
+  const ctx = createContext({
+    dashboardCacheFetch_: (key, fetchFn) => { keys.push(key); return fetchFn(); },
+    dashboardGetSpreadsheet_: () => null
+  });
+
+  ctx.loadTreatmentLogs({ patientInfo: { patients: {}, nameToId: {}, warnings: [] }, now: new Date('2025-02-15T00:00:00Z') });
+  ctx.loadTreatmentLogs({ patientInfo: { patients: {}, nameToId: {}, warnings: [] }, now: new Date('2025-03-01T00:00:00Z') });
+
+  assert.notStrictEqual(keys[0], keys[1], '施術録も月が変わればキャッシュキーが分離される');
+  assert.ok(keys[0].includes('202502'), '施術録キャッシュキーが対象月を含む');
+  assert.ok(keys[1].includes('202503'), '施術録キャッシュキーが対象月を含む');
+}
+
+(function run() {
+  testInvoiceCacheKeyIncludesMonth();
+  testTreatmentLogsCacheKeyIncludesMonth();
+  console.log('dashboard cache key isolation tests passed');
+})();

--- a/tests/dashboardGetDashboardDataOptions.test.js
+++ b/tests/dashboardGetDashboardDataOptions.test.js
@@ -1,0 +1,59 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const sheetUtilsCode = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'utils', 'sheetUtils.js'), 'utf8');
+const configCode = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'config.gs'), 'utf8');
+const dashboardCode = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'api', 'getDashboardData.js'), 'utf8');
+
+function createContext(overrides = {}) {
+  const context = {
+    console,
+    JSON,
+    Date,
+    Set,
+    Utilities: {
+      formatDate: (date, _tz, _fmt) => date.toISOString()
+    },
+    Session: {
+      getScriptTimeZone: () => 'Asia/Tokyo',
+      getActiveUser: () => ({ getEmail: () => 'session@example.com' })
+    }
+  };
+  Object.assign(context, overrides);
+  vm.createContext(context);
+  vm.runInContext(configCode, context);
+  vm.runInContext(sheetUtilsCode, context);
+  vm.runInContext(dashboardCode, context);
+  return context;
+}
+
+function testOptionsArePropagated() {
+  const now = new Date('2025-04-15T00:00:00Z');
+  const seen = {};
+  const ctx = createContext({
+    loadPatientInfo: () => ({ patients: {}, nameToId: {}, warnings: [] }),
+    loadNotes: () => ({ notes: {}, warnings: [] }),
+    loadAIReports: () => ({ reports: {}, warnings: [] }),
+    loadInvoices: opts => { seen.invoices = opts; return { invoices: {}, warnings: [] }; },
+    loadTreatmentLogs: opts => { seen.treatmentLogs = opts; return { logs: [], warnings: [], lastStaffByPatient: {} }; },
+    assignResponsibleStaff: opts => { seen.responsible = opts; return { responsible: {}, warnings: [] }; },
+    getTasks: () => ({ tasks: [], warnings: [] }),
+    getTodayVisits: () => ({ visits: [], warnings: [] })
+  });
+
+  ctx.getDashboardData({ now, cache: false });
+
+  assert.strictEqual(seen.invoices.now, now, 'loadInvoices に now が伝搬する');
+  assert.strictEqual(seen.treatmentLogs.now, now, 'loadTreatmentLogs に now が伝搬する');
+  assert.strictEqual(seen.responsible.now, now, 'assignResponsibleStaff に now が伝搬する');
+  assert.strictEqual(seen.invoices.cache, false, 'cache:false が請求書読み込みに伝搬する');
+  assert.strictEqual(seen.treatmentLogs.cache, false, 'cache:false が施術録読み込みに伝搬する');
+  assert.strictEqual(seen.responsible.cache, false, 'cache:false が担当者判定に伝搬する');
+}
+
+(function run() {
+  testOptionsArePropagated();
+  console.log('dashboardGetDashboardData options tests passed');
+})();


### PR DESCRIPTION
## Summary
- propagate dashboard `now`/`cache` options through invoice, treatment log, and responsible staff loading
- include target month in invoice and treatment log cache keys to prevent cross-month reuse
- add tests covering dashboard option propagation and monthly cache key isolation

## Testing
- for f in tests/*.test.js; do node $f; done


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fbaf68540832580fb9073cacce308)