### PR TITLE
Update receipt display logic for receipt issuance rules

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -312,14 +312,18 @@ function resolveInvoiceReceiptDisplay_(item) {
     return { showReceipt: false, receiptRemark: '', receiptMonths: aggregateMonths };
   }
 
-  const shouldShow = status === null || status === ''
-    ? true
-    : (status === 'AGGREGATE' ? hasValidAggregateUntil : hasValidAggregateUntil);
-  const receiptRemark = shouldShow && hasValidAggregateUntil ? formatAggregatedReceiptRemark_(aggregateMonths) : '';
+  if (status === 'AGGREGATE') {
+    const showAggregateReceipt = hasValidAggregateUntil;
+    return {
+      showReceipt: showAggregateReceipt,
+      receiptRemark: showAggregateReceipt ? formatAggregatedReceiptRemark_(aggregateMonths) : '',
+      receiptMonths: aggregateMonths
+    };
+  }
 
   return {
-    showReceipt: shouldShow,
-    receiptRemark,
+    showReceipt: true,
+    receiptRemark: hasValidAggregateUntil ? formatAggregatedReceiptRemark_(aggregateMonths) : '',
     receiptMonths: aggregateMonths
   };
 }

--- a/tests/billingOutput.test.js
+++ b/tests/billingOutput.test.js
@@ -241,6 +241,26 @@ function testAggregateReceiptIsHiddenUntilEndMonthIsValid() {
   );
 }
 
+function testPaidInvoiceAlwaysShowsReceipt() {
+  const context = createContext();
+  vm.createContext(context);
+  vm.runInContext(billingOutputCode, context);
+
+  const { resolveInvoiceReceiptDisplay_ } = context;
+
+  const defaultStatus = resolveInvoiceReceiptDisplay_({ billingMonth: '202501', receiptStatus: null });
+  assert.strictEqual(defaultStatus.showReceipt, true, 'ステータス未指定でも領収書を表示する');
+  assert.deepStrictEqual(
+    Array.from(defaultStatus.receiptMonths || []),
+    ['202501'],
+    '請求月の領収書を作成する'
+  );
+
+  const paidStatus = resolveInvoiceReceiptDisplay_({ billingMonth: '202501', receiptStatus: 'PAID' });
+  assert.strictEqual(paidStatus.showReceipt, true, '通常入金は必ず領収書を表示する');
+  assert.strictEqual(paidStatus.receiptRemark, '', '合算指定がなければ備考は空');
+}
+
 function testSelfPaidInvoiceDoesNotRoundManualUnitPrice() {
   const context = createContext();
   vm.createContext(context);
@@ -582,6 +602,7 @@ function run() {
   testFullWidthInputsAreNormalized();
   testSelfPaidInvoiceStaysZeroWithoutManualUnitPrice();
   testAggregateReceiptIsHiddenUntilEndMonthIsValid();
+  testPaidInvoiceAlwaysShowsReceipt();
   testSelfPaidInvoiceDoesNotRoundManualUnitPrice();
   testInsuranceBillingIsRoundedToNearestTen();
   testWelfareBillingStillAddsTransport();


### PR DESCRIPTION
## Summary
- adjust `resolveInvoiceReceiptDisplay_` to hide receipts for unpaid or pending aggregates while always showing them for normal payments
- retain aggregate remarks only when the aggregate period is valid and covered
- add regression coverage for always-show receipt behavior on paid invoices

## Testing
- node tests/billingOutput.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946b00220188321906a50274a3eb552)