### PR TITLE
Handle missing unpaidHistory when logging prepared payloads

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -925,10 +925,16 @@ function exportBankTransferRows_(billingMonth, rowObjects, bankStatuses) {
   function logPreparedBankPayloadStatus_(prepared) {
     const requiredKeys = ['billingJson', 'visitsByPatient', 'totalsByPatient', 'carryOverByPatient', 'unpaidHistory', 'bankAccountInfoByPatient'];
     const normalized = normalizePreparedBilling_(prepared) || {};
+    const preparedWithUnpaidHistory = Object.assign({}, normalized, {
+      unpaidHistory: Array.isArray(normalized.unpaidHistory) ? normalized.unpaidHistory : []
+    });
     const missing = requiredKeys.filter(key => {
-      const value = normalized[key];
+      const value = preparedWithUnpaidHistory[key];
       if (key === 'billingJson') {
         return !Array.isArray(value) || value.length === 0;
+      }
+      if (key === 'unpaidHistory') {
+        return !Array.isArray(value);
       }
       if (Array.isArray(value)) return value.length === 0;
       return !value || (typeof value === 'object' && Object.keys(value).length === 0);


### PR DESCRIPTION
## Summary
- ensure prepared payloads default unpaidHistory to an empty array when absent
- avoid flagging unpaidHistory as missing when it is simply empty during prepared bank payload logging

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69489f8826d48321a79ba8fe077e2c46)