### PR TITLE
Add finalized watermark to invoice PDFs

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -28,9 +28,30 @@
     .subtable th.amount, .subtable td.amount { text-align: right; }
     .note { color: #475569; font-size: 12px; margin-top: 6px; }
     .divider { border: 0; border-top: 1px dashed #cbd5e1; margin: 4px 0 2px; }
+    .watermark {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 120px;
+      font-weight: 700;
+      color: #cbd5e1;
+      opacity: 0.22;
+      transform: rotate(-45deg);
+      pointer-events: none;
+      user-select: none;
+      white-space: nowrap;
+      z-index: 0;
+    }
+    .wrapper { position: relative; z-index: 1; }
   </style>
 </head>
 <body>
+  <? var watermark = data && data.watermark; ?>
+  <? if (watermark && watermark.text) { ?>
+    <div class="watermark"><?= watermark.text ?></div>
+  <? } ?>
   <div class="wrapper">
     <header class="header">
       <? var isAggregateInvoice = data.isAggregateInvoice || data.invoiceMode === 'aggregate'; ?>

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -500,11 +500,17 @@ function formatAggregateInvoiceRemark_(months) {
   return labels.join('・') + '分 施術料金として';
 }
 
+function buildInvoiceWatermark_(item) {
+  const finalized = !!(item && item.billingFinalized);
+  return finalized ? { text: '確定済み' } : null;
+}
+
 function buildAggregateInvoiceTemplateData_(item, aggregateMonths) {
   const billingMonth = item && item.billingMonth;
   const monthLabel = normalizeBillingMonthLabel_(billingMonth);
   const aggregateLabel = monthLabel ? `${monthLabel}（合算）` : '合算請求';
   const amount = normalizeBillingAmount_(item);
+  const watermark = buildInvoiceWatermark_(item);
   const months = normalizeAggregateMonthsForInvoice_(aggregateMonths, billingMonth);
   const aggregateRemark = formatAggregateInvoiceRemark_(months);
 
@@ -513,6 +519,7 @@ function buildAggregateInvoiceTemplateData_(item, aggregateMonths) {
     chargeMonthLabel: aggregateLabel,
     isAggregateInvoice: true,
     invoiceMode: 'aggregate',
+    watermark,
     receiptMonths: months,
     receiptRemark: aggregateRemark,
     aggregateRemark,
@@ -532,6 +539,7 @@ function buildInvoiceTemplateData_(item) {
   const breakdown = calculateInvoiceChargeBreakdown_(Object.assign({}, item, { billingMonth }));
   const visits = breakdown.visits || 0;
   const unitPrice = breakdown.treatmentUnitPrice || 0;
+  const watermark = buildInvoiceWatermark_(item);
   const hasPreviousReceiptSheet = resolveHasPreviousReceiptSheet_(item);
   const normalizedPreviousReceiptAmount = normalizeInvoiceMoney_(item && item.previousReceiptAmount);
   const rows = [
@@ -571,6 +579,7 @@ function buildInvoiceTemplateData_(item) {
     chargeMonthLabel,
     isAggregateInvoice,
     invoiceMode: isAggregateInvoice ? 'aggregate' : 'standard',
+    watermark,
     receiptMonths,
     receiptRemark: (receipt && receipt.receiptRemark) || '',
     showReceipt: !!(receipt && receipt.visible),


### PR DESCRIPTION
## Summary
- add reusable watermark metadata to invoice and aggregate invoice PDF data
- render a light gray diagonal "確定済み" watermark when billing is finalized

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a4686b4288325977a603dff165345)