### PR TITLE
Improve bank withdrawal flow UI and guards

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -68,10 +68,18 @@
   .override-badge{ background:#fef3c7; color:#92400e; padding:2px 6px; border-radius:8px; font-size:0.75rem; font-weight:700; white-space:nowrap; }
   .action-footer{ margin-top:12px; padding:12px 14px; border:1px dashed var(--border); border-radius:12px; display:flex; flex-wrap:wrap; gap:10px; align-items:center; justify-content:space-between; background:#f8fafc; }
   .action-buttons{ display:flex; gap:8px; flex-wrap:wrap; }
+  .bank-flow-grid{ display:grid; grid-template-columns:1.2fr 1fr; gap:18px; align-items:flex-start; }
+  .bank-actions{ display:flex; flex-direction:column; gap:12px; }
+  .bank-action{ border:1px solid var(--border); border-radius:12px; padding:12px; background:#f8fafc; display:flex; flex-direction:column; gap:8px; }
+  .bank-action .btn{ width:100%; justify-content:center; display:inline-flex; align-items:center; gap:8px; }
+  .bank-action .field-note{ margin:0; }
+  .bank-status-cards{ display:grid; grid-template-columns:1fr; gap:10px; }
+  .bank-status-cards .summary-card{ height:100%; }
   @media (max-width: 900px){
     .layout{ grid-template-columns:1fr; }
     .sidebar{ flex-direction:row; flex-wrap:wrap; align-items:center; }
     .sidebar button{ width:100%; }
+    .bank-flow-grid{ grid-template-columns:1fr; }
   }
 </style>
 </head>
@@ -107,14 +115,45 @@
     <section class="card" id="bankWithdrawalFlow">
       <h2>銀行引落管理</h2>
       <p class="muted">対象月の請求データ集計から未回収反映まで、手動で完結させるためのフローです。</p>
-      <div class="controls">
-        <label>対象月
-          <input type="month" id="bankWithdrawalMonth" />
-        </label>
-        <button class="btn" id="bankAggregateBtn" type="button" onclick="handleBankFlowAggregation()">請求データ集計</button>
-        <button class="btn secondary" id="bankSheetBtn" type="button" onclick="handleBankSheetGeneration()">銀行引落シート生成</button>
-        <button class="btn secondary" id="bankFinalizeBtn" type="button" onclick="handleBankFinalize()">確定</button>
-        <button class="btn danger" id="bankUnpaidBtn" type="button" onclick="handleBankUnpaidApply()">未回収反映</button>
+      <div class="bank-flow-grid">
+        <div class="bank-actions">
+          <div class="bank-action">
+            <label>対象月
+              <input type="month" id="bankWithdrawalMonth" />
+            </label>
+            <p class="field-note">最初に対象月を必ず選択してください。</p>
+          </div>
+          <div class="bank-action">
+            <button class="btn" id="bankAggregateBtn" type="button" onclick="handleBankFlowAggregation()">請求データ集計</button>
+            <p class="field-note">銀行引落用の請求データを集計します。</p>
+          </div>
+          <div class="bank-action">
+            <button class="btn secondary" id="bankSheetBtn" type="button" onclick="handleBankSheetGeneration()">銀行引落シート生成</button>
+            <p class="field-note">シートを作成・更新します（同月の重複生成を防止）。</p>
+          </div>
+          <div class="bank-action">
+            <button class="btn danger" id="bankUnpaidBtn" type="button" onclick="handleBankUnpaidApply()">未回収反映</button>
+            <p class="field-note">シートの未回収チェック結果を履歴へ反映します。</p>
+          </div>
+          <div class="bank-action">
+            <button class="btn secondary" id="bankFinalizeBtn" type="button" onclick="handleBankFinalize()">確定</button>
+            <p class="field-note">確定（データが揃った状態にするだけ）。</p>
+          </div>
+        </div>
+        <div class="bank-status-cards">
+          <div class="summary-card">
+            <p class="summary-label">現在の対象月</p>
+            <p class="summary-value" id="bankCurrentMonth">未選択</p>
+          </div>
+          <div class="summary-card">
+            <p class="summary-label">銀行引落シート</p>
+            <p class="summary-value" id="bankSheetStatus">未生成</p>
+          </div>
+          <div class="summary-card">
+            <p class="summary-label">未回収チェック件数</p>
+            <p class="summary-value" id="bankUnpaidCount">0件</p>
+          </div>
+        </div>
       </div>
       <div class="status-line" style="margin-top:8px">
         <div id="bankFlowStatus" class="status-line" style="flex:1"></div>

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -20,7 +20,8 @@ const bankFlowState = {
   aggregation: null,
   sheet: null,
   finalized: null,
-  unpaid: null
+  unpaid: null,
+  targetMonth: ''
 };
 
 const BILLING_BURDEN_OPTIONS = [
@@ -98,6 +99,18 @@ function getBankTargetMonth() {
   return normalizeYm(billingInput && billingInput.value ? billingInput.value : '');
 }
 
+function formatYmDisplay(ym) {
+  if (!ym || ym.length !== 6) return '';
+  return ym.slice(0, 4) + '-' + ym.slice(4);
+}
+
+function getBankSheetSummary() {
+  if (bankFlowState.sheet && bankFlowState.sheet.sheetSummary) return bankFlowState.sheet.sheetSummary;
+  if (bankFlowState.finalized && bankFlowState.finalized.sheetSummary) return bankFlowState.finalized.sheetSummary;
+  if (bankFlowState.aggregation && bankFlowState.aggregation.sheetSummary) return bankFlowState.aggregation.sheetSummary;
+  return null;
+}
+
 function updateBankControls() {
   const monthInput = qs('bankWithdrawalMonth');
   const aggregateBtn = qs('bankAggregateBtn');
@@ -105,13 +118,46 @@ function updateBankControls() {
   const finalizeBtn = qs('bankFinalizeBtn');
   const unpaidBtn = qs('bankUnpaidBtn');
   const loading = bankFlowState.loading;
+  const selectedMonth = getBankTargetMonth();
+  const sheetSummary = getBankSheetSummary();
+  const hasMonth = !!selectedMonth;
+  const hasAggregation = bankFlowState.aggregation && bankFlowState.aggregation.billingMonth === selectedMonth;
+  const hasSheet = sheetSummary && sheetSummary.exists && sheetSummary.billingMonth === selectedMonth;
 
   if (monthInput) monthInput.disabled = loading;
-  [aggregateBtn, sheetBtn, finalizeBtn, unpaidBtn].forEach(btn => {
-    if (!btn) return;
-    btn.disabled = loading;
-    btn.setAttribute('aria-busy', loading ? 'true' : 'false');
-  });
+  if (aggregateBtn) {
+    const disabled = loading || !hasMonth;
+    aggregateBtn.disabled = disabled;
+    aggregateBtn.setAttribute('aria-busy', loading ? 'true' : 'false');
+    aggregateBtn.title = disabled && !hasMonth ? '対象月を入力してください' : '';
+  }
+  if (sheetBtn) {
+    const disabled = loading || !hasMonth || !hasAggregation || hasSheet;
+    sheetBtn.disabled = disabled;
+    sheetBtn.setAttribute('aria-busy', loading ? 'true' : 'false');
+    if (!hasMonth) {
+      sheetBtn.title = '対象月を入力してください';
+    } else if (!hasAggregation) {
+      sheetBtn.title = '先に「請求データ集計」を実行してください';
+    } else if (hasSheet) {
+      sheetBtn.title = 'この月の銀行引落シートは生成済みです';
+    } else {
+      sheetBtn.title = '';
+    }
+  }
+  if (unpaidBtn) {
+    const disabled = loading || !hasMonth || !hasSheet;
+    unpaidBtn.disabled = disabled;
+    unpaidBtn.setAttribute('aria-busy', loading ? 'true' : 'false');
+    unpaidBtn.title = disabled && !hasSheet ? '銀行引落シート生成後に実行できます' : '';
+  }
+  if (finalizeBtn) {
+    const disabled = loading || !hasMonth || !hasAggregation;
+    finalizeBtn.disabled = disabled;
+    finalizeBtn.setAttribute('aria-busy', loading ? 'true' : 'false');
+    finalizeBtn.title = disabled && !hasAggregation ? '先に「請求データ集計」を実行してください' : '';
+  }
+  renderBankFlowSummary();
 }
 
 function renderBankFlowDetail() {
@@ -171,6 +217,8 @@ function renderBankFlowDetail() {
       detailEl.style.display = 'block';
     }
   }
+
+  renderBankFlowSummary();
 }
 
 function setBankLoading(flag, message) {
@@ -194,6 +242,30 @@ function normalizeYm(raw) {
   if (cleaned.length === 6) return cleaned;
   if (cleaned.length === 4) return cleaned + '01';
   return '';
+}
+
+function renderBankFlowSummary() {
+  const ym = bankFlowState.targetMonth || getBankTargetMonth();
+  const displayYm = ym ? formatYmDisplay(ym) : '未選択';
+  const summary = getBankSheetSummary();
+  const currentMonthEl = qs('bankCurrentMonth');
+  const sheetStatusEl = qs('bankSheetStatus');
+  const unpaidCountEl = qs('bankUnpaidCount');
+
+  if (currentMonthEl) {
+    currentMonthEl.textContent = displayYm || '未選択';
+  }
+  if (sheetStatusEl) {
+    if (summary && summary.exists) {
+      sheetStatusEl.textContent = `${formatYmDisplay(summary.billingMonth)} 生成済み（${summary.rows || 0}行）`;
+    } else {
+      sheetStatusEl.textContent = '未生成';
+    }
+  }
+  if (unpaidCountEl) {
+    const count = summary && typeof summary.unpaidChecked === 'number' ? summary.unpaidChecked : 0;
+    unpaidCountEl.textContent = `${count}件`;
+  }
 }
 
 function logBillingState(stage, extra) {
@@ -1091,6 +1163,7 @@ function handleBankFlowAggregation() {
     alert('対象月を入力してください (YYYY-MM)');
     return;
   }
+  bankFlowState.targetMonth = ym;
   setBankLoading(true, '請求データ集計中…');
   google.script.run
     .withSuccessHandler(function(result) {
@@ -1114,6 +1187,12 @@ function handleBankSheetGeneration() {
     alert('対象月を入力してください (YYYY-MM)');
     return;
   }
+  const summary = getBankSheetSummary();
+  if (summary && summary.exists && summary.billingMonth === ym) {
+    alert('この月の銀行引落シートは既に生成済みです。対象月を変更してください。');
+    return;
+  }
+  bankFlowState.targetMonth = ym;
   setBankLoading(true, '銀行引落シート生成中…');
   google.script.run
     .withSuccessHandler(function(result) {
@@ -1135,6 +1214,7 @@ function handleBankFinalize() {
     alert('対象月を入力してください (YYYY-MM)');
     return;
   }
+  bankFlowState.targetMonth = ym;
   setBankLoading(true, '確定処理中…');
   google.script.run
     .withSuccessHandler(function(result) {
@@ -1156,6 +1236,7 @@ function handleBankUnpaidApply() {
     alert('対象月を入力してください (YYYY-MM)');
     return;
   }
+  bankFlowState.targetMonth = ym;
   setBankLoading(true, '未回収履歴へ反映中…');
   google.script.run
     .withSuccessHandler(function(result) {
@@ -1585,6 +1666,13 @@ function initBillingPage() {
   const bankMonthInput = qs('bankWithdrawalMonth');
   if (bankMonthInput && !bankMonthInput.value) {
     bankMonthInput.value = input && input.value ? input.value : getDefaultMonth();
+  }
+  if (bankMonthInput) {
+    bankFlowState.targetMonth = normalizeYm(bankMonthInput.value);
+    bankMonthInput.onchange = function () {
+      bankFlowState.targetMonth = normalizeYm(this.value);
+      updateBankControls();
+    };
   }
   updateBillingControls();
   updateBankControls();


### PR DESCRIPTION
## Summary
- Rework the bank withdrawal section layout with ordered actions, helper text, and status cards for the current month, sheet state, and unpaid check counts
- Add guardrails that disable actions when the month is not set or prerequisites are missing, including preventing duplicate sheet generation
- Track the selected month in state so the UI stays in sync with the operator’s selection

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ff05d44c8832598d25b2aabd6c964)