### PR TITLE
Use final visit staff for invoice folders

### DIFF
--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -289,7 +289,9 @@ function generateBillingJsonFromSource(sourceData) {
       ? resolvedStaffNames
       : staffEmails.map(email => billingResolveStaffDisplayName_(email, staffDirectory)).filter(Boolean);
     const responsibleEmail = staffEmails.length ? staffEmails[0] : '';
-    const responsibleName = responsibleNames.join('・');
+    const responsibleName = responsibleNames.length
+      ? responsibleNames[0]
+      : (responsibleEmail ? billingResolveStaffDisplayName_(responsibleEmail, staffDirectory) : '');
     const carryOverFromPatient = normalizeMoneyNumber_(patient.carryOverAmount);
     const carryOverFromHistory = normalizeMoneyNumber_(carryOverByPatient[pid]);
     const manualUnitPrice = normalizeMoneyNumber_(patient.manualUnitPrice != null ? patient.manualUnitPrice : patient.unitPrice);


### PR DESCRIPTION
## Summary
- ensure invoice responsibility uses the most recent visit staff instead of concatenated names
- preserve staff lists for display while setting a single responsible name for folder naming
- add a billing logic test covering latest-visit staff selection

## Testing
- node tests/billingLogic.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69466bd5f2b0832196bca28920955cc3)