### PR TITLE
Add unpaid alert aggregation to dashboard

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -63,6 +63,10 @@
   .loading{ position:fixed; inset:0; display:flex; align-items:center; justify-content:center; background:rgba(11,21,36,0.72); z-index:20; }
   .loading.hidden{ display:none; }
   .spinner{ width:40px; height:40px; border-radius:50%; border:4px solid rgba(56,189,248,0.3); border-top-color:var(--accent); animation:spin 0.8s linear infinite; }
+  .alert-card{ display:flex; flex-direction:column; gap:8px; }
+  .alert-metrics{ display:flex; gap:8px; flex-wrap:wrap; align-items:center; }
+  .alert-amount{ font-size:1.1rem; font-weight:800; color:#fbbf24; }
+  .alert-months{ display:flex; gap:6px; flex-wrap:wrap; font-size:0.9rem; color:var(--muted); }
   @keyframes spin{ to{ transform:rotate(360deg); } }
   @media (max-width:640px){
     .visit{ grid-template-columns:60px 1fr; }
@@ -87,6 +91,14 @@
       <span class="small" id="taskCount"></span>
     </div>
     <div class="grid" id="taskList"></div>
+  </div>
+
+  <div class="section">
+    <div class="section-header">
+      <h2>未回収アラート</h2>
+      <span class="small" id="unpaidAlertCount"></span>
+    </div>
+    <div class="grid" id="unpaidAlertList"></div>
   </div>
 
   <div class="section">
@@ -170,6 +182,7 @@ function renderAll() {
   renderMeta();
   renderWarnings();
   renderTasks();
+  renderUnpaidAlerts();
   renderVisits();
   renderPatients();
   renderError();
@@ -270,6 +283,66 @@ function renderTasks() {
       detail.className = 'muted';
       detail.textContent = String(task.detail);
       card.appendChild(detail);
+    }
+
+    list.appendChild(card);
+  });
+}
+
+function renderUnpaidAlerts() {
+  const list = document.getElementById('unpaidAlertList');
+  const count = document.getElementById('unpaidAlertCount');
+  if (!list) return;
+  list.innerHTML = '';
+
+  const alerts = dashboardState.data && Array.isArray(dashboardState.data.unpaidAlerts)
+    ? dashboardState.data.unpaidAlerts
+    : [];
+  if (count) count.textContent = alerts.length ? `${alerts.length}件` : 'アラートなし';
+
+  if (!alerts.length) {
+    const empty = document.createElement('div');
+    empty.className = 'muted';
+    empty.textContent = '連続未回収の対象はありません';
+    list.appendChild(empty);
+    return;
+  }
+
+  alerts.forEach(alert => {
+    const card = document.createElement('div');
+    card.className = 'card alert-card';
+
+    const header = document.createElement('div');
+    header.className = 'patient-header';
+    const name = document.createElement('div');
+    name.className = 'patient-name';
+    name.textContent = alert.patientName || '氏名未登録';
+    header.appendChild(name);
+    const tags = document.createElement('div');
+    tags.style.display = 'flex';
+    tags.style.gap = '6px';
+    tags.style.flexWrap = 'wrap';
+    if (alert.patientId) tags.appendChild(makeBadge('ID: ' + alert.patientId));
+    header.appendChild(tags);
+    card.appendChild(header);
+
+    const metrics = document.createElement('div');
+    metrics.className = 'alert-metrics';
+    const months = document.createElement('span');
+    months.className = 'badge';
+    months.textContent = `連続${alert.consecutiveMonths}ヶ月`;
+    metrics.appendChild(months);
+    const amount = document.createElement('span');
+    amount.className = 'alert-amount';
+    amount.textContent = formatCurrency(alert.totalAmount);
+    metrics.appendChild(amount);
+    card.appendChild(metrics);
+
+    if (Array.isArray(alert.months) && alert.months.length) {
+      const monthList = document.createElement('div');
+      monthList.className = 'alert-months';
+      monthList.textContent = '対象月: ' + alert.months.map(m => m.key).join(', ');
+      card.appendChild(monthList);
     }
 
     list.appendChild(card);
@@ -491,6 +564,15 @@ function formatTaskLabel(type) {
     case 'aiReportDelayed': return '医師報告書遅延';
     case 'invoiceUnconfirmed': return '請求書確認待ち';
     default: return 'タスク';
+  }
+}
+
+function formatCurrency(amount) {
+  const num = Number(amount) || 0;
+  try {
+    return num.toLocaleString('ja-JP', { style: 'currency', currency: 'JPY', maximumFractionDigits: 0 });
+  } catch (_err) {
+    return `¥${num.toFixed(0)}`;
   }
 }
 

--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -32,6 +32,9 @@ function getDashboardData(options) {
     const responsible = opts.responsible || (typeof assignResponsibleStaff === 'function'
       ? assignResponsibleStaff(Object.assign({ patientInfo, treatmentLogs, now: opts.now }, cacheOptions))
       : { responsible: {}, warnings: [] });
+    const unpaidAlertsResult = opts.unpaidAlerts || (typeof loadUnpaidAlerts === 'function'
+      ? loadUnpaidAlerts(Object.assign({ patientInfo, now: opts.now }, cacheOptions))
+      : { alerts: [], warnings: [] });
 
     const tasksResult = opts.tasksResult || (typeof getTasks === 'function' ? getTasks({
       patientInfo,
@@ -62,6 +65,7 @@ function getDashboardData(options) {
       invoices,
       treatmentLogs,
       responsible,
+      unpaidAlertsResult,
       tasksResult,
       visitsResult
     ]);
@@ -72,6 +76,7 @@ function getDashboardData(options) {
       tasks: tasksResult && tasksResult.tasks ? tasksResult.tasks : [],
       todayVisits: visitsResult && visitsResult.visits ? visitsResult.visits : [],
       patients,
+      unpaidAlerts: unpaidAlertsResult && unpaidAlertsResult.alerts ? unpaidAlertsResult.alerts : [],
       warnings: warningState.warnings,
       meta
     };

--- a/src/dashboard/config.gs
+++ b/src/dashboard/config.gs
@@ -14,3 +14,7 @@ const DASHBOARD_SHEET_PATIENTS = '患者情報';
 const DASHBOARD_SHEET_TREATMENTS = '施術録';
 const DASHBOARD_SHEET_NOTES = '申し送り';
 const DASHBOARD_SHEET_AI_REPORTS = 'AI報告書';
+const DASHBOARD_SHEET_UNPAID_HISTORY = '未回収履歴';
+
+// 未回収アラート判定に利用する連続月数のデフォルト値
+const DASHBOARD_UNPAID_ALERT_MONTHS = 3;

--- a/src/dashboard/data/loadUnpaidAlerts.js
+++ b/src/dashboard/data/loadUnpaidAlerts.js
@@ -1,0 +1,225 @@
+/**
+ * 未回収履歴から連続未回収アラートを組み立てる。
+ * @param {Object} [options]
+ * @param {Object} [options.patientInfo]
+ * @param {number} [options.consecutiveMonths]
+ * @param {Date} [options.now]
+ * @return {{alerts: Object[], warnings: string[], setupIncomplete: boolean}}
+ */
+function loadUnpaidAlerts(options) {
+  const opts = options || {};
+  const normalizedThreshold = normalizeUnpaidThreshold_(opts.consecutiveMonths);
+  const now = dashboardCoerceDate_(opts.now) || new Date();
+  const fetchOptions = Object.assign({}, opts, { consecutiveMonths: normalizedThreshold, now });
+  const fetchFn = () => loadUnpaidAlertsUncached_(fetchOptions);
+  return dashboardCacheFetch_(
+    dashboardCacheKey_(`unpaidAlerts:v1:${normalizedThreshold}`),
+    fetchFn,
+    DASHBOARD_CACHE_TTL_SECONDS,
+    fetchOptions
+  );
+}
+
+function loadUnpaidAlertsUncached_(options) {
+  const opts = options || {};
+  const threshold = normalizeUnpaidThreshold_(opts.consecutiveMonths);
+  const tz = dashboardResolveTimeZone_();
+
+  const patientInfo = opts.patientInfo || (typeof loadPatientInfo === 'function' ? loadPatientInfo(opts) : null);
+  const patients = patientInfo && patientInfo.patients ? patientInfo.patients : {};
+
+  const history = readUnpaidHistory_(Object.assign({}, opts, { tz }));
+
+  const warnings = [];
+  if (patientInfo && Array.isArray(patientInfo.warnings)) warnings.push.apply(warnings, patientInfo.warnings);
+  if (history && Array.isArray(history.warnings)) warnings.push.apply(warnings, history.warnings);
+
+  const alerts = buildUnpaidAlerts_(history.entries, patients, threshold, tz);
+
+  return {
+    alerts,
+    warnings,
+    setupIncomplete: !!(patientInfo && patientInfo.setupIncomplete) || !!(history && history.setupIncomplete)
+  };
+}
+
+function readUnpaidHistory_(options) {
+  const opts = options || {};
+  const entries = [];
+  const warnings = [];
+  let setupIncomplete = false;
+
+  const wb = dashboardGetSpreadsheet_();
+  if (!wb) {
+    warnings.push('スプレッドシートを取得できませんでした');
+    setupIncomplete = true;
+    return { entries, warnings, setupIncomplete };
+  }
+
+  const sheetName = typeof DASHBOARD_SHEET_UNPAID_HISTORY !== 'undefined' ? DASHBOARD_SHEET_UNPAID_HISTORY : '未回収履歴';
+  const sheet = wb && wb.getSheetByName ? wb.getSheetByName(sheetName) : null;
+  if (!sheet) {
+    warnings.push(`${sheetName}シートが見つかりません`);
+    setupIncomplete = true;
+    return { entries, warnings, setupIncomplete };
+  }
+
+  const lastRow = sheet.getLastRow ? sheet.getLastRow() : 0;
+  if (lastRow < 2) return { entries, warnings, setupIncomplete };
+
+  const lastCol = sheet.getLastColumn ? sheet.getLastColumn() : sheet.getMaxColumns ? sheet.getMaxColumns() : 0;
+  const headers = sheet.getRange(1, 1, 1, lastCol).getDisplayValues()[0] || [];
+  const values = sheet.getRange(2, 1, lastRow - 1, lastCol).getValues();
+  const displayValues = sheet.getRange(2, 1, lastRow - 1, lastCol).getDisplayValues();
+
+  const colPatientId = dashboardResolveColumn_(headers, ['患者ID', 'patientId', 'ID', 'id'], 1);
+  const colMonth = dashboardResolveColumn_(headers, ['対象月', '月', '年月', '請求月'], 2);
+  const colAmount = dashboardResolveColumn_(headers, ['金額', '未回収金額', '請求額', '額'], 3);
+  const colReason = dashboardResolveColumn_(headers, ['理由', '未回収理由', '未回収備考'], 4);
+  const colMemo = dashboardResolveColumn_(headers, ['備考', 'メモ'], 5);
+  const colRecordedAt = dashboardResolveColumn_(headers, ['記録日時', 'timestamp', '記録日', '入力日時'], 6);
+
+  for (let i = 0; i < values.length; i++) {
+    const row = values[i] || [];
+    const rowDisplay = displayValues[i] || [];
+    const rowNumber = i + 2;
+
+    const patientId = dashboardNormalizePatientId_(rowDisplay[colPatientId - 1] || row[colPatientId - 1]);
+    if (!patientId) {
+      warnings.push(`未回収履歴の患者IDが空です (row:${rowNumber})`);
+      continue;
+    }
+
+    const monthKey = normalizeUnpaidMonthKey_(rowDisplay[colMonth - 1] || row[colMonth - 1], opts.tz);
+    if (!monthKey) {
+      warnings.push(`未回収履歴の対象月を解釈できません (row:${rowNumber})`);
+      continue;
+    }
+
+    const amount = coerceUnpaidAmount_(row[colAmount - 1] != null ? row[colAmount - 1] : rowDisplay[colAmount - 1]);
+    const reason = String(rowDisplay[colReason - 1] || row[colReason - 1] || '').trim();
+    const memo = String(rowDisplay[colMemo - 1] || row[colMemo - 1] || '').trim();
+    const recordedAt = dashboardParseTimestamp_(row[colRecordedAt - 1] || rowDisplay[colRecordedAt - 1]);
+
+    entries.push({ patientId, monthKey, amount, reason, memo, recordedAt });
+  }
+
+  return { entries, warnings, setupIncomplete };
+}
+
+function buildUnpaidAlerts_(entries, patients, threshold, tz) {
+  const grouped = {};
+  (entries || []).forEach(entry => {
+    const pid = dashboardNormalizePatientId_(entry && entry.patientId);
+    if (!pid || !entry || !entry.monthKey) return;
+    if (!grouped[pid]) {
+      grouped[pid] = { totals: {}, records: {} };
+    }
+    grouped[pid].totals[entry.monthKey] = (grouped[pid].totals[entry.monthKey] || 0) + (entry.amount || 0);
+    if (!grouped[pid].records[entry.monthKey]) grouped[pid].records[entry.monthKey] = [];
+    grouped[pid].records[entry.monthKey].push({
+      amount: entry.amount || 0,
+      reason: entry.reason || '',
+      memo: entry.memo || '',
+      recordedAt: entry.recordedAt instanceof Date && !Number.isNaN(entry.recordedAt.getTime())
+        ? dashboardFormatDate_(entry.recordedAt, tz, 'yyyy-MM-dd HH:mm')
+        : ''
+    });
+  });
+
+  const alerts = [];
+  Object.keys(grouped).forEach(pid => {
+    const bucket = grouped[pid];
+    const runKeys = summarizeLatestRun_(bucket.totals);
+    if (runKeys.length < threshold) return;
+
+    const months = runKeys.map(key => ({
+      key,
+      amount: bucket.totals[key] || 0,
+      records: (bucket.records[key] || []).map(record => Object.assign({}, record)),
+      followUp: { phone: false, visit: false }
+    }));
+
+    const totalAmount = months.reduce((sum, month) => sum + (Number(month.amount) || 0), 0);
+    const patient = patients && patients[pid] ? patients[pid] : {};
+
+    alerts.push({
+      patientId: pid,
+      patientName: patient.name || patient.patientName || '',
+      consecutiveMonths: runKeys.length,
+      totalAmount,
+      months,
+      followUp: { phone: false, visit: false }
+    });
+  });
+
+  alerts.sort((a, b) => {
+    if (b.consecutiveMonths !== a.consecutiveMonths) return b.consecutiveMonths - a.consecutiveMonths;
+    if (b.totalAmount !== a.totalAmount) return b.totalAmount - a.totalAmount;
+    return (a.patientName || '').localeCompare(b.patientName || '', 'ja');
+  });
+
+  return alerts;
+}
+
+function summarizeLatestRun_(monthTotals) {
+  const parsed = Object.keys(monthTotals || {})
+    .map(key => ({ key, ordinal: unpaidMonthOrdinal_(key) }))
+    .filter(entry => entry.ordinal !== null)
+    .sort((a, b) => b.ordinal - a.ordinal);
+
+  if (!parsed.length) return [];
+
+  const run = [parsed[0].key];
+  for (let i = 1; i < parsed.length; i++) {
+    if (parsed[i - 1].ordinal - parsed[i].ordinal === 1) {
+      run.push(parsed[i].key);
+    } else {
+      break;
+    }
+  }
+  return run;
+}
+
+function normalizeUnpaidThreshold_(value) {
+  const raw = Number(value);
+  if (Number.isFinite(raw) && raw > 0) return Math.floor(raw);
+  if (typeof DASHBOARD_UNPAID_ALERT_MONTHS === 'number' && Number.isFinite(DASHBOARD_UNPAID_ALERT_MONTHS)) {
+    return Math.max(1, Math.floor(DASHBOARD_UNPAID_ALERT_MONTHS));
+  }
+  return 3;
+}
+
+function normalizeUnpaidMonthKey_(value, tz) {
+  const parsed = dashboardCoerceDate_(value);
+  if (parsed instanceof Date && !Number.isNaN(parsed.getTime())) {
+    return dashboardFormatDate_(new Date(parsed.getFullYear(), parsed.getMonth(), 1), tz, 'yyyy-MM');
+  }
+  const str = String(value == null ? '' : value).trim();
+  if (!str) return '';
+  const digits = str.replace(/[^0-9]/g, '');
+  if (digits.length >= 6) {
+    const year = digits.slice(0, 4);
+    const month = digits.slice(4, 6);
+    if (Number(month) >= 1 && Number(month) <= 12) {
+      return `${year}-${month}`;
+    }
+  }
+  return '';
+}
+
+function unpaidMonthOrdinal_(monthKey) {
+  const match = String(monthKey || '').match(/^([0-9]{4})-([0-9]{2})$/);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  if (!Number.isFinite(year) || !Number.isFinite(month)) return null;
+  return year * 12 + (month - 1);
+}
+
+function coerceUnpaidAmount_(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  const digits = String(value == null ? '' : value).replace(/[^0-9.-]/g, '');
+  const parsed = Number(digits);
+  return Number.isFinite(parsed) ? parsed : 0;
+}

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -53,6 +53,7 @@ function testAggregatesDashboardData() {
   const responsible = { responsible: { '001': 'staff@example.com' }, warnings: ['r1'] };
   const tasksResult = { tasks: [{ type: 'consentWarning', patientId: '001' }], warnings: ['task'] };
   const visitsResult = { visits: [{ patientId: '001', time: '10:00' }], warnings: ['visit'] };
+  const unpaidAlerts = { alerts: [{ patientId: '001', patientName: '山田太郎', consecutiveMonths: 3, totalAmount: 15000, months: [], followUp: { phone: false, visit: false } }], warnings: ['u1'] };
 
   const ctx = createContext();
   const result = ctx.getDashboardData({
@@ -63,6 +64,7 @@ function testAggregatesDashboardData() {
     invoices,
     treatmentLogs,
     responsible,
+    unpaidAlerts,
     tasksResult,
     visitsResult
   });
@@ -90,8 +92,10 @@ function testAggregatesDashboardData() {
       row: 5
     }
   });
+  assert.strictEqual(result.unpaidAlerts.length, 1, '未回収アラートが伝搬する');
+  assert.strictEqual(result.unpaidAlerts[0].patientId, '001');
   const warnings = JSON.parse(JSON.stringify(result.warnings)).sort();
-  assert.deepStrictEqual(warnings, ['a1', 'i1', 'n1', 'p1', 'r1', 't1', 'task', 'visit'].sort());
+  assert.deepStrictEqual(warnings, ['a1', 'i1', 'n1', 'p1', 'r1', 't1', 'task', 'u1', 'visit'].sort());
 }
 
 function testErrorIsCapturedInMeta() {

--- a/tests/dashboardGetDashboardDataOptions.test.js
+++ b/tests/dashboardGetDashboardDataOptions.test.js
@@ -32,13 +32,15 @@ function createContext(overrides = {}) {
 function testOptionsArePropagated() {
   const now = new Date('2025-04-15T00:00:00Z');
   const seen = {};
+  const patientInfo = { patients: {}, nameToId: {}, warnings: [] };
   const ctx = createContext({
-    loadPatientInfo: () => ({ patients: {}, nameToId: {}, warnings: [] }),
+    loadPatientInfo: () => patientInfo,
     loadNotes: () => ({ notes: {}, warnings: [] }),
     loadAIReports: () => ({ reports: {}, warnings: [] }),
     loadInvoices: opts => { seen.invoices = opts; return { invoices: {}, warnings: [] }; },
     loadTreatmentLogs: opts => { seen.treatmentLogs = opts; return { logs: [], warnings: [], lastStaffByPatient: {} }; },
     assignResponsibleStaff: opts => { seen.responsible = opts; return { responsible: {}, warnings: [] }; },
+    loadUnpaidAlerts: opts => { seen.unpaidAlerts = opts; return { alerts: [], warnings: [] }; },
     getTasks: () => ({ tasks: [], warnings: [] }),
     getTodayVisits: () => ({ visits: [], warnings: [] })
   });
@@ -51,6 +53,9 @@ function testOptionsArePropagated() {
   assert.strictEqual(seen.invoices.cache, false, 'cache:false が請求書読み込みに伝搬する');
   assert.strictEqual(seen.treatmentLogs.cache, false, 'cache:false が施術録読み込みに伝搬する');
   assert.strictEqual(seen.responsible.cache, false, 'cache:false が担当者判定に伝搬する');
+  assert.strictEqual(seen.unpaidAlerts.patientInfo, patientInfo, '未回収アラートに患者情報が伝搬する');
+  assert.strictEqual(seen.unpaidAlerts.now, now, '未回収アラートに now が伝搬する');
+  assert.strictEqual(seen.unpaidAlerts.cache, false, '未回収アラート読み込みも cache:false を受け取る');
 }
 
 (function run() {

--- a/tests/dashboardLoadUnpaidAlerts.test.js
+++ b/tests/dashboardLoadUnpaidAlerts.test.js
@@ -1,0 +1,98 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const sheetUtilsCode = fs.readFileSync(path.join(__dirname, '../src/dashboard/utils/sheetUtils.js'), 'utf8');
+const configCode = fs.readFileSync(path.join(__dirname, '../src/dashboard/config.gs'), 'utf8');
+const cacheUtilsCode = fs.readFileSync(path.join(__dirname, '../src/dashboard/utils/cacheUtils.js'), 'utf8');
+const unpaidAlertsCode = fs.readFileSync(path.join(__dirname, '../src/dashboard/data/loadUnpaidAlerts.js'), 'utf8');
+
+function createSheet(rows) {
+  const headers = ['患者ID', '対象月', '金額', '理由', '備考', '記録日時'];
+  const data = rows || [];
+  return {
+    getLastRow: () => 1 + data.length,
+    getLastColumn: () => headers.length,
+    getRange: (row, col, numRows, numCols) => {
+      if (row === 1) {
+        return { getDisplayValues: () => [headers.slice(col - 1, col - 1 + numCols)] };
+      }
+      const slice = data.slice(row - 2, row - 2 + numRows).map(r => {
+        const rowData = [];
+        for (let i = 0; i < numCols; i++) {
+          rowData[i] = r[col - 1 + i];
+        }
+        return rowData;
+      });
+      return {
+        getValues: () => slice,
+        getDisplayValues: () => slice
+      };
+    }
+  };
+}
+
+function createContext(sheet) {
+  const workbook = { getSheetByName: name => (name === '未回収履歴' ? sheet : null) };
+  const Utilities = {
+    formatDate: (date, _tz, format) => {
+      const iso = date.toISOString();
+      if (format === 'yyyy-MM') return iso.slice(0, 7);
+      if (format === 'yyyy-MM-dd HH:mm') return iso.replace('T', ' ').slice(0, 16);
+      return iso;
+    }
+  };
+
+  const context = {
+    console,
+    Utilities,
+    Session: { getScriptTimeZone: () => 'Asia/Tokyo' },
+    dashboardGetSpreadsheet_: () => workbook
+  };
+  vm.createContext(context);
+  vm.runInContext(configCode, context);
+  vm.runInContext(sheetUtilsCode, context);
+  vm.runInContext(cacheUtilsCode, context);
+  context.dashboardGetSpreadsheet_ = () => workbook;
+  vm.runInContext(unpaidAlertsCode, context);
+  return context;
+}
+
+function testConsecutiveUnpaidAlertsAreCollected() {
+  const sheet = createSheet([
+    ['001', '2024-01-10', 10000, '確認中', '', '2024-02-05T00:00:00Z'],
+    ['001', '2023/12/01', 20000, '', '', '2024-01-10T00:00:00Z'],
+    ['001', '2023-11-01', 30000, '', '', '2023-12-05T00:00:00Z'],
+    ['002', '2023-12-01', 5000, '', '', '2023-12-10T00:00:00Z']
+  ]);
+  const ctx = createContext(sheet);
+  const result = ctx.loadUnpaidAlerts({
+    patientInfo: { patients: { '001': { name: '山田太郎' }, '002': { name: '佐藤花子' } }, warnings: [] }
+  });
+
+  assert.strictEqual(result.alerts.length, 1, '連続3ヶ月のみが抽出される');
+  const alert = result.alerts[0];
+  assert.strictEqual(alert.patientId, '001');
+  assert.strictEqual(alert.patientName, '山田太郎');
+  assert.strictEqual(alert.consecutiveMonths, 3);
+  assert.strictEqual(alert.totalAmount, 60000);
+  assert.strictEqual(alert.months.map(m => m.key).join(','), '2024-01,2023-12,2023-11');
+}
+
+function testMissingSheetProducesWarning() {
+  const workbook = { getSheetByName: () => null };
+  const context = createContext(null);
+  context.dashboardGetSpreadsheet_ = () => workbook;
+  const result = context.loadUnpaidAlerts({ patientInfo: { patients: {}, warnings: [] } });
+
+  assert.ok(Array.isArray(result.alerts) && result.alerts.length === 0);
+  assert.strictEqual(result.setupIncomplete, true);
+  assert.ok(result.warnings.some(w => w.includes('未回収履歴')), 'シート欠如の警告が含まれる');
+}
+
+(function run() {
+  testConsecutiveUnpaidAlertsAreCollected();
+  testMissingSheetProducesWarning();
+  console.log('dashboardLoadUnpaidAlerts tests passed');
+})();


### PR DESCRIPTION
## Summary
- add unpaid history aggregation to produce consecutive-month alert data
- expose unpaid alerts via the dashboard API and render a new section displaying streaks and totals
- cover unpaid alert loading and option propagation with new tests

## Testing
- node tests/dashboardGetDashboardData.test.js
- node tests/dashboardGetDashboardDataOptions.test.js
- node tests/dashboardLoadUnpaidAlerts.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ff1bcb51883258a0a9d7f18a10943)