### PR TITLE
Use bank withdrawal sheet for previous receipts

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -307,23 +307,32 @@ function normalizeReceiptMonths_(months, fallbackMonth) {
 }
 
 function resolveInvoiceReceiptDisplay_(item) {
-  const isUnpaidChecked = !!(item && item.unpaidChecked);
   const hasPreviousPrepared = !!(item && item.hasPreviousPrepared);
-  const billingMonth = item && item.billingMonth;
-  const normalizedBillingMonth = normalizeInvoiceMonthKey_(billingMonth);
-  const explicitReceiptMonths = normalizeReceiptMonths_(item && item.receiptMonths);
-  const hasExplicitMonths = explicitReceiptMonths.length > 0;
-  const receiptMonths = hasExplicitMonths
-    ? explicitReceiptMonths
-    : normalizeReceiptMonths_([], normalizedBillingMonth);
+  const previousMonth = resolvePreviousBillingMonthKey_(item && item.billingMonth);
+  const receiptMonths = previousMonth
+    ? normalizeReceiptMonths_([previousMonth])
+    : [];
 
-  const showReceipt = hasPreviousPrepared && isUnpaidChecked;
+  const showReceipt = hasPreviousPrepared && receiptMonths.length > 0;
 
   return {
     showReceipt,
     receiptRemark: '',
     receiptMonths
   };
+}
+
+function resolvePreviousBillingMonthKey_(billingMonth) {
+  const key = normalizeInvoiceMonthKey_(billingMonth);
+  if (!key) return '';
+
+  const year = Number(key.slice(0, 4));
+  const month = Number(key.slice(4, 6));
+  if (!Number.isFinite(year) || !Number.isFinite(month)) return '';
+
+  const previousMonth = month === 1 ? 12 : month - 1;
+  const previousYear = month === 1 ? year - 1 : year;
+  return String(previousYear).padStart(4, '0') + String(previousMonth).padStart(2, '0');
 }
 
 function isPreviousReceiptSettled_(item) {

--- a/tests/billingOutput.test.js
+++ b/tests/billingOutput.test.js
@@ -259,16 +259,12 @@ function testReceiptVisibilityReliesOnUnpaidStatusOnly() {
 
   const { resolveInvoiceReceiptDisplay_ } = context;
 
-  const defaultStatus = resolveInvoiceReceiptDisplay_({ billingMonth: '202501', receiptStatus: null });
-  assert.strictEqual(defaultStatus.showReceipt, true, 'ステータス未指定でも領収書を表示する');
-  assert.deepStrictEqual(Array.from(defaultStatus.receiptMonths || []), ['202501'], '請求月の領収書を作成する');
+  const defaultStatus = resolveInvoiceReceiptDisplay_({ billingMonth: '202501', hasPreviousPrepared: true });
+  assert.strictEqual(defaultStatus.showReceipt, true, '銀行引落シートがあれば前月領収書を表示する');
+  assert.deepStrictEqual(Array.from(defaultStatus.receiptMonths || []), ['202412'], '前月の領収書を作成する');
 
-  const paidStatus = resolveInvoiceReceiptDisplay_({ billingMonth: '202501', receiptStatus: 'PAID' });
-  assert.strictEqual(paidStatus.showReceipt, true, '通常入金は必ず領収書を表示する');
-  assert.strictEqual(paidStatus.receiptRemark, '', '判定条件は未回収チェックのみ');
-
-  const unpaidStatus = resolveInvoiceReceiptDisplay_({ billingMonth: '202501', receiptStatus: 'UNPAID' });
-  assert.strictEqual(unpaidStatus.showReceipt, false, '未回収チェックがある場合のみ非表示にする');
+  const withoutPreviousSheet = resolveInvoiceReceiptDisplay_({ billingMonth: '202501', hasPreviousPrepared: false });
+  assert.strictEqual(withoutPreviousSheet.showReceipt, false, '銀行引落シートが無ければ前月領収書を非表示にする');
 }
 
 function testPreviousReceiptVisibilityFollowsReceiptDecision() {
@@ -279,10 +275,10 @@ function testPreviousReceiptVisibilityFollowsReceiptDecision() {
   const { buildInvoiceTemplateData_ } = context;
 
   const payable = buildInvoiceTemplateData_({ billingMonth: '202501', receiptStatus: 'PAID', hasPreviousPrepared: true });
-  assert.strictEqual(payable.previousReceipt.visible, true, '領収表示時は前月領収書も表示する');
+  assert.strictEqual(payable.previousReceipt.visible, true, '銀行引落シートがあれば前月領収書も表示する');
 
   const onHold = buildInvoiceTemplateData_({ billingMonth: '202501', receiptStatus: 'HOLD', hasPreviousPrepared: true });
-  assert.strictEqual(onHold.previousReceipt.visible, false, '未回収チェックがある場合は前月領収書も非表示');
+  assert.strictEqual(onHold.previousReceipt.visible, true, '領収ステータスに依存せず表示する');
 }
 
 function testPreviousReceiptIsHiddenWhenPreviousPreparedMissing() {


### PR DESCRIPTION
## Summary
- derive previous receipt visibility from the existence of the prior bank withdrawal sheet and target the previous month
- add helper for resolving the prior billing month in invoice output logic
- update invoice output tests to reflect bank sheet-driven receipt handling

## Testing
- node tests/billingOutput.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69486f4ce52883218399929ccddf18e1)