### PR TITLE
Overwrite receipt status when updating billing history

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -1106,19 +1106,11 @@ function appendBillingHistoryRows(billingJson, options) {
     }
 
     if (columns.receiptStatus) {
-      const existingReceiptStatus = existingRow ? existingRow[columns.receiptStatus - 1] : '';
-      const resolvedReceiptStatus = (existingReceiptStatus != null && String(existingReceiptStatus).trim() !== '')
-        ? existingReceiptStatus
-        : entry.row[columns.receiptStatus - 1];
-      mergedRow[columns.receiptStatus - 1] = resolvedReceiptStatus;
+      mergedRow[columns.receiptStatus - 1] = entry.row[columns.receiptStatus - 1];
     }
 
     if (columns.aggregateUntilMonth) {
-      const existingAggregate = existingRow ? existingRow[columns.aggregateUntilMonth - 1] : '';
-      const resolvedAggregate = (existingAggregate != null && String(existingAggregate).trim() !== '')
-        ? existingAggregate
-        : entry.row[columns.aggregateUntilMonth - 1];
-      mergedRow[columns.aggregateUntilMonth - 1] = resolvedAggregate;
+      mergedRow[columns.aggregateUntilMonth - 1] = entry.row[columns.aggregateUntilMonth - 1];
     }
 
     workingRowsByKey.set(entry.key, mergedRow);


### PR DESCRIPTION
## Summary
- always write prepared receipt status and aggregate end month into billing history rows instead of keeping prior values
- add FakeSheet test helper and regression test to ensure receipt fields are overwritten

## Testing
- node tests/billingOutput.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ac5bacb08321bc82a014ac5986bd)