### PR TITLE
Add settled check for previous month receipts

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -345,6 +345,16 @@ function resolveInvoiceReceiptDisplay_(item) {
   };
 }
 
+function isPreviousReceiptSettled_(item) {
+  const amount = normalizeInvoiceMoney_(item && item.previousReceiptAmount);
+  const rawStatus = item && item.receiptStatus;
+  const status = rawStatus == null ? null : String(rawStatus).trim().toUpperCase();
+
+  if (status === 'HOLD') return false;
+
+  return Number.isFinite(amount) && amount > 0;
+}
+
 function buildInvoicePreviousReceipt_(item, display) {
   const receiptDisplay = display || resolveInvoiceReceiptDisplay_(item);
   const addressee = item && item.nameKanji ? String(item.nameKanji).trim() : '';
@@ -420,8 +430,14 @@ function buildInvoiceTemplateData_(item) {
     ? item.previousReceipt
     : buildInvoicePreviousReceipt_(item, receipt);
 
-  if (previousReceipt && previousReceipt.visible === undefined) {
-    previousReceipt.visible = !!(receipt && receipt.showReceipt);
+  if (previousReceipt) {
+    const settled = isPreviousReceiptSettled_(item);
+
+    if (!settled) {
+      previousReceipt.visible = false;
+    } else if (previousReceipt.visible === undefined) {
+      previousReceipt.visible = !!(receipt && receipt.showReceipt);
+    }
   }
 
   return Object.assign({}, item, {


### PR DESCRIPTION
## Summary
- add helper to determine when previous-month receipts are considered settled
- hide previous-month receipt output unless the amount is positive and status is not HOLD

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947810992bc832191677d9c05dd039e)