### PR TITLE
Handle legacy unpaid history extraction and receipt aggregation

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -455,16 +455,21 @@ function mergeReceiptSettingsIntoPrepared_(prepared, status, aggregateUntilMonth
   }
 
   return payload;
-}
+  }
 
-function resolvePreviousBillingMonthKey_(billingMonth) {
-  const month = normalizeBillingMonthInput(billingMonth);
-  if (!month || !month.key) return '';
-  const prevDate = new Date(month.year, month.month - 2, 1);
-  const year = String(prevDate.getFullYear()).padStart(4, '0');
-  const monthText = String(prevDate.getMonth() + 1).padStart(2, '0');
-  return year + monthText;
-}
+  function resolvePreviousBillingMonthKey_(billingMonth) {
+    const monthKey = normalizeBillingMonthKeySafe_(billingMonth);
+    if (!monthKey) return '';
+
+    const yearNum = Number(monthKey.slice(0, 4));
+    const monthNum = Number(monthKey.slice(4, 6));
+    if (!Number.isFinite(yearNum) || !Number.isFinite(monthNum)) return '';
+
+    const prevDate = new Date(yearNum, monthNum - 2, 1);
+    const prevYear = String(prevDate.getFullYear()).padStart(4, '0');
+    const monthText = String(prevDate.getMonth() + 1).padStart(2, '0');
+    return prevYear + monthText;
+  }
 
 function normalizeReceiptMonthKeys_(months) {
   if (!Array.isArray(months)) return [];

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -322,13 +322,13 @@ function resolveInvoiceReceiptDisplay_(item) {
   const hasValidBillingMonth = !!normalizedBillingMonth;
   const hasValidAggregateUntil = hasValidBillingMonth && !!normalizedAggregateUntil
     && Number(normalizedAggregateUntil) >= Number(normalizedBillingMonth);
-  const explicitReceiptMonths = normalizeReceiptMonths_(item && item.receiptMonths, normalizedBillingMonth);
+  const explicitReceiptMonths = normalizeReceiptMonths_(item && item.receiptMonths);
   const hasExplicitMonths = explicitReceiptMonths.length > 0;
   const receiptMonths = hasExplicitMonths
     ? explicitReceiptMonths
     : (hasValidAggregateUntil
       ? buildInclusiveMonthRange_(billingMonth, aggregateUntil)
-      : (normalizedBillingMonth ? [normalizedBillingMonth] : []));
+      : normalizeReceiptMonths_([], normalizedBillingMonth));
   const aggregationApplied = hasValidAggregateUntil || (hasExplicitMonths && receiptMonths.length > 1);
 
   if (!hasValidBillingMonth && !hasExplicitMonths) {


### PR DESCRIPTION
## Summary
- guard billing unpaid history extraction against missing sheet metadata and default columns
- use aggregate range when building invoice receipt months to include combined periods
- compute previous billing month key without requiring normalizeBillingMonthInput

## Testing
- for f in tests/*.test.js; do echo "Running $f"; node $f || break; done

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694799da77e48321846bd3b7cf4c663e)