### PR TITLE
Use previous receipt amount for previous receipts

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -359,12 +359,7 @@ function buildInvoicePreviousReceipt_(item, display) {
   const receiptDisplay = display || resolveInvoiceReceiptDisplay_(item);
   const addressee = item && item.nameKanji ? String(item.nameKanji).trim() : '';
   const date = formatInvoiceDateLabel_();
-  const amountSource = item && item.previousReceiptAmount != null
-    ? item.previousReceiptAmount
-    : (item && item.total != null
-      ? item.total
-      : (item && item.grandTotal != null ? item.grandTotal : item && item.billingAmount));
-  const amount = normalizeInvoiceMoney_(amountSource);
+  const amount = normalizeInvoiceMoney_(item && item.previousReceiptAmount);
   const note = receiptDisplay && receiptDisplay.receiptRemark ? receiptDisplay.receiptRemark : '';
 
   return {


### PR DESCRIPTION
## Summary
- ensure previous month receipts always use `previousReceiptAmount`
- remove fallbacks to current billing totals when determining receipt amount

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69478221ca2c83219f18a2c8ea110e99)