### PR TITLE
Simplify previous receipt amount sourcing

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -376,7 +376,7 @@ function formatReceiptSettlementDate_(receiptMonths, fallbackDate) {
 
 function resolveReceiptMonthBreakdown_(item, receiptMonths) {
   const precomputed = item && Array.isArray(item.receiptMonthBreakdown) ? item.receiptMonthBreakdown : [];
-  if (precomputed.length) return precomputed;
+  if (item && item.hasOwnProperty('receiptMonthBreakdown')) return precomputed;
 
   try {
     return buildReceiptMonthBreakdownForEntry_(
@@ -1249,12 +1249,6 @@ function applyPaymentResultsToHistory(billingMonth, bankStatuses) {
       const grandTotal = columns.grandTotal ? Number(newRow[columns.grandTotal - 1]) || 0 : 0;
       const unpaid = statusEntry.unpaidAmount != null ? statusEntry.unpaidAmount : grandTotal - paid;
       if (columns.unpaidAmount) newRow[columns.unpaidAmount - 1] = unpaid;
-      changed = true;
-    }
-
-    if (columns.previousReceiptAmount && statusEntry.bankStatus === 'OK') {
-      const grandTotal = columns.grandTotal ? Number(newRow[columns.grandTotal - 1]) || 0 : 0;
-      newRow[columns.previousReceiptAmount - 1] = grandTotal;
       changed = true;
     }
 


### PR DESCRIPTION
## Summary
- derive previous receipt amounts from the prior billing month's totals instead of bank withdrawal data or stored receipt values
- prevent receipt month breakdowns from regenerating via bank data when precomputed values are provided
- stop updating previous receipt amounts when applying bank payment results

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947d58ea4a48321aea6af737d3ded0c)