### PR TITLE
Handle previous receipt visibility when prior billing missing

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -592,6 +592,7 @@ function attachPreviousReceiptAmounts_(prepared) {
     : null;
   const previousPrepared = loaded && loaded.prepared !== undefined ? loaded.prepared : loaded;
   const normalizedPrevious = normalizePreparedBilling_(previousPrepared || {});
+  const hasPreviousPrepared = !!(normalizedPrevious && Array.isArray(normalizedPrevious.billingJson) && normalizedPrevious.billingJson.length);
   const previousAmounts = buildBillingAmountByPatientId_(normalizedPrevious && normalizedPrevious.billingJson);
 
   const normalizePid = typeof billingNormalizePatientId_ === 'function'
@@ -610,7 +611,7 @@ function attachPreviousReceiptAmounts_(prepared) {
     });
   });
 
-  return Object.assign({}, prepared, { billingJson: enrichedJson });
+  return Object.assign({}, prepared, { billingJson: enrichedJson, hasPreviousPrepared });
 }
 
 function collectBankWithdrawalAmountsByPatientCached_(billingMonth, prepared, cache) {

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -307,7 +307,8 @@ function normalizeReceiptMonths_(months, fallbackMonth) {
 }
 
 function resolveInvoiceReceiptDisplay_(item) {
-  const isUnpaidChecked = !!(item && item.unpaidChecked);
+  const status = item && item.receiptStatus ? String(item.receiptStatus).trim().toUpperCase() : '';
+  const isUnpaidChecked = !!(item && (item.unpaidChecked || status === 'UNPAID' || status === 'HOLD'));
   const billingMonth = item && item.billingMonth;
   const normalizedBillingMonth = normalizeInvoiceMonthKey_(billingMonth);
   const explicitReceiptMonths = normalizeReceiptMonths_(item && item.receiptMonths);
@@ -433,6 +434,7 @@ function buildInvoiceTemplateData_(item) {
   const breakdown = calculateInvoiceChargeBreakdown_(Object.assign({}, item, { billingMonth }));
   const visits = breakdown.visits || 0;
   const unitPrice = breakdown.treatmentUnitPrice || 0;
+  const hasPreviousPrepared = !!(item && item.hasPreviousPrepared);
   const normalizedPreviousReceiptAmount = normalizeInvoiceMoney_(item && item.previousReceiptAmount);
   const rows = [
     { label: '前月繰越', detail: '', amount: normalizeBillingCarryOver_(item) },
@@ -459,6 +461,10 @@ function buildInvoiceTemplateData_(item) {
     previousReceipt.visible = previousReceipt.visible === undefined
       ? !!(receipt && receipt.showReceipt)
       : previousReceipt.visible;
+
+    if (!hasPreviousPrepared) {
+      previousReceipt.visible = false;
+    }
   }
 
   return Object.assign({}, item, {

--- a/tests/billingOutput.test.js
+++ b/tests/billingOutput.test.js
@@ -278,11 +278,23 @@ function testPreviousReceiptVisibilityFollowsReceiptDecision() {
 
   const { buildInvoiceTemplateData_ } = context;
 
-  const payable = buildInvoiceTemplateData_({ billingMonth: '202501', receiptStatus: 'PAID' });
+  const payable = buildInvoiceTemplateData_({ billingMonth: '202501', receiptStatus: 'PAID', hasPreviousPrepared: true });
   assert.strictEqual(payable.previousReceipt.visible, true, '領収表示時は前月領収書も表示する');
 
-  const onHold = buildInvoiceTemplateData_({ billingMonth: '202501', receiptStatus: 'HOLD' });
+  const onHold = buildInvoiceTemplateData_({ billingMonth: '202501', receiptStatus: 'HOLD', hasPreviousPrepared: true });
   assert.strictEqual(onHold.previousReceipt.visible, false, '未回収チェックがある場合は前月領収書も非表示');
+}
+
+function testPreviousReceiptIsHiddenWhenPreviousPreparedMissing() {
+  const context = createContext();
+  vm.createContext(context);
+  vm.runInContext(billingOutputCode, context);
+
+  const { buildInvoiceTemplateData_ } = context;
+
+  const data = buildInvoiceTemplateData_({ billingMonth: '202501', receiptStatus: 'PAID', hasPreviousPrepared: false });
+
+  assert.strictEqual(data.previousReceipt.visible, false, '前月請求が未生成なら前月領収書を非表示にする');
 }
 
 function testSelfPaidInvoiceDoesNotRoundManualUnitPrice() {
@@ -704,6 +716,7 @@ function run() {
   testSelfPaidInvoiceStaysZeroWithoutManualUnitPrice();
   testReceiptVisibilityReliesOnUnpaidStatusOnly();
   testPreviousReceiptVisibilityFollowsReceiptDecision();
+  testPreviousReceiptIsHiddenWhenPreviousPreparedMissing();
   testSelfPaidInvoiceDoesNotRoundManualUnitPrice();
   testReceiptStatusIsOverwrittenInHistory();
   testInsuranceBillingUsesYenRounding();


### PR DESCRIPTION
## Summary
- track whether a previous month's prepared billing exists when enriching billing entries
- hide previous receipts in invoice data when no prior billing is available and respect receipt status for visibility
- cover previous receipt visibility for missing prior billing and receipt status handling in tests

## Testing
- node tests/billingOutput.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947d8db0d8083219e9979c35dff5de1)