### PR TITLE
Set previous receipt visibility when display info exists

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -420,6 +420,10 @@ function buildInvoiceTemplateData_(item) {
     ? item.previousReceipt
     : buildInvoicePreviousReceipt_(item, receipt);
 
+  if (previousReceipt && previousReceipt.visible === undefined) {
+    previousReceipt.visible = !!(receipt && receipt.showReceipt);
+  }
+
   return Object.assign({}, item, {
     monthLabel,
     rows,


### PR DESCRIPTION
## Summary
- ensure previous receipt visibility defaults to the current receipt display flag when unspecified

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69477bd93f048321ba62a0cf6b098503)