### PR TITLE
Add fallback for billingSs in billingGet

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -11,6 +11,15 @@ if (typeof billingLogger_ === 'undefined') {
   billingLogger_ = { log: billingFallbackLog_ }; // eslint-disable-line no-global-assign
 }
 
+if (typeof billingSs === 'undefined') {
+  function billingSs() {
+    if (typeof SpreadsheetApp !== 'undefined' && SpreadsheetApp.getActiveSpreadsheet) {
+      return SpreadsheetApp.getActiveSpreadsheet();
+    }
+    throw new Error('billingSs is not available');
+  }
+}
+
 const billingUnpaidHistorySheetName_ = typeof UNPAID_HISTORY_SHEET_NAME === 'string'
   ? UNPAID_HISTORY_SHEET_NAME
   : '未回収履歴';


### PR DESCRIPTION
## Summary
- add a fallback billingSs helper so billingGet can run without external bootstrap code
- keep billing data retrieval working in isolation environments

## Testing
- for f in tests/*.test.js; do node $f; done

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940ff080840832587bc71989fae8182)