### PR TITLE
Add receipt display handling to invoice template data

### DIFF
--- a/tests/billingInvoiceLayout.test.js
+++ b/tests/billingInvoiceLayout.test.js
@@ -108,12 +108,36 @@ function testInvoiceTemplateRecalculatesSelfPaidBreakdown() {
   assert.strictEqual(data.grandTotal, 3366, '合計は再計算された施術料と交通費に基づく');
 }
 
+function testInvoiceTemplateAddsReceiptDecision() {
+  const unpaid = buildInvoiceTemplateData_({
+    billingMonth: '202311',
+    receiptStatus: 'UNPAID'
+  });
+
+  assert.strictEqual(unpaid.showReceipt, false, 'UNPAID の月は領収書を表示しない');
+
+  const aggregated = buildInvoiceTemplateData_({
+    billingMonth: '202311',
+    aggregateUntilMonth: '202312',
+    receiptStatus: 'AGGREGATE'
+  });
+
+  assert.strictEqual(aggregated.showReceipt, true, 'AGGREGATE 指定は領収書を表示対象とする');
+  assert.deepStrictEqual(Array.from(aggregated.receiptMonths || []), ['202311', '202312'], '合算対象の月を保持する');
+  assert.strictEqual(
+    aggregated.receiptRemark,
+    '令和5年11月分・12月分施術代として',
+    '合算領収の但し書きを生成する'
+  );
+}
+
 function run() {
   testInvoiceChargeBreakdown();
   testInvoiceChargeBreakdownUsesCustomTransportPrice();
   testInvoiceHtmlIncludesBreakdown();
   testInvoiceHtmlEscapesUserInput();
   testInvoiceTemplateRecalculatesSelfPaidBreakdown();
+  testInvoiceTemplateAddsReceiptDecision();
   console.log('billingInvoiceLayout tests passed');
 }
 


### PR DESCRIPTION
## Summary
- add helpers to normalize months and compute receipt visibility/remarks for invoices
- include receipt display metadata in invoice template data without changing the PDF template
- cover the new receipt determination logic with layout tests

## Testing
- node tests/billingInvoiceLayout.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69469c9f7a2883218f8bb22475f277cd)