### PR TITLE
Add shared patient ID aliases

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -585,8 +585,11 @@ function toBooleanFromCell_(cell){
 }
 
 /***** 先頭行（見出し）の揺れに耐えるためのラベル候補群 *****/
+const PATIENT_ID_LABELS = [
+  '施術録番号', '施術録No', '施術録NO', '記録番号', 'カルテ番号', '患者ID', '患者番号', 'recNo', 'patientId'
+];
 const LABELS = {
-  recNo:     ['施術録番号','施術録No','施術録NO','記録番号','カルテ番号','患者ID','患者番号'],
+  recNo:     PATIENT_ID_LABELS,
   name:      ['名前','氏名','患者名','お名前'],
   hospital:  ['病院名','医療機関','病院'],
   doctor:    ['医師','主治医','担当医'],

--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -136,8 +136,12 @@ const billingNormalizeBurdenRatio_ = typeof normalizeBurdenRatio_ === 'function'
     return null;
   };
 
+const BILLING_PATIENT_ID_LABELS = typeof PATIENT_ID_LABELS !== 'undefined'
+  ? PATIENT_ID_LABELS
+  : ['施術録番号', '施術録No', '施術録NO', '記録番号', 'カルテ番号', '患者ID', '患者番号', 'recNo', 'patientId'];
+
 const BILLING_LABELS = typeof LABELS !== 'undefined' ? LABELS : {
-  recNo: ['施術録番号', '施術録No', '施術録NO', '記録番号', 'カルテ番号', '患者ID', '患者番号'],
+  recNo: BILLING_PATIENT_ID_LABELS,
   name: ['名前', '氏名', '患者名', 'お名前'],
   hospital: ['病院名', '医療機関', '病院'],
   doctor: ['医師', '主治医', '担当医'],


### PR DESCRIPTION
## Summary
- add shared patient ID alias list to unify patient identifier labels across sheets
- reuse the shared alias list in billing data retrieval to cover recNo/patientId variations

## Testing
- node tests/*.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69465c1ad30c83219a22e33af3af0a91)