### PR TITLE
Adjust receipt visibility based on unpaid checks

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -556,20 +556,15 @@ function applyReceiptRulesFromUnpaidCheck_(prepared) {
         ? normalizeBillingMonthKeySafe_(aggregateSource)
         : '';
 
-      let entryStatus = rowStatus;
-      let aggregateUntilMonth = baseAggregate;
-      let receiptMonths = normalizeReceiptMonthKeys_(rowPayload.receiptMonths);
-
-      if (pid && currentUnpaid.has(pid)) {
-        entryStatus = 'HOLD';
-        aggregateUntilMonth = '';
-        receiptMonths = [];
-      }
+      const isUnpaidChecked = pid && currentUnpaid.has(pid);
+      const aggregateUntilMonth = isUnpaidChecked ? '' : baseAggregate;
+      const receiptMonths = isUnpaidChecked ? [] : normalizeReceiptMonthKeys_(rowPayload.receiptMonths);
 
       return Object.assign({}, rowPayload, {
-        receiptStatus: entryStatus,
+        receiptStatus: rowStatus,
         aggregateUntilMonth,
-        receiptMonths
+        receiptMonths,
+        unpaidChecked: !!isUnpaidChecked
       });
     });
 

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -307,8 +307,7 @@ function normalizeReceiptMonths_(months, fallbackMonth) {
 }
 
 function resolveInvoiceReceiptDisplay_(item) {
-  const rawStatus = item && item.receiptStatus;
-  const status = rawStatus == null ? null : String(rawStatus).trim().toUpperCase();
+  const isUnpaidChecked = !!(item && item.unpaidChecked);
   const billingMonth = item && item.billingMonth;
   const normalizedBillingMonth = normalizeInvoiceMonthKey_(billingMonth);
   const explicitReceiptMonths = normalizeReceiptMonths_(item && item.receiptMonths);
@@ -317,7 +316,7 @@ function resolveInvoiceReceiptDisplay_(item) {
     ? explicitReceiptMonths
     : normalizeReceiptMonths_([], normalizedBillingMonth);
 
-  if (status === 'UNPAID' || status === 'HOLD') {
+  if (isUnpaidChecked) {
     return { showReceipt: false, receiptRemark: '', receiptMonths };
   }
 


### PR DESCRIPTION
## Summary
- carry unpaid check information into prepared billing entries
- base receipt visibility on unpaid check flags instead of receipt status values

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947d633b5088321aff5ad0c0e9f73a4)