### PR TITLE
Use bank withdrawal sheet for previous receipts

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -553,7 +553,7 @@ function attachPreviousReceiptAmounts_(prepared) {
   if (!previousMonthKey) return prepared;
 
   const previousReceipt = collectPreviousReceiptAmountsFromBankSheet_(previousMonthKey, prepared);
-  const hasPreviousPrepared = !!(previousReceipt && previousReceipt.hasSheet);
+  const hasPreviousReceiptSheet = !!(previousReceipt && previousReceipt.hasSheet);
   const previousAmounts = previousReceipt && previousReceipt.amounts;
 
   const normalizePid = typeof billingNormalizePatientId_ === 'function'
@@ -569,7 +569,11 @@ function attachPreviousReceiptAmounts_(prepared) {
     return Object.assign({}, entry, { previousReceiptAmount });
   });
 
-  return Object.assign({}, prepared, { billingJson: enrichedJson, hasPreviousPrepared });
+  return Object.assign({}, prepared, {
+    billingJson: enrichedJson,
+    hasPreviousPrepared: hasPreviousReceiptSheet,
+    hasPreviousReceiptSheet
+  });
 }
 
 function collectPreviousReceiptAmountsFromBankSheet_(billingMonth, prepared) {
@@ -587,12 +591,7 @@ function collectPreviousReceiptAmountsFromBankSheet_(billingMonth, prepared) {
   const amountColIndex = columnLetterToNumber_(BANK_WITHDRAWAL_AMOUNT_COLUMN_LETTER);
   const headerCount = Math.max(sheet.getLastColumn(), amountColIndex || 0);
   const headers = sheet.getRange(1, 1, 1, headerCount).getDisplayValues()[0];
-  const amountCol = resolveBillingColumn_(
-    headers,
-    ['金額', '請求金額', '引落額', '引落金額'],
-    '金額',
-    { required: true, fallbackLetter: BANK_WITHDRAWAL_AMOUNT_COLUMN_LETTER }
-  );
+  const amountCol = columnLetterToNumber_(BANK_WITHDRAWAL_AMOUNT_COLUMN_LETTER);
   const pidCol = resolveBillingColumn_(headers, BILLING_LABELS.recNo.concat(['患者ID', '患者番号']), '患者ID', {});
   const nameCol = resolveBillingColumn_(headers, BILLING_LABELS.name, '名前', { required: true, fallbackLetter: 'A' });
   const kanaCol = resolveBillingColumn_(headers, BILLING_LABELS.furigana, 'フリガナ', {});

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -307,13 +307,13 @@ function normalizeReceiptMonths_(months, fallbackMonth) {
 }
 
 function resolveInvoiceReceiptDisplay_(item) {
-  const hasPreviousPrepared = !!(item && item.hasPreviousPrepared);
+  const hasPreviousReceiptSheet = !!(item && (item.hasPreviousReceiptSheet || item.hasPreviousPrepared));
   const previousMonth = resolvePreviousBillingMonthKey_(item && item.billingMonth);
   const receiptMonths = previousMonth
     ? normalizeReceiptMonths_([previousMonth])
     : [];
 
-  const showReceipt = hasPreviousPrepared && receiptMonths.length > 0;
+  const showReceipt = hasPreviousReceiptSheet && receiptMonths.length > 0;
 
   return {
     showReceipt,
@@ -441,7 +441,7 @@ function buildInvoiceTemplateData_(item) {
   const breakdown = calculateInvoiceChargeBreakdown_(Object.assign({}, item, { billingMonth }));
   const visits = breakdown.visits || 0;
   const unitPrice = breakdown.treatmentUnitPrice || 0;
-  const hasPreviousPrepared = !!(item && item.hasPreviousPrepared);
+  const hasPreviousReceiptSheet = !!(item && (item.hasPreviousReceiptSheet || item.hasPreviousPrepared));
   const normalizedPreviousReceiptAmount = normalizeInvoiceMoney_(item && item.previousReceiptAmount);
   const rows = [
     { label: '前月繰越', detail: '', amount: normalizeBillingCarryOver_(item) },
@@ -469,7 +469,7 @@ function buildInvoiceTemplateData_(item) {
       ? !!(receipt && receipt.showReceipt)
       : previousReceipt.visible;
 
-    if (!hasPreviousPrepared) {
+    if (!hasPreviousReceiptSheet) {
       previousReceipt.visible = false;
     }
   }


### PR DESCRIPTION
## Summary
- derive previous receipt visibility and amounts directly from the prior month bank withdrawal sheet
- expose a dedicated flag for the previous bank sheet to drive invoice rendering and rely on the sheet’s amount column

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694874a314f883218022f20a98b19aae)