### PR TITLE
Add bank withdrawal AE/AF flags to prepared payload

### DIFF
--- a/tests/preparedBillingCache.test.js
+++ b/tests/preparedBillingCache.test.js
@@ -22,6 +22,7 @@ function buildValidPreparedPayload(ctx, overrides = {}) {
     staffDirectory: {},
     staffDisplayByPatient: {},
     billingOverrideFlags: {},
+    bankFlagsByPatient: {},
     carryOverByPatient: {},
     bankAccountInfoByPatient: {}
   }, overrides);


### PR DESCRIPTION
## Summary
- read AE/AF bank withdrawal flags using header names and map them to patient IDs
- store normalized bank withdrawal flags on prepared billing payloads and client payloads

## Testing
- npm test *(fails: repository has no package.json)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a1adcdf48832595dedf185fe26e37)