### PR TITLE
Select invoice folder staff from latest monthly visit

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -1503,6 +1503,7 @@ function getBillingSourceData(billingMonth) {
     bankInfoByName: buildBankLookupByKanji_(bankRecords),
     bankStatuses: getBillingPaymentResultsIfExists_(month),
     staffByPatient: visitCountsResult.staffByPatient || {},
+    staffHistoryByPatient: visitCountsResult.staffHistoryByPatient || {},
     staffDirectory,
       staffDisplayByPatient,
       unpaidHistory,


### PR DESCRIPTION
## Summary
- propagate monthly staff visit history to billing JSON generation
- choose invoice folder responsible staff based on the latest visit in the billing month instead of array order

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946701e013c832192898afd9bf141dd)