### PR TITLE
Document receipt display validation rules

### DIFF
--- a/docs/billing-receipt-status.md
+++ b/docs/billing-receipt-status.md
@@ -15,6 +15,45 @@
 - `UNPAID` / `HOLD` は常に非表示（`showReceipt: false`）。その他のステータスは `null` / 空文字 / `AGGREGATE` / `aggregateUntilMonth` 指定時のみ `true` になる。【F:src/output/billingOutput.js†L298-L318】
 - `aggregateUntilMonth` がある場合のみ備考（`receiptRemark`）が付き、請求月から指定月までを令和表記で連結する。【F:src/output/billingOutput.js†L284-L318】
 
+## `resolveInvoiceReceiptDisplay_` / `formatAggregatedReceiptRemark_` 期待仕様（詳細）
+空値/UNPAID/HOLD/AGGREGATE/合算無しの主要ケースをテーブル化し、表示可否と備考の期待値を明示する。
+
+| receiptStatus 入力 | aggregateUntilMonth 入力 | 想定される整形結果 | showReceipt | receiptRemark | receiptMonths 例 | 備考 |
+| --- | --- | --- | --- | --- | --- | --- |
+| `null` / 空文字 | 未指定 | `receiptStatus: ''`（正規化）、`aggregateUntilMonth: ''` | `true` | `''` | `['202501']` | 「未指定は表示するが備考なし」の基準ケース |
+| `UNPAID` | 未指定/指定 | `status: 'UNPAID'` | `false` | `''` | `['202501']` or `['202501','202502']` など | 支払待ちは常に非表示。合算指定があっても備考は付けない |
+| `HOLD` | 未指定/指定 | `status: 'HOLD'` | `false` | `''` | `['202501']` or `['202501','202502']` など | 保留も非表示で固定 |
+| `AGGREGATE` | `202503`（請求月 202501） | `status: 'AGGREGATE'`、`aggregateUntilMonth: '202503'` | `true` | `令和7年1月分・03月分施術代として` | `['202501','202502','202503']` | 月範囲を令和表記（開始は年付、以降は月のみ）で連結 |
+| `AGGREGATE` | 未指定/空文字 | `status: 'AGGREGATE'`、`aggregateUntilMonth: ''` | `true` | `''` | `['202501']` | 集計終了月が無くても領収書は表示、備考は空 |
+| `PAID` / その他 | 未指定 | `status: 'PAID'` | `false` | `''` | `['202501']` | 合算無しの通常ステータスは非表示 |
+| `PAID` / その他 | `202503`（請求月 202501） | `status: 'PAID'`、`aggregateUntilMonth: '202503'` | `true` | `令和7年1月分・03月分施術代として` | `['202501','202502','202503']` | 合算指定があればステータスに関わらず表示し備考を付ける |
+
+上記表は `resolveInvoiceReceiptDisplay_` と `formatAggregatedReceiptRemark_` の現行挙動に沿った期待値であり、今後のテストケース作成時の基準とする。【F:src/output/billingOutput.js†L284-L318】
+
+## `aggregateUntilMonth` のバリデーション仕様（定義案）
+- **フォーマット**: `YYYYMM` 6 桁数字。非数・桁不足は無効扱いとし、`normalizeInvoiceMonthKey_` で正規化できない値は空に落とす。【F:src/output/billingOutput.js†L246-L258】
+- **範囲**: `200001`〜`209912` を有効とし、それ以外はエラー扱いにして空へフォールバック（上限/下限は Issue で調整可）。
+- **請求月との前後関係**: `aggregateUntilMonth` は請求月以上を許容し、それより前なら無効とみなす。逆転時は単月に丸めず空へフォールバックする。
+- **エラー時のフォールバック**:
+  - `resolveInvoiceReceiptDisplay_` は請求月のみで `receiptMonths` を構成し、`showReceipt` は `receiptStatus` に基づく（`AGGREGATE` でも合算無しと同等）。
+  - 備考は常に空文字。
+  - UI もしくはログで「集計終了月が無効」のメッセージを出せるよう Issue を起票する。
+
+## 合算ユーティリティの仕様適合確認と追加タスク
+- `buildInclusiveMonthRange_` は開始 > 終了で開始のみ返却し、240 ヶ月で打ち切る現行挙動。上記バリデーションでは「請求月より前は無効にして空へフォールバック」にしたいため、逆転時の返却値を空にする修正が必要（Issue 化）。【F:src/output/billingOutput.js†L259-L282】
+- `formatAggregatedReceiptRemark_` は月ラベル生成に失敗した要素を除外するため、部分的に無効な配列でも出力される。月範囲が欠落している場合は備考を空に統一する仕様としたいので、無効要素を含む場合は空文字を返すよう変更が必要（Issue 化）。【F:src/output/billingOutput.js†L284-L305】
+- 上記 2 点を Issue に記載し、実装は後続とする。
+
+## 受入条件（ロジック単体テスト入力例と期待出力）
+- **空ステータス**: `{ billingMonth: '202501', receiptStatus: null, aggregateUntilMonth: null }` → `showReceipt: true`、`receiptRemark: ''`、`receiptMonths: ['202501']`。
+- **UNPAID**: `{ billingMonth: '202501', receiptStatus: 'UNPAID', aggregateUntilMonth: '202503' }` → `showReceipt: false`、`receiptRemark: ''`、`receiptMonths: ['202501','202502','202503']`。
+- **HOLD**: `{ billingMonth: '202501', receiptStatus: 'HOLD', aggregateUntilMonth: null }` → `showReceipt: false`、`receiptRemark: ''`、`receiptMonths: ['202501']`。
+- **AGGREGATE + 正常月**: `{ billingMonth: '202501', receiptStatus: 'AGGREGATE', aggregateUntilMonth: '202503' }` → `showReceipt: true`、`receiptRemark: '令和7年1月分・03月分施術代として'`、`receiptMonths: ['202501','202502','202503']`。
+- **AGGREGATE + 終了月欠落**: `{ billingMonth: '202501', receiptStatus: 'AGGREGATE', aggregateUntilMonth: '' }` → `showReceipt: true`、`receiptRemark: ''`、`receiptMonths: ['202501']`。
+- **PAID + 合算無し**: `{ billingMonth: '202501', receiptStatus: 'PAID', aggregateUntilMonth: null }` → `showReceipt: false`、`receiptRemark: ''`、`receiptMonths: ['202501']`。
+- **PAID + 合算指定**: `{ billingMonth: '202501', receiptStatus: 'PAID', aggregateUntilMonth: '202503' }` → `showReceipt: true`、`receiptRemark: '令和7年1月分・03月分施術代として'`、`receiptMonths: ['202501','202502','202503']`。
+- **無効な aggregateUntilMonth**: `{ billingMonth: '202501', receiptStatus: 'AGGREGATE', aggregateUntilMonth: '20241234' }` → `aggregateUntilMonth` を無効として扱い、`showReceipt: true`、`receiptRemark: ''`、`receiptMonths: ['202501']`（バリデーション後のフォールバックを確認）。
+
 ## 請求月キー正規化と月範囲ビルダーの挙動
 - `normalizeBillingMonthKeySafe_` は引数がオブジェクトの場合、`key` / `billingMonth` / `ym` / `month.key` / `month.ym` / `month` の順に候補を拾う。各候補を `normalizeBillingMonthInput` で厳密変換し、例外時は文字列化してトリムした値でフォールバックする。候補が全て空なら空文字を返す（空入力時の安全な戻り値）。【F:src/main.gs†L165-L189】
 - 未来月や任意の 6 桁数字は `normalizeBillingMonthInput` が弾かないため、そのままキー化される（例: `209912` も通る）。月部分が 1〜12 以外なら例外が発生し、上記フォールバックでトリム済み文字列か空文字になる。【F:src/get/billingGet.js†L236-L271】


### PR DESCRIPTION
## Summary
- add detailed expectations for resolveInvoiceReceiptDisplay_ and formatAggregatedReceiptRemark_ across key status combinations
- define aggregateUntilMonth validation and fallback behavior plus utility gaps to address in follow-up issues
- list acceptance test input/output examples for receipt display logic

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946a739ca3c8321b66cda18fd03313a)