### PR TITLE
Improve finalized billing lock UI

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -57,6 +57,10 @@
   .finalized-badge{ display:inline-flex; flex-direction:column; align-items:flex-start; gap:2px; margin-left:6px; }
   .finalized-sub{ font-size:0.75rem; color:var(--muted); line-height:1.2; }
   .finalized-row td{ background:#f8fafc; color:#4b5563; }
+  .locked-text{ color:#6b7280; display:inline-flex; align-items:center; gap:6px; }
+  .locked-text::before{ content:'\26D4'; font-size:0.85rem; }
+  .finalized-lock-note{ font-size:0.9rem; color:#991b1b; margin:6px 0 0; }
+  .finalized-lock-note small{ display:block; color:var(--muted); margin-top:2px; }
   .downloads{ display:flex; gap:8px; flex-wrap:wrap; margin-top:10px; }
   .download-link{ display:inline-flex; align-items:center; gap:8px; padding:10px 12px; border-radius:10px; background:#eff6ff; color:#1d4ed8; font-weight:600; text-decoration:none; }
   .download-link svg{ width:16px; height:16px; }
@@ -118,6 +122,7 @@
           <div id="billingStatus" class="status-line" style="flex:1"></div>
           <div id="carryOverLedgerStatus" class="pill neutral" style="display:none"></div>
         </div>
+        <p class="finalized-lock-note" id="finalizedLockNote" style="display:none"></p>
         <div id="billingError" class="alert danger" style="display:none"></div>
       </div>
       <div class="generation-options">

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -83,19 +83,26 @@ function updateBillingControls() {
   const saveBtn = qs('billingSaveBtn');
   const loading = billingState.loading;
   const prepared = !!(billingState.prepared && billingState.prepared.billingMonth);
+  const finalizedLocked = hasFinalizedBillingRows();
 
   if (monthInput) {
     monthInput.disabled = loading;
   }
   if (aggregateBtn) {
-    aggregateBtn.disabled = loading;
+    const disabled = loading || finalizedLocked;
+    aggregateBtn.disabled = disabled;
     aggregateBtn.setAttribute('aria-busy', loading ? 'true' : 'false');
+    aggregateBtn.title = disabled && finalizedLocked ? '確定済みの請求が含まれているため再集計できません' : '';
   }
   if (pdfBtn) {
-    const disabled = loading || !prepared;
+    const disabled = loading || !prepared || finalizedLocked;
     pdfBtn.disabled = disabled;
     pdfBtn.setAttribute('aria-busy', loading ? 'true' : 'false');
-    pdfBtn.title = disabled && !prepared ? '先に「請求データを集計」を実行してください' : '';
+    pdfBtn.title = disabled
+      ? (!prepared
+        ? '先に「請求データを集計」を実行してください'
+        : (finalizedLocked ? '確定済みの請求が含まれているためPDF生成できません' : ''))
+      : '';
   }
   if (saveBtn) {
     const disabled = loading || !prepared;
@@ -105,6 +112,7 @@ function updateBillingControls() {
   }
   updateInvoiceModeControls();
   renderReceiptControls();
+  renderFinalizedLockNotice();
 }
 
 function getBankTargetMonth() {
@@ -119,11 +127,26 @@ function getSimpleBankMonth() {
   return input && input.value ? normalizeYm(input.value) : '';
 }
 
-const BILLING_FINALIZED_ALERT_MESSAGE = 'この請求は確定済みのため操作できません';
+const BILLING_FINALIZED_LOCK_MESSAGE = '確定済み（合算確定）の請求が含まれているため、再集計とPDF再生成はできません。';
+
+function renderFinalizedLockNotice() {
+  const note = qs('finalizedLockNote');
+  if (!note) return;
+  const hasPreparedMonth = !!(billingState.prepared && billingState.prepared.billingMonth);
+  const locked = hasPreparedMonth && hasFinalizedBillingRows();
+  if (!locked) {
+    note.style.display = 'none';
+    note.textContent = '';
+    return;
+  }
+  note.style.display = '';
+  note.textContent = BILLING_FINALIZED_LOCK_MESSAGE;
+  note.innerHTML = `${escapeHtml(BILLING_FINALIZED_LOCK_MESSAGE)}<small>確定解除しない限り、再集計やPDFの再生成は行えません。</small>`;
+}
 
 function shouldBlockFinalizedBillingOperation() {
   if (!hasFinalizedBillingRows()) return false;
-  alert(BILLING_FINALIZED_ALERT_MESSAGE);
+  renderFinalizedLockNotice();
   return true;
 }
 
@@ -231,7 +254,6 @@ function handleInvoicePatientInput(event) {
 function handleReceiptStatusChange(event) {
   if (isReceiptEditingLocked()) {
     renderReceiptControls();
-    alert(BILLING_FINALIZED_ALERT_MESSAGE);
     return;
   }
   const value = event && event.target ? event.target.value : '';
@@ -244,7 +266,6 @@ function handleReceiptStatusChange(event) {
 function handleReceiptAggregateChange(event) {
   if (isReceiptEditingLocked()) {
     renderReceiptControls();
-    alert(BILLING_FINALIZED_ALERT_MESSAGE);
     return;
   }
   const value = event && event.target ? event.target.value : '';
@@ -257,7 +278,6 @@ function handleReceiptAggregateChange(event) {
 function persistReceiptStatus() {
   if (isReceiptEditingLocked()) {
     renderReceiptControls();
-    alert(BILLING_FINALIZED_ALERT_MESSAGE);
     return;
   }
   if (!billingState.prepared || !billingState.prepared.billingMonth) {
@@ -1971,7 +1991,8 @@ function renderBillingResult() {
     })();
 
     if (finalized) {
-      return wrapWithOverrideBadge(display, item.patientId, field, alignRight);
+      const locked = `<span class="locked-text" title="確定済みのため編集不可" aria-disabled="true">${display}</span>`;
+      return wrapWithOverrideBadge(locked, item.patientId, field, alignRight);
     }
 
     const view = `<button type="button" class="${viewClass}" ${baseAttrs} aria-label="${field} を編集">${display}</button>`;
@@ -1984,10 +2005,11 @@ function renderBillingResult() {
       const detailText = escapeHtml(getFinalizationDetailText(item));
       const source = item.finalizationSource ? String(item.finalizationSource).trim() : '';
       const sourceLabel = source ? ` (${escapeHtml(source)})` : '';
+      const lockNote = '<div class="finalized-lock-note">確定済みのため再集計・PDF再生成はできません<small>解除しない限り内容を編集できません</small></div>';
       if (detailText) {
-        return `<div class="muted">確定済み${sourceLabel}<br><small>${detailText}</small></div>`;
+        return `<div class="muted">確定済み${sourceLabel}<br><small>${detailText}</small>${lockNote}</div>`;
       }
-      return `<div class="muted">確定済み${sourceLabel}</div>`;
+      return `<div class="muted">確定済み${sourceLabel}${lockNote}</div>`;
     }
 
     const disabled = billingState.loading || !billingState.prepared || !billingState.prepared.billingMonth;


### PR DESCRIPTION
## Summary
- disable aggregation and PDF generation buttons when finalized billing rows are present and surface a warning note
- add explicit locked styling and helper text for finalized rows to clarify they cannot be edited or regenerated
- render finalized-row badges with additional guidance about disabled operations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a730cb83483258cc0966bb344c966)