### PR TITLE
Aggregate receipt months from unpaid history

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -308,14 +308,13 @@ function normalizeReceiptMonths_(months, fallbackMonth) {
 
 function resolveInvoiceReceiptDisplay_(item) {
   const hasPreviousReceiptSheet = !!(item && item.hasPreviousReceiptSheet);
-  const previousMonth = resolvePreviousBillingMonthKey_(item && item.billingMonth);
-  const receiptMonths = previousMonth
-    ? normalizeReceiptMonths_([previousMonth])
-    : [];
+  const fallbackMonth = resolvePreviousBillingMonthKey_(item && item.billingMonth);
+  const receiptMonths = normalizeReceiptMonths_(item && item.receiptMonths, fallbackMonth);
+  const receiptRemark = formatAggregatedReceiptRemark_(receiptMonths);
 
   return {
     visible: hasPreviousReceiptSheet,
-    receiptRemark: '',
+    receiptRemark,
     receiptMonths
   };
 }


### PR DESCRIPTION
## Summary
- derive receiptMonths by walking unpaid history from the latest bank withdrawal sheet
- include the computed receiptMonths on billing entries for invoice generation
- surface aggregated receipt months and remarks when building receipt displays

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694892f849b88321b1ece0c18ae5d5b8)