### PR TITLE
Simplify receipt visibility rules

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -307,8 +307,8 @@ function normalizeReceiptMonths_(months, fallbackMonth) {
 }
 
 function resolveInvoiceReceiptDisplay_(item) {
-  const status = item && item.receiptStatus ? String(item.receiptStatus).trim().toUpperCase() : '';
-  const isUnpaidChecked = !!(item && (item.unpaidChecked || status === 'UNPAID' || status === 'HOLD'));
+  const isUnpaidChecked = !!(item && item.unpaidChecked);
+  const hasPreviousPrepared = !!(item && item.hasPreviousPrepared);
   const billingMonth = item && item.billingMonth;
   const normalizedBillingMonth = normalizeInvoiceMonthKey_(billingMonth);
   const explicitReceiptMonths = normalizeReceiptMonths_(item && item.receiptMonths);
@@ -317,12 +317,10 @@ function resolveInvoiceReceiptDisplay_(item) {
     ? explicitReceiptMonths
     : normalizeReceiptMonths_([], normalizedBillingMonth);
 
-  if (isUnpaidChecked) {
-    return { showReceipt: false, receiptRemark: '', receiptMonths };
-  }
+  const showReceipt = hasPreviousPrepared && !isUnpaidChecked;
 
   return {
-    showReceipt: true,
+    showReceipt,
     receiptRemark: '',
     receiptMonths
   };

--- a/tests/receiptHoldRules.test.js
+++ b/tests/receiptHoldRules.test.js
@@ -14,7 +14,6 @@ function createContext(overrides = {}) {
 
 (function testUnpaidChecksOnlyHoldMatchingPatients() {
   const ctx = createContext();
-  ctx.summarizeBankWithdrawalSheet_ = () => ({ billingMonth: '202501', unpaidChecked: 2 });
   ctx.resolveUnpaidCheckedPatientIds_ = () => new Set(['P-HOLD']);
 
   const prepared = {
@@ -33,10 +32,10 @@ function createContext(overrides = {}) {
 
   assert.strictEqual(result.receiptStatus, 'AGGREGATE', '集計設定は全体の設定を保持する');
   assert.strictEqual(result.aggregateUntilMonth, '202504', '全体の合算終了月を保持する');
-  assert.strictEqual(holdRow.receiptStatus, 'HOLD', '未回収チェックの患者のみ HOLD になる');
-  assert.strictEqual(holdRow.aggregateUntilMonth, '', 'HOLD の患者には合算終了月を付与しない');
-  assert.strictEqual(okRow.receiptStatus, 'AGGREGATE', '未回収チェック無しの患者は合算設定を維持する');
-  assert.strictEqual(okRow.aggregateUntilMonth, '202504', '未回収チェック無しの患者は合算終了月を維持する');
+  assert.strictEqual(holdRow.unpaidChecked, true, '未回収チェックの患者のみ unpaidChecked が付与される');
+  assert.strictEqual(okRow.unpaidChecked, false, '未回収チェック無しの患者には unpaidChecked が付与されない');
+  assert.strictEqual(holdRow.receiptStatus, undefined, '行の領収書状態は変更しない');
+  assert.strictEqual(okRow.receiptStatus, undefined, '行の領収書状態は変更しない');
 })();
 
 console.log('receipt hold rules tests passed');


### PR DESCRIPTION
## Summary
- reduce applyReceiptRulesFromUnpaidCheck_ to only annotate billing rows with unpaidChecked flags
- keep previous receipt enrichment focused on prior-month amounts and previous data availability
- adjust invoice receipt visibility logic and tests to rely solely on unpaid checks and prior prepared billing

## Testing
- Not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947e3d8a8f4832189beb4a1fd3c429e)