### PR TITLE
Align billing name key normalization

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1092,6 +1092,13 @@ function ensureBankWithdrawalSheet_(billingMonth, options) {
   return sheet;
 }
 
+function normalizeBillingNameKey_(value) {
+  return String(value || '')
+    .normalize('NFKC')
+    .replace(/\s+/g, '')
+    .trim();
+}
+
 function buildFullNameKey_(nameKanji, nameKana) {
   const kanjiKey = normalizeBillingNameKey_(nameKanji);
   const kanaKey = normalizeBillingNameKey_(nameKana);


### PR DESCRIPTION
## Summary
- normalize billing name keys with NFKC whitespace stripping and document the canonical key generation
- apply the unified name key builder across bank info, patient master, and billing JSON mapping for bank exports
- add a regression test to ensure the unified key links bank data, patient master entries, and billing records

## Testing
- node tests/billingOutput.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943b52f8a4883259beaf2f7f3585edb)