### PR TITLE
Remove aggregate checkbox data validation

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1360,20 +1360,6 @@ function ensureBankWithdrawalFlagColumns_(sheet, headers) {
         const aggregateCheckboxRule = SpreadsheetApp.newDataValidation().requireCheckbox().build();
         aggregateRange.setDataValidation(aggregateCheckboxRule);
       }
-      if (SpreadsheetApp && typeof SpreadsheetApp.newDataValidation === 'function') {
-        const aggregateBuilder = SpreadsheetApp.newDataValidation();
-        if (typeof aggregateBuilder.requireCheckbox === 'function') {
-          aggregateBuilder.requireCheckbox();
-        }
-        if (typeof aggregateBuilder.requireFormulaSatisfied === 'function') {
-          const rowScopedUnpaid = `INDIRECT(ADDRESS(ROW(), ${unpaidCol}))`;
-          aggregateBuilder.requireFormulaSatisfied(`${rowScopedUnpaid}=TRUE`);
-        }
-        aggregateBuilder.setAllowInvalid(false);
-        aggregateBuilder.setHelpText('未回収チェックがONのときのみチェックできます');
-        const aggregateRule = aggregateBuilder.build();
-        aggregateRange.setDataValidation(aggregateRule);
-      }
     }
   } catch (err) {
     console.warn('[billing] Failed to ensure checkbox columns for bank withdrawal flags', err);


### PR DESCRIPTION
## Summary
- remove data validation rules from the bank withdrawal aggregate checkbox column that relied on Apps Script formulas
- keep only checkbox insertion while relying on existing server-side constraint enforcement

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a249404a48325bef8baa29f532019)