### PR TITLE
Add aggregated invoice PDF generation

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -80,6 +80,9 @@
         </tfoot>
       </table>
       <div class="note"><?= isAggregateInvoice ? '未回収期間を含めた合計金額です。' : '前月繰越を含む合計金額です。' ?>口座振替日：毎月20日（祝日の場合は翌営業日）</div>
+      <? if (data.aggregateRemark) { ?>
+        <div class="note"><strong>備考:</strong> <?= data.aggregateRemark ?></div>
+      <? } ?>
     </section>
 
     <hr class="divider">
@@ -95,9 +98,10 @@
     <? var receiptBreakdown = receipt.breakdown || []; ?>
     <? var hasReceiptBreakdown = Array.isArray(receiptBreakdown) && receiptBreakdown.length > 0; ?>
 
-    <section class="card">
-      <h3 class="section-title">前月分領収書</h3>
-      <? if (showReceipt) { ?>
+    <? if (!data.forceHideReceipt) { ?>
+      <section class="card">
+        <h3 class="section-title">前月分領収書</h3>
+        <? if (showReceipt) { ?>
         <div class="info">
           <div class="label">宛名</div>
           <div><?= receiptAddressee || '―' ?></div>
@@ -127,9 +131,10 @@
           </table>
         <? } ?>
       <? } else { ?>
-        <div class="note">前月分は未入金のため、後日合算して請求されます</div>
-      <? } ?>
-    </section>
+          <div class="note">前月分は未入金のため、後日合算して請求されます</div>
+        <? } ?>
+      </section>
+    <? } ?>
   </div>
 </body>
 </html>

--- a/src/main.gs
+++ b/src/main.gs
@@ -2064,6 +2064,47 @@ function generateInvoicesFromCache(billingMonth, options) {
   return generatePreparedInvoices_(prepared, options);
 }
 
+function normalizeAggregateInvoiceMonths_(months, prepared, billingMonth) {
+  const aggregateUntilMonth = prepared && prepared.aggregateUntilMonth ? prepared.aggregateUntilMonth : '';
+  const source = []
+    .concat(months || [])
+    .concat(aggregateUntilMonth ? [aggregateUntilMonth] : [])
+    .concat(billingMonth ? [billingMonth] : []);
+  return typeof normalizeAggregateMonthsForInvoice_ === 'function'
+    ? normalizeAggregateMonthsForInvoice_(source, billingMonth)
+    : source;
+}
+
+function generateAggregatedInvoice(billingMonth, options) {
+  const month = normalizeBillingMonthInput(billingMonth);
+  const opts = options || {};
+  const patientId = billingNormalizePatientId_(opts.patientId);
+  if (!patientId) {
+    throw new Error('患者IDを指定してください');
+  }
+
+  const loaded = loadPreparedBillingWithSheetFallback_(month.key, { withValidation: true, restoreCache: true });
+  const validation = loaded && loaded.validation ? loaded.validation : null;
+  const prepared = normalizePreparedBilling_(loaded && loaded.prepared);
+  if (!prepared || !prepared.billingJson || (validation && validation.ok === false)) {
+    throw new Error('事前集計が見つかりません。先に「請求データを集計」ボタンを実行してください。');
+  }
+
+  const entry = (prepared.billingJson || []).find(row => billingNormalizePatientId_(row && row.patientId) === patientId);
+  if (!entry) {
+    throw new Error('対象患者の請求データが見つかりません');
+  }
+
+  const mergedMonths = []
+    .concat(opts.aggregateMonths || [])
+    .concat(entry.aggregateMonths || [])
+    .concat(entry.receiptMonths || []);
+  const aggregateMonths = normalizeAggregateInvoiceMonths_(mergedMonths, prepared, month.key);
+
+  const file = generateAggregateInvoicePdf(entry, { aggregateMonths, billingMonth: month.key });
+  return { billingMonth: month.key, patientId, aggregateMonths, file };
+}
+
 function normalizeBillingEditBurden_(value) {
   if (value === null || value === undefined) return null;
   const raw = String(value).trim();


### PR DESCRIPTION
## Summary
- add aggregate invoice helpers to build combined-month data and filenames using existing template
- expose a generateAggregatedInvoice entry point that outputs a single aggregated invoice PDF for the requested patient
- update the invoice template to show aggregate remarks and hide receipts when generating combined invoices

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a2afc0db483259b4c106e77c81d56)