### PR TITLE
Use bank withdrawal amounts for previous receipts

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -349,9 +349,11 @@ function buildInvoicePreviousReceipt_(item, display) {
   const receiptDisplay = display || resolveInvoiceReceiptDisplay_(item);
   const addressee = item && item.nameKanji ? String(item.nameKanji).trim() : '';
   const date = formatInvoiceDateLabel_();
-  const amountSource = item && item.total != null
-    ? item.total
-    : (item && item.grandTotal != null ? item.grandTotal : item && item.billingAmount);
+  const amountSource = item && item.previousReceiptAmount != null
+    ? item.previousReceiptAmount
+    : (item && item.total != null
+      ? item.total
+      : (item && item.grandTotal != null ? item.grandTotal : item && item.billingAmount));
   const amount = normalizeInvoiceMoney_(amountSource);
   const note = receiptDisplay && receiptDisplay.receiptRemark ? receiptDisplay.receiptRemark : '';
 


### PR DESCRIPTION
## Summary
- pull previous-month receipt amounts from the prior bank withdrawal sheet instead of the current billing totals
- enrich prepared billing data with those bank withdrawal amounts while skipping rows marked as unpaid
- render previous-month receipts using the new amount source without altering existing billing logic

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69477fb242908321a055ea3dbd252a72)