### PR TITLE
Remove bank status fallback from previous receipt settlement

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -368,11 +368,9 @@ function isPreviousReceiptSettled_(item) {
   const amount = normalizeInvoiceMoney_(item && item.previousReceiptAmount);
   const rawStatus = item && item.receiptStatus;
   const status = rawStatus == null ? null : String(rawStatus).trim().toUpperCase();
-  const rawBankStatus = item && item.bankStatus;
-  const bankStatus = rawBankStatus == null ? null : String(rawBankStatus).trim().toUpperCase();
   const hasPreviousReceiptAmount = Number.isFinite(amount) && amount > 0;
 
-  if (hasPreviousReceiptAmount || bankStatus === 'OK') return true;
+  if (hasPreviousReceiptAmount) return true;
 
   if (status === 'HOLD') return false;
 

--- a/tests/billingOutput.test.js
+++ b/tests/billingOutput.test.js
@@ -318,7 +318,7 @@ function testPaidInvoiceAlwaysShowsReceipt() {
   assert.strictEqual(paidStatus.receiptRemark, '', '合算指定がなければ備考は空');
 }
 
-function testPreviousReceiptIsShownWhenAmountOrBankStatusOk() {
+function testPreviousReceiptIsShownOnlyWhenAmountExists() {
   const context = createContext();
   vm.createContext(context);
   vm.runInContext(billingOutputCode, context);
@@ -328,10 +328,7 @@ function testPreviousReceiptIsShownWhenAmountOrBankStatusOk() {
   const settledByAmount = isPreviousReceiptSettled_({ previousReceiptAmount: 1200, receiptStatus: 'HOLD' });
   assert.strictEqual(settledByAmount, true, '前月領収額がある場合はHOLDでも表示する');
 
-  const settledByBankStatus = isPreviousReceiptSettled_({ bankStatus: 'OK', receiptStatus: 'HOLD' });
-  assert.strictEqual(settledByBankStatus, true, '請求履歴の入金ステータスがOKなら表示する');
-
-  const unsettled = isPreviousReceiptSettled_({ receiptStatus: 'HOLD', bankStatus: 'NG' });
+  const unsettled = isPreviousReceiptSettled_({ receiptStatus: 'HOLD' });
   assert.strictEqual(unsettled, false, '入金済み情報がないHOLDは非表示のまま');
 }
 
@@ -754,7 +751,7 @@ function run() {
   testSelfPaidInvoiceStaysZeroWithoutManualUnitPrice();
   testAggregateReceiptIsHiddenUntilEndMonthIsValid();
   testPaidInvoiceAlwaysShowsReceipt();
-  testPreviousReceiptIsShownWhenAmountOrBankStatusOk();
+  testPreviousReceiptIsShownOnlyWhenAmountExists();
   testSelfPaidInvoiceDoesNotRoundManualUnitPrice();
   testReceiptStatusIsOverwrittenInHistory();
   testInsuranceBillingUsesYenRounding();


### PR DESCRIPTION
## Summary
- remove the bank status fallback from `isPreviousReceiptSettled_` so settlement depends only on previous receipt amount and receipt status
- update the billing output tests to reflect the new settlement logic

## Testing
- node tests/billingOutput.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947c55765dc8321a149164570b5448e)