### PR TITLE
Add diff to bank withdrawal mismatch log

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -732,7 +732,8 @@ function logBankWithdrawalAmountMismatches_(billingMonthKey, bankAmounts, prepar
     const mismatch = {
       patientId: pid,
       billedAmount,
-      bankWithdrawalAmount: bankAmount
+      bankWithdrawalAmount: bankAmount,
+      diff: bankAmount - billedAmount
     };
     if (patientName) mismatch.name = patientName;
     mismatches.push(mismatch);


### PR DESCRIPTION
## Summary
- add the bank-minus-billed diff value to each bank withdrawal mismatch log entry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69478f1a4fac83218c0aa897cd7e9d66)