### PR TITLE
Display finalized billing metadata on billing rows

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -54,6 +54,8 @@
   .pill.ok{ background:#ecfeff; color:#0f172a; }
   .pill.neutral{ background:#e5e7eb; color:#111827; }
   .pill.finalized{ background:#eef2ff; color:#4338ca; }
+  .finalized-badge{ display:inline-flex; flex-direction:column; align-items:flex-start; gap:2px; margin-left:6px; }
+  .finalized-sub{ font-size:0.75rem; color:var(--muted); line-height:1.2; }
   .finalized-row td{ background:#f8fafc; color:#4b5563; }
   .downloads{ display:flex; gap:8px; flex-wrap:wrap; margin-top:10px; }
   .download-link{ display:inline-flex; align-items:center; gap:8px; padding:10px 12px; border-radius:10px; background:#eff6ff; color:#1d4ed8; font-weight:600; text-decoration:none; }

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -771,9 +771,24 @@ function isBillingRowFinalized(item) {
   return flag === true || flag === 'true' || flag === 1 || flag === '1';
 }
 
+function getFinalizationDetailParts(item) {
+  const timestamp = formatDateTimeDisplay(item && item.finalizedAt);
+  const actor = item && item.finalizedBy ? String(item.finalizedBy).trim() : '';
+  return [timestamp, actor].filter(Boolean);
+}
+
+function getFinalizationDetailText(item) {
+  return getFinalizationDetailParts(item).join(' / ');
+}
+
 function renderFinalizedBadge(item) {
   if (!isBillingRowFinalized(item)) return '';
-  return ' <span class="pill finalized" title="この請求は確定済みです">確定済み</span>';
+  const detail = getFinalizationDetailText(item);
+  const title = detail
+    ? `この請求は確定済みです\n${detail}`
+    : 'この請求は確定済みです';
+  const subText = detail ? `<span class="finalized-sub">${escapeHtml(detail)}</span>` : '';
+  return ` <span class="finalized-badge"><span class="pill finalized" title="${escapeHtml(title)}">確定済み</span>${subText}</span>`;
 }
 
 function maskAccountNumber(value) {
@@ -1955,11 +1970,8 @@ function renderBillingResult() {
   function renderFinalizeAction(item) {
     const finalized = isBillingRowFinalized(item);
     if (finalized) {
-      const timestamp = formatDateTimeDisplay(item.finalizedAt);
-      const actor = item.finalizedBy ? String(item.finalizedBy).trim() : '';
+      const detailText = escapeHtml(getFinalizationDetailText(item));
       const source = item.finalizationSource ? String(item.finalizationSource).trim() : '';
-      const detailParts = [timestamp, actor].filter(Boolean);
-      const detailText = detailParts.length ? escapeHtml(detailParts.join(' / ')) : '';
       const sourceLabel = source ? ` (${escapeHtml(source)})` : '';
       if (detailText) {
         return `<div class="muted">確定済み${sourceLabel}<br><small>${detailText}</small></div>`;


### PR DESCRIPTION
## Summary
- add tooltip/subtext support to the finalized billing badge with updated styling
- surface finalized timestamp and actor details consistently for finalized billing rows

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a3810ddb483258965f759064fc9e2)