### PR TITLE
Respect bank flags when showing receipts

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -325,7 +325,11 @@ function resolveInvoiceReceiptDisplay_(item) {
     ? formatAggregatedReceiptRemark_(receiptMonths)
     : '';
   const receiptStatus = item && item.receiptStatus ? String(item.receiptStatus).toUpperCase() : '';
-  const showReceipt = hasPreviousReceiptSheet && receiptStatus !== 'UNPAID';
+  const bankFlags = item && item.bankFlags;
+  const unpaidFlag = bankFlags && (bankFlags.ae || bankFlags.AE);
+  const aggregateFlag = bankFlags && (bankFlags.af || bankFlags.AF);
+  const hasBankRestriction = !!(unpaidFlag || aggregateFlag);
+  const showReceipt = hasPreviousReceiptSheet && receiptStatus !== 'UNPAID' && !hasBankRestriction;
 
   return {
     visible: showReceipt,


### PR DESCRIPTION
## Summary
- prevent receipt display when AE or AF bank withdrawal flags are set on billing rows
- preserve existing receipt behavior when both flags are off or absent
- add tests covering bank flag handling alongside existing receipt visibility rules

## Testing
- node tests/billingOutput.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a20c94dbc8325b277b6497fc9e225)