### PR TITLE
Fix bank withdrawal matching using full name

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -332,6 +332,16 @@ function normalizeBillingNameKey_(value) {
   return String(value || '').replace(/\s+/g, '').trim();
 }
 
+function normalizeBillingFullNameKey_(nameKanji, nameKana) {
+  const kanjiKey = normalizeBillingNameKey_(nameKanji);
+  const kanaKey = normalizeBillingNameKey_(nameKana);
+  const combined = [kanjiKey, kanaKey].filter(Boolean).join('::');
+  if (!combined) return '';
+  const numericOnly = combined.replace(/::/g, '');
+  if (/^\d+$/.test(numericOnly)) return '';
+  return combined;
+}
+
 function loadBillingStaffDirectory_() {
   const sheet = billingSs().getSheetByName('スタッフ一覧');
   if (!sheet) return {};
@@ -1164,9 +1174,11 @@ function getBillingBankRecords() {
 function buildBankLookupByKanji_(bankRecords) {
   return (bankRecords || []).reduce((map, rec) => {
     if (!rec) return map;
-    const key = normalizeBillingNameKey_(rec.nameKanji);
-    if (key && !map[key]) {
-      map[key] = rec;
+    const key = normalizeBillingFullNameKey_(rec.nameKanji, rec.nameKana);
+    const fallbackKey = key || normalizeBillingNameKey_(rec.nameKanji);
+    const targetKey = key || fallbackKey;
+    if (targetKey && !map[targetKey]) {
+      map[targetKey] = rec;
     }
     return map;
   }, {});

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -120,6 +120,16 @@ function normalizeBillingNameKey_(value) {
   return String(value || '').replace(/\s+/g, '').trim();
 }
 
+function normalizeBillingFullNameKey_(nameKanji, nameKana) {
+  const kanjiKey = normalizeBillingNameKey_(nameKanji);
+  const kanaKey = normalizeBillingNameKey_(nameKana);
+  const combined = [kanjiKey, kanaKey].filter(Boolean).join('::');
+  if (!combined) return '';
+  const numericOnly = combined.replace(/::/g, '');
+  if (/^\d+$/.test(numericOnly)) return '';
+  return combined;
+}
+
 function normalizeKana_(value) {
   return String(value || '')
     .normalize('NFKC')
@@ -419,7 +429,7 @@ function buildBankTransferRowsForBilling_(billingJson, bankInfoByName, patientMa
     total += 1;
     const patient = patientMap && patientMap[pid] ? patientMap[pid] : {};
     const nameKanji = item && item.nameKanji ? String(item.nameKanji).trim() : '';
-    const nameKey = normalizeBillingNameKey_(nameKanji);
+    const nameKey = normalizeBillingFullNameKey_(nameKanji, item && item.nameKana);
     const bankLookup = bankInfoByName && nameKey ? bankInfoByName[nameKey] : null;
 
     const pickWithPriority = (resolver, fallbackValue) => {


### PR DESCRIPTION
## Summary
- add a shared helper that builds composite kanji + furigana keys for billing lookups while ignoring numeric-only values
- match bank records, prepared patient maps, and withdrawal sheet rows by the combined full-name key instead of patient IDs or month
- update withdrawal amount and unpaid-entry processing to use the new matching key without halting when names are unmatched

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941383c1cb883258233a7505e275352)