### PR TITLE
Add simplified bank withdrawal UI

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -113,8 +113,8 @@
       </section>
 
     <section class="card" id="bankWithdrawalFlow">
-      <h2>銀行引落管理</h2>
-      <p class="muted">対象月の請求データ集計から未回収反映まで、手動で完結させるためのフローです。</p>
+      <h2>簡易銀行引落</h2>
+      <p class="muted">銀行情報シートを丸ごとコピーし、名前一致の患者に請求金額をS列へ転記します。</p>
       <div class="bank-flow-grid">
         <div class="bank-actions">
           <div class="bank-action">
@@ -124,20 +124,8 @@
             <p class="field-note">最初に対象月を必ず選択してください。</p>
           </div>
           <div class="bank-action">
-            <button class="btn" id="bankAggregateBtn" type="button" onclick="handleBankFlowAggregation()">請求データ集計</button>
-            <p class="field-note">銀行引落用の請求データを集計します。</p>
-          </div>
-          <div class="bank-action">
-            <button class="btn secondary" id="bankSheetBtn" type="button" onclick="handleBankSheetGeneration()">銀行引落シート生成</button>
-            <p class="field-note">シートを作成・更新します（同月の重複生成を防止）。</p>
-          </div>
-          <div class="bank-action">
-            <button class="btn danger" id="bankUnpaidBtn" type="button" onclick="handleBankUnpaidApply()">未回収反映</button>
-            <p class="field-note">シートの未回収チェック結果を履歴へ反映します。</p>
-          </div>
-          <div class="bank-action">
-            <button class="btn secondary" id="bankFinalizeBtn" type="button" onclick="handleBankFinalize()">確定</button>
-            <p class="field-note">確定（データが揃った状態にするだけ）。</p>
+            <button class="btn secondary" id="simpleBankGenerateBtn" type="button" onclick="handleSimpleBankSheetGeneration()">簡易銀行シート生成</button>
+            <p class="field-note">銀行情報をコピーし、請求額のみ転記します。口座情報がない患者は警告表示のみです。</p>
           </div>
         </div>
         <div class="bank-status-cards">
@@ -150,7 +138,7 @@
             <p class="summary-value" id="bankSheetStatus">未生成</p>
           </div>
           <div class="summary-card">
-            <p class="summary-label">未回収チェック件数</p>
+            <p class="summary-label">口座未登録 / 金額なし</p>
             <p class="summary-value" id="bankUnpaidCount">0件</p>
           </div>
         </div>

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -24,6 +24,14 @@ const bankFlowState = {
   targetMonth: ''
 };
 
+const simpleBankState = {
+  loading: false,
+  status: '',
+  error: '',
+  result: null,
+  targetMonth: ''
+};
+
 const BILLING_BURDEN_OPTIONS = [
   { value: 1, label: '1割' },
   { value: 2, label: '2割' },
@@ -97,6 +105,11 @@ function getBankTargetMonth() {
   if (input && input.value) return normalizeYm(input.value);
   const billingInput = qs('billingMonth');
   return normalizeYm(billingInput && billingInput.value ? billingInput.value : '');
+}
+
+function getSimpleBankMonth() {
+  const input = qs('bankWithdrawalMonth');
+  return input && input.value ? normalizeYm(input.value) : '';
 }
 
 function formatYmDisplay(ym) {
@@ -266,6 +279,132 @@ function renderBankFlowSummary() {
     const count = summary && typeof summary.unpaidChecked === 'number' ? summary.unpaidChecked : 0;
     unpaidCountEl.textContent = `${count}件`;
   }
+}
+
+function updateSimpleBankControls() {
+  const monthInput = qs('bankWithdrawalMonth');
+  const generateBtn = qs('simpleBankGenerateBtn');
+  const loading = simpleBankState.loading;
+  const hasMonth = !!(simpleBankState.targetMonth || getSimpleBankMonth());
+
+  if (monthInput) monthInput.disabled = loading;
+  if (generateBtn) {
+    generateBtn.disabled = loading || !hasMonth;
+    generateBtn.setAttribute('aria-busy', loading ? 'true' : 'false');
+    generateBtn.title = hasMonth ? '' : '対象月を入力してください';
+  }
+}
+
+function renderSimpleBankSummary() {
+  const ym = simpleBankState.targetMonth || getSimpleBankMonth();
+  const displayYm = ym ? formatYmDisplay(ym) : '未選択';
+  const summary = simpleBankState.result;
+  const currentMonthEl = qs('bankCurrentMonth');
+  const sheetStatusEl = qs('bankSheetStatus');
+  const missingEl = qs('bankUnpaidCount');
+
+  if (currentMonthEl) {
+    currentMonthEl.textContent = displayYm || '未選択';
+  }
+  if (sheetStatusEl) {
+    if (summary && summary.sheetName) {
+      sheetStatusEl.textContent = `${summary.sheetName}（${summary.rows || 0}行）`;
+    } else {
+      sheetStatusEl.textContent = '未生成';
+    }
+  }
+  if (missingEl) {
+    const missingCount = summary && Array.isArray(summary.missingAccounts)
+      ? summary.missingAccounts.length
+      : 0;
+    missingEl.textContent = `${missingCount}件`;
+  }
+}
+
+function renderSimpleBankDetail() {
+  const statusEl = qs('bankFlowStatus');
+  const errorEl = qs('bankFlowError');
+  const detailEl = qs('bankFlowDetail');
+  const summary = simpleBankState.result;
+
+  if (statusEl) {
+    statusEl.textContent = simpleBankState.status || 'まだ実行していません。';
+  }
+
+  if (errorEl) {
+    if (simpleBankState.error) {
+      errorEl.textContent = simpleBankState.error;
+      errorEl.style.display = 'block';
+    } else {
+      errorEl.textContent = '';
+      errorEl.style.display = 'none';
+    }
+  }
+
+  if (detailEl) {
+    const lines = [];
+    if (summary && summary.sheetName) {
+      lines.push(`シート名: ${summary.sheetName}`);
+      lines.push(`行数: ${summary.rows || 0} 行`);
+      lines.push(`金額転記: ${summary.filled || 0} 件`);
+    }
+    if (summary && Array.isArray(summary.missingAccounts) && summary.missingAccounts.length) {
+      lines.push('口座情報なし: ' + summary.missingAccounts.join(', '));
+    }
+    if (lines.length) {
+      detailEl.innerHTML = '<ul><li>' + lines.map(escapeHtml).join('</li><li>') + '</li></ul>';
+      detailEl.style.display = 'block';
+    } else {
+      detailEl.textContent = '銀行処理の結果がここに表示されます。';
+      detailEl.style.display = 'block';
+    }
+  }
+
+  renderSimpleBankSummary();
+}
+
+function setSimpleBankLoading(flag, message) {
+  simpleBankState.loading = !!flag;
+  simpleBankState.status = flag ? (message || '') : simpleBankState.status;
+  if (flag) simpleBankState.error = '';
+  updateSimpleBankControls();
+  renderSimpleBankDetail();
+}
+
+function setSimpleBankError(message, err) {
+  const detail = err && err.message ? err.message : (err != null ? String(err) : '');
+  simpleBankState.error = message ? `${message}: ${detail || ''}` : (detail || '不明なエラー');
+  simpleBankState.loading = false;
+  renderSimpleBankDetail();
+}
+
+function onSimpleBankCompleted(result) {
+  simpleBankState.loading = false;
+  simpleBankState.result = result || null;
+  const missing = result && Array.isArray(result.missingAccounts) ? result.missingAccounts : [];
+  const filledText = result ? `${result.filled || 0}/${result.rows || 0}件` : '';
+  simpleBankState.status = result ? `銀行シートを作成しました（${filledText}）` : '銀行シートを作成しました。';
+  simpleBankState.error = missing.length ? `口座情報が見つからない患者: ${missing.join(', ')}` : '';
+  renderSimpleBankDetail();
+  updateSimpleBankControls();
+}
+
+function handleSimpleBankSheetGeneration() {
+  const ym = getSimpleBankMonth();
+  if (!ym) {
+    alert('対象月を入力してください (YYYY-MM)');
+    return;
+  }
+  simpleBankState.targetMonth = ym;
+  setSimpleBankLoading(true, '銀行シート作成中…');
+  google.script.run
+    .withSuccessHandler(function(result) {
+      onSimpleBankCompleted(result);
+    })
+    .withFailureHandler(function(err) {
+      setSimpleBankError('銀行シート生成に失敗しました', err);
+    })
+    .generateSimpleBankSheet(ym);
 }
 
 function logBillingState(stage, extra) {
@@ -1668,16 +1807,17 @@ function initBillingPage() {
     bankMonthInput.value = input && input.value ? input.value : getDefaultMonth();
   }
   if (bankMonthInput) {
-    bankFlowState.targetMonth = normalizeYm(bankMonthInput.value);
+    simpleBankState.targetMonth = normalizeYm(bankMonthInput.value);
     bankMonthInput.onchange = function () {
-      bankFlowState.targetMonth = normalizeYm(this.value);
-      updateBankControls();
+      simpleBankState.targetMonth = normalizeYm(this.value);
+      updateSimpleBankControls();
+      renderSimpleBankSummary();
     };
   }
   updateBillingControls();
-  updateBankControls();
+  updateSimpleBankControls();
   renderBillingResult();
-  renderBankFlowDetail();
+  renderSimpleBankDetail();
 }
 
 (function bootstrap() {
@@ -1701,9 +1841,6 @@ if (billingGlobal) {
   billingGlobal.handleBillingAggregation = handleBillingAggregation;
   billingGlobal.handleBillingPdfGeneration = handleBillingPdfGeneration;
   billingGlobal.handleBillingSaveEdits = handleBillingSaveEdits;
-  billingGlobal.handleBankFlowAggregation = handleBankFlowAggregation;
-  billingGlobal.handleBankSheetGeneration = handleBankSheetGeneration;
-  billingGlobal.handleBankFinalize = handleBankFinalize;
-  billingGlobal.handleBankUnpaidApply = handleBankUnpaidApply;
+  billingGlobal.handleSimpleBankSheetGeneration = handleSimpleBankSheetGeneration;
 }
 </script>


### PR DESCRIPTION
## Summary
- add a simplified bank section that generates a monthly sheet from the bank info copy and fills patient amounts
- implement a minimal Apps Script endpoint to copy the bank info sheet, match patients by name, and write amounts to column S while warning on missing accounts
- update status messaging to show the selected month, generated sheet, and any patients without account data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941252280b483259ac76897bb7724e9)