### PR TITLE
Fix previous month receipt visibility and sourcing

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -80,10 +80,10 @@
     <? var receipt = data.previousReceipt || data.receipt || {}; ?>
     <?
       var showReceipt = null;
-      if (data.receiptVisible !== undefined) {
-        showReceipt = !!data.receiptVisible;
-      } else if (receipt.visible !== undefined) {
+      if (receipt.visible !== undefined) {
         showReceipt = !!receipt.visible;
+      } else if (data.receiptVisible !== undefined) {
+        showReceipt = !!data.receiptVisible;
       } else if (data.showReceipt !== undefined) {
         showReceipt = !!data.showReceipt;
       } else {

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -416,7 +416,9 @@ function buildInvoiceTemplateData_(item) {
   ];
 
   const receipt = resolveInvoiceReceiptDisplay_(item);
-  const previousReceipt = buildInvoicePreviousReceipt_(item, receipt);
+  const previousReceipt = item && item.previousReceipt
+    ? item.previousReceipt
+    : buildInvoicePreviousReceipt_(item, receipt);
 
   return Object.assign({}, item, {
     monthLabel,


### PR DESCRIPTION
## Summary
- preserve provided previous month receipt data so invoices use confirmed prior-month receipts
- ensure receipt visibility checks prioritize the previous receipt entry when rendering

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694768c307b083218c8304755070d571)