### PR TITLE
Adjust receipt display logic for aggregate invoices

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -313,17 +313,20 @@ function resolveInvoiceReceiptDisplay_(item) {
   }
 
   if (status === 'AGGREGATE') {
-    const showAggregateReceipt = hasValidAggregateUntil;
+    if (!hasValidAggregateUntil) {
+      return { showReceipt: false, receiptRemark: '', receiptMonths: aggregateMonths };
+    }
+
     return {
-      showReceipt: showAggregateReceipt,
-      receiptRemark: showAggregateReceipt ? formatAggregatedReceiptRemark_(aggregateMonths) : '',
+      showReceipt: true,
+      receiptRemark: formatAggregatedReceiptRemark_(aggregateMonths),
       receiptMonths: aggregateMonths
     };
   }
 
   return {
     showReceipt: true,
-    receiptRemark: hasValidAggregateUntil ? formatAggregatedReceiptRemark_(aggregateMonths) : '',
+    receiptRemark: '',
     receiptMonths: aggregateMonths
   };
 }


### PR DESCRIPTION
## Summary
- align resolveInvoiceReceiptDisplay_ with requirements so only aggregate receipts with valid end month show remarks
- ensure non-aggregate statuses continue to show standard receipts without aggregate remarks

## Testing
- node tests/billingOutput.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946b1db187083218c65bc0f7a4a9eb8)