### PR TITLE
Fix receipt visibility fallback for invoice PDFs

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -78,7 +78,18 @@
     <hr class="divider">
 
     <? var receipt = data.previousReceipt || data.receipt || {}; ?>
-    <? var showReceipt = data.receiptVisible !== undefined ? !!data.receiptVisible : (receipt.visible === undefined ? false : !!receipt.visible); ?>
+    <?
+      var showReceipt = null;
+      if (data.receiptVisible !== undefined) {
+        showReceipt = !!data.receiptVisible;
+      } else if (receipt.visible !== undefined) {
+        showReceipt = !!receipt.visible;
+      } else if (data.showReceipt !== undefined) {
+        showReceipt = !!data.showReceipt;
+      } else {
+        showReceipt = false;
+      }
+    ?>
     <? var receiptAddressee = receipt.addressee || data.nameKanji || ''; ?>
     <? var receiptDate = receipt.date || receipt.receiptDate || ''; ?>
     <? var receiptAmount = receipt.amount != null ? receipt.amount : receipt.total != null ? receipt.total : receipt.price; ?>


### PR DESCRIPTION
## Summary
- ensure invoice template respects per-patient receipt visibility derived from billing data
- fallback to show receipts when `showReceipt` flag is set on the provided data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947635c4298832197d9b61becf21a0b)