### PR TITLE
Copy bank flags into billingJson entries

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1715,15 +1715,32 @@ function coerceBillingJsonArray_(raw) {
     const rawLength = Array.isArray(payload && payload.billingJson) ? payload.billingJson.length : 0;
     if (!payload) return null;
     const normalizeMap_ = value => (value && typeof value === 'object' && !Array.isArray(value) ? value : {});
+    const normalizeBankFlags_ = flags => ({
+      ae: !!(flags && flags.ae),
+      af: !!(flags && flags.af)
+    });
+    const bankFlagsByPatient = normalizeMap_(payload.bankFlagsByPatient);
+    const billingJson = coerceBillingJsonArray_(payload.billingJson).map(entry => {
+      const pid = typeof billingNormalizePatientId_ === 'function'
+        ? billingNormalizePatientId_(entry && entry.patientId)
+        : String(entry && entry.patientId ? entry.patientId : '').trim();
+      const bankFlags = pid && bankFlagsByPatient && Object.prototype.hasOwnProperty.call(bankFlagsByPatient, pid)
+        ? bankFlagsByPatient[pid]
+        : null;
+      return Object.assign({}, entry || {}, {
+        bankFlags: normalizeBankFlags_(bankFlags)
+      });
+    });
     const schemaVersion = Number(payload.schemaVersion);
     const normalized = {
       schemaVersion: Number.isFinite(schemaVersion) ? schemaVersion : null,
       billingMonth: payload.billingMonth || '',
       preparedAt: payload.preparedAt || null,
-      billingJson: coerceBillingJsonArray_(payload.billingJson),
+      billingJson,
       patients: normalizeMap_(payload.patients),
       bankInfoByName: normalizeMap_(payload.bankInfoByName),
       bankAccountInfoByPatient: normalizeMap_(payload.bankAccountInfoByPatient),
+      bankFlagsByPatient,
       visitsByPatient: normalizeMap_(payload.visitsByPatient),
       totalsByPatient: normalizeMap_(payload.totalsByPatient),
       staffByPatient: normalizeMap_(payload.staffByPatient),

--- a/tests/billingOutput.test.js
+++ b/tests/billingOutput.test.js
@@ -487,6 +487,7 @@ function testBankExportUsesNormalizedBillingJsonWhenMissingFromPayload() {
   const normalizedBillingJson = [{ billingMonth: '202501', patientId: 'P001', nameKanji: '正規化済み' }];
   const bankInfoByName = { normalized: { bankCode: '0001', branchCode: '002', accountNumber: '1234567' } };
   const patients = { P001: { bankCode: '0001', branchCode: '002', accountNumber: '1234567' } };
+  const bankFlagsByPatient = { P001: { ae: true, af: false } };
   const buildCalls = [];
   const exportCalls = [];
 
@@ -496,7 +497,8 @@ function testBankExportUsesNormalizedBillingJsonWhenMissingFromPayload() {
       billingJson: normalizedBillingJson,
       bankInfoByName,
       patients,
-      bankStatuses: {}
+      bankStatuses: {},
+      bankFlagsByPatient
     }, payload),
     logPreparedBankPayloadStatus_: () => {}
   });
@@ -513,7 +515,12 @@ function testBankExportUsesNormalizedBillingJsonWhenMissingFromPayload() {
   const result = context.exportBankTransferDataForPrepared_({ billingMonth: '202501' });
 
   assert.strictEqual(buildCalls.length, 1, '正規化済みの billingJson で銀行CSV構築に進む');
-  assert.deepStrictEqual(buildCalls[0].billingJson, normalizedBillingJson, 'billingJson は正規化結果がそのまま渡される');
+  assert.deepStrictEqual(buildCalls[0].billingJson, [{
+    billingMonth: '202501',
+    patientId: 'P001',
+    nameKanji: '正規化済み',
+    bankFlags: { ae: true, af: false }
+  }], 'billingJson は bankFlags を付与した上で渡される');
   assert.strictEqual(exportCalls.length, 1, 'エクスポート処理まで到達する');
   assert.strictEqual(result.rows.length, 1, '正規化済みデータから行が生成される');
 }

--- a/tests/preparedBillingCache.test.js
+++ b/tests/preparedBillingCache.test.js
@@ -333,6 +333,23 @@ function testBankExportReturnsEmptyForZeroBilling() {
   }, /破損しています/);
 }
 
+function testBankFlagsAreMergedIntoBillingJson() {
+  const ctx = createMainContext();
+  const normalized = ctx.normalizePreparedBilling_({
+    billingMonth: '202501',
+    billingJson: [
+      { patientId: 'P001', billingMonth: '202501' },
+      { patientId: 'P002', billingMonth: '202501' }
+    ],
+    bankFlagsByPatient: {
+      P001: { ae: true, af: false }
+    }
+  });
+
+  assert.deepStrictEqual(normalized.billingJson[0].bankFlags, { ae: true, af: false }, 'bankFlagsは準備データからコピーされる');
+  assert.deepStrictEqual(normalized.billingJson[1].bankFlags, { ae: false, af: false }, 'bankFlagsが無い患者はfalseで初期化される');
+}
+
 function testBankExportReportsLedgerIssues() {
   let ctx;
   ctx = createMainContext({
@@ -608,6 +625,7 @@ function run() {
   testBankExportPassesWhenArrayProvided();
   testBankExportAcceptsYmObject();
   testBankExportReturnsEmptyForZeroBilling();
+  testBankFlagsAreMergedIntoBillingJson();
   testBankExportReportsLedgerIssues();
   testBankExportReportsMissingPreparation();
   testPreparedBillingSheetFallback();


### PR DESCRIPTION
## Summary
- propagate bankFlags from prepared payloads onto every billingJson entry with boolean defaults
- normalize prepared payloads to retain bankFlagsByPatient metadata
- cover bankFlags propagation with billing export and prepared cache tests

## Testing
- npm test --silent

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a1ee2b9b88325b7c41527e5247852)