### PR TITLE
Adjust invoice receipt display logic

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -302,32 +302,46 @@ function resolveInvoiceReceiptDisplay_(item) {
   const billingMonth = item && item.billingMonth;
   const normalizedBillingMonth = normalizeInvoiceMonthKey_(billingMonth);
   const normalizedAggregateUntil = normalizeInvoiceMonthKey_(aggregateUntil);
-  const hasValidAggregateUntil = !!normalizedBillingMonth && !!normalizedAggregateUntil
+  const hasValidBillingMonth = !!normalizedBillingMonth;
+  const hasValidAggregateUntil = hasValidBillingMonth && !!normalizedAggregateUntil
     && Number(normalizedAggregateUntil) >= Number(normalizedBillingMonth);
-  const aggregateMonths = hasValidAggregateUntil
+  const receiptMonths = hasValidAggregateUntil
     ? buildInclusiveMonthRange_(billingMonth, aggregateUntil)
     : (normalizedBillingMonth ? [normalizedBillingMonth] : []);
+  const aggregationApplied = hasValidAggregateUntil;
+
+  if (!hasValidBillingMonth) {
+    return { showReceipt: false, receiptRemark: '', receiptMonths };
+  }
 
   if (status === 'UNPAID' || status === 'HOLD') {
-    return { showReceipt: false, receiptRemark: '', receiptMonths: aggregateMonths };
+    return { showReceipt: false, receiptRemark: '', receiptMonths };
   }
 
   if (status === 'AGGREGATE') {
-    if (!hasValidAggregateUntil) {
-      return { showReceipt: false, receiptRemark: '', receiptMonths: aggregateMonths };
+    if (!aggregationApplied) {
+      return { showReceipt: false, receiptRemark: '', receiptMonths };
     }
 
     return {
       showReceipt: true,
-      receiptRemark: formatAggregatedReceiptRemark_(aggregateMonths),
-      receiptMonths: aggregateMonths
+      receiptRemark: formatAggregatedReceiptRemark_(receiptMonths),
+      receiptMonths
+    };
+  }
+
+  if (aggregationApplied) {
+    return {
+      showReceipt: true,
+      receiptRemark: formatAggregatedReceiptRemark_(receiptMonths),
+      receiptMonths
     };
   }
 
   return {
     showReceipt: true,
     receiptRemark: '',
-    receiptMonths: aggregateMonths
+    receiptMonths
   };
 }
 


### PR DESCRIPTION
## Summary
- align resolveInvoiceReceiptDisplay_ with the defined receipt display business rules
- prioritize billing month validity, unpaid/hold suppression, and aggregation handling with clear conditions
- generate aggregation remarks only when valid and keep receipt months available even when hidden

## Testing
- Not run (not specified)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946b92af3148321b2a6f5fe6f2fc2c0)