### PR TITLE
Show previous receipt when amount exists or bank status OK

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -368,10 +368,15 @@ function isPreviousReceiptSettled_(item) {
   const amount = normalizeInvoiceMoney_(item && item.previousReceiptAmount);
   const rawStatus = item && item.receiptStatus;
   const status = rawStatus == null ? null : String(rawStatus).trim().toUpperCase();
+  const rawBankStatus = item && item.bankStatus;
+  const bankStatus = rawBankStatus == null ? null : String(rawBankStatus).trim().toUpperCase();
+  const hasPreviousReceiptAmount = Number.isFinite(amount) && amount > 0;
+
+  if (hasPreviousReceiptAmount || bankStatus === 'OK') return true;
 
   if (status === 'HOLD') return false;
 
-  return Number.isFinite(amount) && amount > 0;
+  return hasPreviousReceiptAmount;
 }
 
 function buildInvoicePreviousReceipt_(item, display) {

--- a/tests/billingOutput.test.js
+++ b/tests/billingOutput.test.js
@@ -318,6 +318,23 @@ function testPaidInvoiceAlwaysShowsReceipt() {
   assert.strictEqual(paidStatus.receiptRemark, '', '合算指定がなければ備考は空');
 }
 
+function testPreviousReceiptIsShownWhenAmountOrBankStatusOk() {
+  const context = createContext();
+  vm.createContext(context);
+  vm.runInContext(billingOutputCode, context);
+
+  const { isPreviousReceiptSettled_ } = context;
+
+  const settledByAmount = isPreviousReceiptSettled_({ previousReceiptAmount: 1200, receiptStatus: 'HOLD' });
+  assert.strictEqual(settledByAmount, true, '前月領収額がある場合はHOLDでも表示する');
+
+  const settledByBankStatus = isPreviousReceiptSettled_({ bankStatus: 'OK', receiptStatus: 'HOLD' });
+  assert.strictEqual(settledByBankStatus, true, '請求履歴の入金ステータスがOKなら表示する');
+
+  const unsettled = isPreviousReceiptSettled_({ receiptStatus: 'HOLD', bankStatus: 'NG' });
+  assert.strictEqual(unsettled, false, '入金済み情報がないHOLDは非表示のまま');
+}
+
 function testSelfPaidInvoiceDoesNotRoundManualUnitPrice() {
   const context = createContext();
   vm.createContext(context);
@@ -737,6 +754,7 @@ function run() {
   testSelfPaidInvoiceStaysZeroWithoutManualUnitPrice();
   testAggregateReceiptIsHiddenUntilEndMonthIsValid();
   testPaidInvoiceAlwaysShowsReceipt();
+  testPreviousReceiptIsShownWhenAmountOrBankStatusOk();
   testSelfPaidInvoiceDoesNotRoundManualUnitPrice();
   testReceiptStatusIsOverwrittenInHistory();
   testInsuranceBillingUsesYenRounding();


### PR DESCRIPTION
## Summary
- update previous receipt settlement logic to always show when an amount exists or bank status is OK
- add tests covering the updated settlement rules

## Testing
- node tests/billingOutput.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947b83ba6e88321be6cd0a7a989d579)