### PR TITLE
Handle raw patient name headers when building name map

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1041,8 +1041,8 @@ function buildPatientNameToIdMap_(patients) {
   return entries.reduce((map, pid) => {
     const patient = patients[pid] || {};
     const key = buildFullNameKey_(
-      patient.nameKanji || (patient.raw && patient.raw.nameKanji),
-      patient.nameKana || (patient.raw && patient.raw.nameKana)
+      patient.nameKanji || (patient.raw && (patient.raw.nameKanji || patient.raw['氏名'])),
+      patient.nameKana || (patient.raw && (patient.raw.nameKana || patient.raw['フリガナ']))
     );
     const normalizedPid = billingNormalizePatientId_(pid);
     if (key && normalizedPid && !map[key]) {


### PR DESCRIPTION
## Summary
- add fallback to raw header labels when building patient name-to-id map
- ensure billing name lookup works when patients only have original header fields

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69437fea47e88325a24f0978b333721d)