### PR TITLE
Remove 10-yen rounding from billing calculations

### DIFF
--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -27,12 +27,6 @@ const billingResolveStaffDisplayName_ = typeof resolveStaffDisplayName_ === 'fun
     return parts[0] || normalized;
   };
 
-function roundToNearestTen_(value) {
-  const num = Number(value);
-  if (!Number.isFinite(num)) return 0;
-  return Math.round(num);
-}
-
 function normalizeBurdenMultiplier_(burdenRate, insuranceType) {
   const type = String(insuranceType || '').trim();
   if (type === '自費') return 1;
@@ -230,7 +224,7 @@ function calculateBillingAmounts_(params) {
   const selfPayTotal = selfPayItems.reduce((sum, entry) => sum + (Number(entry.amount) || 0), 0);
   const billingAmount = isSelfPaid
     ? treatmentAmount
-    : roundToNearestTen_(treatmentAmount * burdenMultiplier);
+    : treatmentAmount * burdenMultiplier;
   const total = treatmentAmount + resolvedTransportAmount;
   const grandTotal = billingAmount + resolvedTransportAmount + carryOverAmount + selfPayTotal;
 

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -620,12 +620,6 @@ function normalizeMoneyNumber(value) {
   return Number.isFinite(num) ? num : 0;
 }
 
-function roundToNearestTen(value) {
-  const num = Number(value);
-  if (!Number.isFinite(num)) return 0;
-  return Math.round(num / 10) * 10;
-}
-
 function normalizeVisitCount(value) {
   if (typeof value === 'number') {
     return Number.isFinite(value) && value > 0 ? value : 0;
@@ -891,7 +885,7 @@ function calculateBillingRowTotalsLocal(row) {
   const burdenMultiplier = isSelfPaid ? 1 : (Number.isFinite(burdenRate) && burdenRate > 0 ? burdenRate / 10 : 0);
   const treatmentAmount = isSelfPaid
     ? treatmentAmountFull
-    : roundToNearestTen(treatmentAmountFull * burdenMultiplier);
+    : treatmentAmountFull * burdenMultiplier;
   const transportAmount = hasManualTransport
     ? normalizedManualTransport
     : hasChargeablePrice && visitCount > 0

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -8,12 +8,6 @@ const TRANSPORT_PRICE = (typeof BILLING_TRANSPORT_UNIT_PRICE !== 'undefined')
 const INVOICE_TREATMENT_UNIT_PRICE_BY_BURDEN = { 1: 417, 2: 834, 3: 1251 };
 const INVOICE_UNIT_PRICE_FALLBACK = (typeof BILLING_UNIT_PRICE !== 'undefined') ? BILLING_UNIT_PRICE : 4170;
 
-function roundToNearestTen_(value) {
-  const num = Number(value);
-  if (!Number.isFinite(num)) return 0;
-  return Math.round(num);
-}
-
 function escapeHtml_(value) {
   return String(value || '').replace(/[&<>"']/g, (c) => ({
     '&': '&amp;',
@@ -588,7 +582,7 @@ function calculateInvoiceChargeBreakdown_(params) {
       : (insuranceType === '自費' ? 1 : (burdenRateInt > 0 ? burdenRateInt / 10 : 0)));
   const treatmentAmount = isSelfPaid
     ? treatmentAmountFull
-    : roundToNearestTen_(treatmentAmountFull * burdenMultiplier);
+    : treatmentAmountFull * burdenMultiplier;
   const transportAmount = (manualTransportInput !== '' && manualTransportInput !== null && manualTransportInput !== undefined
     && Number.isFinite(manualTransportAmount))
     ? manualTransportAmount


### PR DESCRIPTION
## Summary
- remove 10-yen rounding helpers from billing calculations
- compute patient charges using exact burdened treatment and transport amounts on both server and client

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947a2f06d80832180e11e3d2fc779ed)