### PR TITLE
Add finalized aggregate helper text to billing list

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -808,12 +808,17 @@ function renderReceiptStatusBadge(item) {
 
   const subText = (() => {
     if (finalized) {
+      const finalizedNote = 'この月は合算請求が確定しています';
       const detail = getFinalizationDetailText(item);
+      const subLines = [finalizedNote];
       if (detail) {
         titleLines.push(detail);
-        return `<span class="receipt-badge-sub">${escapeHtml(detail)}</span>`;
+        subLines.push(detail);
       }
-      return '';
+      return subLines
+        .filter(Boolean)
+        .map(line => `<span class="receipt-badge-sub">${escapeHtml(line)}</span>`)
+        .join('');
     }
     if (aggregateLabel) {
       titleLines.push(`${aggregateLabel}までの合算を予定`);


### PR DESCRIPTION
## Summary
- show a default helper note under the finalized aggregate badge on billing rows
- keep any finalization details alongside the new message

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a75251344832583d7c1fd64fea46b)