### PR TITLE
Fix previous receipt date formatting

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -402,14 +402,14 @@ function formatReceiptSettlementDate_(receiptMonths, fallbackDate) {
     const year = Number(lastMonth.slice(0, 4));
     const month = Number(lastMonth.slice(4, 6));
     if (Number.isFinite(year) && Number.isFinite(month)) {
-      const settlementDate = new Date(year, month, 20);
+      const settlementDate = new Date(year, month - 1, 20);
       try {
         const tz = Session.getScriptTimeZone() || 'Asia/Tokyo';
-        return Utilities.formatDate(settlementDate, tz, 'yyyyMMdd');
+        return Utilities.formatDate(settlementDate, tz, 'yyyy-MM-20');
       } catch (e) {
         // ignore and fall through
       }
-      return settlementDate.toISOString().slice(0, 10).replace(/-/g, '');
+      return settlementDate.toISOString().slice(0, 10);
     }
   }
 


### PR DESCRIPTION
## Summary
- adjust previous receipt settlement date to use the prior month on the 20th
- format receipt settlement date with hyphenated YYYY-MM-20 output

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947b759bde88321985e1eceeebad0c1)