### PR TITLE
Fix duplicate billingSs declaration

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -203,35 +203,6 @@ const BILLING_PATIENT_COLS_FIXED = typeof PATIENT_COLS_FIXED !== 'undefined' ? P
   share: 47
 };
 
-function resolveBillingSpreadsheet_() {
-  const scriptProps = typeof PropertiesService !== 'undefined'
-    ? PropertiesService.getScriptProperties()
-    : null;
-  const configuredId = (scriptProps && scriptProps.getProperty('SSID'))
-    || (typeof APP !== 'undefined' ? (APP.SSID || '') : '');
-
-  if (configuredId) {
-    try {
-      return SpreadsheetApp.openById(configuredId);
-    } catch (err) {
-      console.warn('[billing] Failed to open SSID from config:', configuredId, err);
-    }
-  }
-
-  if (typeof ss === 'function') {
-    try {
-      const workbook = ss();
-      if (workbook) return workbook;
-    } catch (err2) {
-      console.warn('[billing] Fallback ss() failed', err2);
-    }
-  }
-
-  return SpreadsheetApp.getActiveSpreadsheet();
-}
-
-const billingSs = resolveBillingSpreadsheet_;
-
 const BILLING_PATIENT_RAW_COL_LIMIT = columnLetterToNumber_('BJ');
 const BILLING_TREATMENT_SHEET_NAME = '施術録';
 const BILLING_PAYMENT_RESULT_SHEET_PREFIX = '入金結果_';

--- a/src/main.gs
+++ b/src/main.gs
@@ -60,7 +60,43 @@ function ss() {
 }
 
 function billingSs() {
+  if (typeof resolveBillingSpreadsheet_ === 'function') {
+    try {
+      const resolved = resolveBillingSpreadsheet_();
+      if (resolved) return resolved;
+    } catch (err) {
+      console.warn('[billing] resolveBillingSpreadsheet_ failed in billingSs', err);
+    }
+  }
+
   return ss();
+}
+
+function resolveBillingSpreadsheet_() {
+  const scriptProps = typeof PropertiesService !== 'undefined'
+    ? PropertiesService.getScriptProperties()
+    : null;
+  const configuredId = (scriptProps && scriptProps.getProperty('SSID'))
+    || (typeof APP !== 'undefined' ? (APP.SSID || '') : '');
+
+  if (configuredId) {
+    try {
+      return SpreadsheetApp.openById(configuredId);
+    } catch (err) {
+      console.warn('[billing] Failed to open SSID from config:', configuredId, err);
+    }
+  }
+
+  if (typeof ss === 'function') {
+    try {
+      const workbook = ss();
+      if (workbook) return workbook;
+    } catch (err2) {
+      console.warn('[billing] Fallback ss() failed', err2);
+    }
+  }
+
+  return SpreadsheetApp.getActiveSpreadsheet();
 }
 
 /**


### PR DESCRIPTION
## Summary
- centralize billing spreadsheet accessor in `main.gs` using resolve logic
- remove duplicate `billingSs` declaration in `billingGet.js` to prevent syntax errors

## Testing
- npm test --silent

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ff7e579108325a769031e5e3b9e35)