### PR TITLE
Remove receipt status and aggregate month controls from billing UI

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -116,20 +116,6 @@
         </div>
         <div id="billingError" class="alert danger" style="display:none"></div>
       </div>
-      <div class="controls" aria-label="領収管理">
-        <label>領収状態
-          <select id="receiptStatus" onchange="handleReceiptStatusChange(event)">
-            <option value="">（デフォルト）</option>
-            <option value="UNPAID">UNPAID</option>
-            <option value="AGGREGATE">AGGREGATE</option>
-            <option value="HOLD">HOLD</option>
-          </select>
-        </label>
-        <label>ここまで合算する月
-          <input type="month" id="receiptAggregateUntil" onchange="handleReceiptAggregateChange(event)" />
-          <span class="muted field-note">${' '}合算月: <span id="receiptAggregateDisplay">—</span></span>
-        </label>
-      </div>
       <div class="generation-options">
         <p class="muted" style="margin:0">PDF生成モード</p>
           <div class="mode-options" role="group" aria-label="請求書PDFの生成モード">


### PR DESCRIPTION
## Summary
- remove receipt status and aggregate-until month inputs from the billing controls UI

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946bd00cefc83218c08c31c1f820d53)