### PR TITLE
Simplify previous receipt display logic

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -82,16 +82,7 @@
 
     <? var receipt = data.previousReceipt || data.receipt || {}; ?>
     <?
-      var showReceipt = null;
-      if (receipt.visible !== undefined) {
-        showReceipt = !!receipt.visible;
-      } else if (data.receiptVisible !== undefined) {
-        showReceipt = !!data.receiptVisible;
-      } else if (data.showReceipt !== undefined) {
-        showReceipt = !!data.showReceipt;
-      } else {
-        showReceipt = false;
-      }
+      var showReceipt = !!receipt.visible;
     ?>
     <? var receiptAddressee = receipt.addressee || data.nameKanji || ''; ?>
     <? var receiptDate = receipt.date || receipt.receiptDate || ''; ?>

--- a/src/main.gs
+++ b/src/main.gs
@@ -566,12 +566,11 @@ function attachPreviousReceiptAmounts_(prepared) {
       ? previousAmounts[pid]
       : 0;
 
-    return Object.assign({}, entry, { previousReceiptAmount });
+    return Object.assign({}, entry, { previousReceiptAmount, hasPreviousReceiptSheet });
   });
 
   return Object.assign({}, prepared, {
     billingJson: enrichedJson,
-    hasPreviousPrepared: hasPreviousReceiptSheet,
     hasPreviousReceiptSheet
   });
 }

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -307,16 +307,14 @@ function normalizeReceiptMonths_(months, fallbackMonth) {
 }
 
 function resolveInvoiceReceiptDisplay_(item) {
-  const hasPreviousReceiptSheet = !!(item && (item.hasPreviousReceiptSheet || item.hasPreviousPrepared));
+  const hasPreviousReceiptSheet = !!(item && item.hasPreviousReceiptSheet);
   const previousMonth = resolvePreviousBillingMonthKey_(item && item.billingMonth);
   const receiptMonths = previousMonth
     ? normalizeReceiptMonths_([previousMonth])
     : [];
 
-  const showReceipt = hasPreviousReceiptSheet && receiptMonths.length > 0;
-
   return {
-    showReceipt,
+    visible: hasPreviousReceiptSheet,
     receiptRemark: '',
     receiptMonths
   };
@@ -349,7 +347,7 @@ function buildInvoicePreviousReceipt_(item, display) {
   const breakdown = resolveReceiptMonthBreakdown_(item, receiptDisplay && receiptDisplay.receiptMonths);
 
   return {
-    visible: !!(receiptDisplay && receiptDisplay.showReceipt),
+    visible: !!(receiptDisplay && receiptDisplay.visible),
     addressee,
     date,
     amount: Number.isFinite(amount) ? amount : 0,
@@ -441,7 +439,7 @@ function buildInvoiceTemplateData_(item) {
   const breakdown = calculateInvoiceChargeBreakdown_(Object.assign({}, item, { billingMonth }));
   const visits = breakdown.visits || 0;
   const unitPrice = breakdown.treatmentUnitPrice || 0;
-  const hasPreviousReceiptSheet = !!(item && (item.hasPreviousReceiptSheet || item.hasPreviousPrepared));
+  const hasPreviousReceiptSheet = !!(item && item.hasPreviousReceiptSheet);
   const normalizedPreviousReceiptAmount = normalizeInvoiceMoney_(item && item.previousReceiptAmount);
   const rows = [
     { label: '前月繰越', detail: '', amount: normalizeBillingCarryOver_(item) },
@@ -465,23 +463,13 @@ function buildInvoiceTemplateData_(item) {
   }
 
   if (previousReceipt) {
-    previousReceipt.visible = previousReceipt.visible === undefined
-      ? !!(receipt && receipt.showReceipt)
-      : previousReceipt.visible;
-
-    if (!hasPreviousReceiptSheet) {
-      previousReceipt.visible = false;
-    }
+    previousReceipt.visible = !!(receipt && receipt.visible && hasPreviousReceiptSheet);
   }
 
   return Object.assign({}, item, {
     monthLabel,
     rows,
     grandTotal: breakdown.grandTotal,
-    showReceipt: receipt.showReceipt,
-    receiptRemark: receipt.receiptRemark,
-    receiptMonths: receipt.receiptMonths,
-    receiptVisible: receipt.showReceipt,
     previousReceipt
   });
 }


### PR DESCRIPTION
## Summary
- base previous receipt visibility solely on the existence of the prior bank withdrawal sheet
- propagate the bank sheet flag to billing entries and simplify receipt visibility handling in invoice generation and templates

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69487a8e249083219e1dcc50a381fdb0)