### PR TITLE
Handle unpaid history fallback and refresh bank sheets

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -11,6 +11,10 @@ if (typeof billingLogger_ === 'undefined') {
   billingLogger_ = { log: billingFallbackLog_ }; // eslint-disable-line no-global-assign
 }
 
+const billingUnpaidHistorySheetName_ = typeof UNPAID_HISTORY_SHEET_NAME === 'string'
+  ? UNPAID_HISTORY_SHEET_NAME
+  : '未回収履歴';
+
 const billingNormalizeHeaderKey_ = typeof normalizeHeaderKey_ === 'function'
   ? normalizeHeaderKey_
   : function normalizeHeaderKey_(s) {
@@ -1353,7 +1357,7 @@ function extractUnpaidBillingHistory(targetBillingMonth) {
 }
 
 function extractUnpaidHistoryFromSheet_() {
-  const sheet = billingSs().getSheetByName(UNPAID_HISTORY_SHEET_NAME);
+  const sheet = billingSs().getSheetByName(billingUnpaidHistorySheetName_);
   if (!sheet) return [];
   const lastRow = sheet.getLastRow();
   if (lastRow < 2) return [];


### PR DESCRIPTION
## Summary
- add a local fallback for the unpaid history sheet name when billing constants are unavailable
- refresh bank withdrawal sheets from the template when regenerating and handle sheets without getMaxRows

## Testing
- for f in tests/*.test.js; do echo "Running $f"; node $f || break; done

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ff49cd0448325b2540aa388fc7bec)