### PR TITLE
Add aggregate status badges to billing list UI

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -54,6 +54,11 @@
   .pill.ok{ background:#ecfeff; color:#0f172a; }
   .pill.neutral{ background:#e5e7eb; color:#111827; }
   .pill.finalized{ background:#eef2ff; color:#4338ca; }
+  .receipt-badge-group{ display:inline-flex; flex-direction:column; align-items:flex-start; gap:2px; margin-left:8px; }
+  .receipt-badge{ display:inline-flex; align-items:center; gap:6px; padding:4px 10px; border-radius:999px; font-size:0.82rem; font-weight:800; letter-spacing:0.01em; box-shadow:0 10px 24px rgba(0,0,0,0.08); border:1px solid transparent; }
+  .receipt-badge.aggregate{ background:#fff7ed; color:#c2410c; border-color:#fdba74; }
+  .receipt-badge.finalized{ background:#eef2ff; color:#312e81; border-color:#c7d2fe; }
+  .receipt-badge-sub{ font-size:0.75rem; color:var(--muted); line-height:1.2; }
   .finalized-badge{ display:inline-flex; flex-direction:column; align-items:flex-start; gap:2px; margin-left:6px; }
   .finalized-sub{ font-size:0.75rem; color:var(--muted); line-height:1.2; }
   .finalized-row td{ background:#f8fafc; color:#4b5563; }

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -774,6 +774,10 @@ function formatPaidStatus(item) {
   return item.paidStatus || item.bankStatus || '';
 }
 
+function normalizeReceiptStatus(status) {
+  return String(status || '').trim().toUpperCase();
+}
+
 function isBillingRowFinalized(item) {
   const flag = item && item.billingFinalized;
   return flag === true || flag === 'true' || flag === 1 || flag === '1';
@@ -789,14 +793,38 @@ function getFinalizationDetailText(item) {
   return getFinalizationDetailParts(item).join(' / ');
 }
 
-function renderFinalizedBadge(item) {
-  if (!isBillingRowFinalized(item)) return '';
-  const detail = getFinalizationDetailText(item);
-  const title = detail
-    ? `この請求は確定済みです\n${detail}`
-    : 'この請求は確定済みです';
-  const subText = detail ? `<span class="finalized-sub">${escapeHtml(detail)}</span>` : '';
-  return ` <span class="finalized-badge"><span class="pill finalized" title="${escapeHtml(title)}">確定済み</span>${subText}</span>`;
+function renderReceiptStatusBadge(item) {
+  const finalized = isBillingRowFinalized(item);
+  const status = normalizeReceiptStatus(item && item.receiptStatus);
+  const aggregateLabel = status === 'AGGREGATE'
+    ? (item && item.aggregateUntilMonth ? formatYmDisplay(item.aggregateUntilMonth) : '')
+    : '';
+
+  if (!finalized && status !== 'AGGREGATE') return '';
+
+  const titleLines = finalized
+    ? ['この請求は合算確定です']
+    : ['この請求は合算請求として処理予定です'];
+
+  const subText = (() => {
+    if (finalized) {
+      const detail = getFinalizationDetailText(item);
+      if (detail) {
+        titleLines.push(detail);
+        return `<span class="receipt-badge-sub">${escapeHtml(detail)}</span>`;
+      }
+      return '';
+    }
+    if (aggregateLabel) {
+      titleLines.push(`${aggregateLabel}までの合算を予定`);
+      return `<span class="receipt-badge-sub">〜${escapeHtml(aggregateLabel)}合算</span>`;
+    }
+    return '';
+  })();
+
+  const badgeClass = finalized ? 'receipt-badge finalized' : 'receipt-badge aggregate';
+  const label = finalized ? '合算確定' : '合算予定';
+  return ` <span class="receipt-badge-group"><span class="${badgeClass}" title="${escapeHtml(titleLines.join(' / '))}">${label}</span>${subText}</span>`;
 }
 
 function maskAccountNumber(value) {
@@ -2003,7 +2031,7 @@ function renderBillingResult() {
       const safeItem = item && typeof item === 'object' ? item : {};
       const finalized = isBillingRowFinalized(safeItem);
       const rowClass = finalized ? ' class="finalized-row"' : '';
-      const nameWithBadge = `${safeItem.nameKanji || ''}${renderFinalizedBadge(safeItem)}`;
+      const nameWithBadge = `${safeItem.nameKanji || ''}${renderReceiptStatusBadge(safeItem)}`;
       bodyRows.push(`
       <tr${rowClass}>
         <td>${safeItem.patientId || ''}</td>


### PR DESCRIPTION
## Summary
- add high-visibility receipt status badges for billing rows
- display aggregate-planned and aggregate-confirmed states directly in the list
- include styling for easy visual identification

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a71d38cbc8325af95db0d6b74f7d7)