### PR TITLE
Ensure aggregate invoices use explicit representative month fallback

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -26,6 +26,7 @@
     .subtable { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 12px; }
     .subtable th, .subtable td { border: 1px solid #e2e8f0; padding: 6px 8px; text-align: left; }
     .subtable th.amount, .subtable td.amount { text-align: right; }
+    .subsection-title { margin: 10px 0 4px; font-weight: 700; font-size: 13px; }
     .note { color: #475569; font-size: 12px; margin-top: 6px; }
     .divider { border: 0; border-top: 1px dashed #cbd5e1; margin: 4px 0 2px; }
     .watermark {
@@ -80,26 +81,117 @@
 
     <section class="card">
       <h3 class="section-title">ご請求内容（<?= isAggregateInvoice ? '未回収合算' : '当月' ?>）</h3>
-      <table>
-        <thead>
-          <tr><th>項目</th><th>詳細</th><th class="amount">金額</th></tr>
-        </thead>
-        <tbody>
-          <? data.rows.forEach(function(row) { ?>
+      <?
+        var aggregateDetails = isAggregateInvoice && Array.isArray(data.aggregateInvoiceDetails)
+          ? data.aggregateInvoiceDetails
+          : [];
+        var aggregateDetailCount = aggregateDetails.length;
+        var useStackedAggregate = isAggregateInvoice && aggregateDetailCount > 0 && aggregateDetailCount <= 3;
+        var useAggregateSummary = isAggregateInvoice && aggregateDetailCount >= 4;
+        var normalizedBillingMonth = normalizeInvoiceMonthKey_(data.billingMonth || '');
+        var normalizedRepresentativeMonth = normalizeInvoiceMonthKey_(data.representativeMonth || normalizedBillingMonth);
+        var representativeDetail = data.representativeInvoiceDetail || null;
+        if (!representativeDetail && normalizedRepresentativeMonth) {
+          representativeDetail = aggregateDetails.find(function(detail) {
+            return normalizeInvoiceMonthKey_(detail && detail.month) === normalizedRepresentativeMonth;
+          });
+        }
+        if (!representativeDetail && aggregateDetailCount) {
+          representativeDetail = aggregateDetails[aggregateDetailCount - 1];
+        }
+        var aggregateSummaryRows = Array.isArray(data.aggregateSummaryRows) ? data.aggregateSummaryRows : [];
+      ?>
+      <? if (useStackedAggregate) { ?>
+        <? aggregateDetails.forEach(function(detail) { ?>
+          <div class="subsection-title"><?= detail.monthLabel || normalizeBillingMonthLabel_(detail.month) ?> ご請求</div>
+          <table>
+            <thead>
+              <tr><th>項目</th><th>詳細</th><th class="amount">金額</th></tr>
+            </thead>
+            <tbody>
+              <? detail.rows.forEach(function(row) { ?>
+                <tr>
+                  <td><?= row.label ?></td>
+                  <td><?= row.detail || '' ?></td>
+                  <td class="amount"><?= formatBillingCurrency_(row.amount) ?> 円</td>
+                </tr>
+              <? }); ?>
+            </tbody>
+            <tfoot>
+              <tr>
+                <td colspan="2">合計</td>
+                <td class="amount"><?= formatBillingCurrency_(detail.grandTotal) ?> 円</td>
+              </tr>
+            </tfoot>
+          </table>
+        <? }); ?>
+        <div class="note"><strong>合算請求額:</strong> <?= formatBillingCurrency_(data.grandTotal) ?> 円</div>
+      <? } else if (useAggregateSummary && representativeDetail) { ?>
+        <div class="subsection-title">月別簡易内訳</div>
+        <table class="subtable">
+          <thead>
+            <tr><th>月</th><th class="amount">施術料</th><th class="amount">交通費</th><th class="amount">小計</th></tr>
+          </thead>
+          <tbody>
+            <? aggregateSummaryRows.forEach(function(row) { ?>
+              <tr>
+                <td><?= row.monthLabel || normalizeBillingMonthLabel_(row.month) ?></td>
+                <td class="amount"><?= formatBillingCurrency_(row.treatmentAmount || 0) ?> 円</td>
+                <td class="amount"><?= formatBillingCurrency_(row.transportAmount || 0) ?> 円</td>
+                <td class="amount"><?= formatBillingCurrency_(row.subtotal || 0) ?> 円</td>
+              </tr>
+            <? }); ?>
+          </tbody>
+          <tfoot>
             <tr>
-              <td><?= row.label ?></td>
-              <td><?= row.detail || '' ?></td>
-              <td class="amount"><?= formatBillingCurrency_(row.amount) ?> 円</td>
+              <td colspan="3">合算請求額</td>
+              <td class="amount"><?= formatBillingCurrency_(data.grandTotal) ?> 円</td>
             </tr>
-          <? }); ?>
-        </tbody>
-        <tfoot>
-          <tr>
-            <td colspan="2">合計</td>
-            <td class="amount"><?= formatBillingCurrency_(data.grandTotal) ?> 円</td>
-          </tr>
-        </tfoot>
-      </table>
+          </tfoot>
+        </table>
+        <div class="subsection-title">詳細内訳（<?= representativeDetail.monthLabel || normalizeBillingMonthLabel_(representativeDetail.month) ?>）</div>
+        <table>
+          <thead>
+            <tr><th>項目</th><th>詳細</th><th class="amount">金額</th></tr>
+          </thead>
+          <tbody>
+            <? representativeDetail.rows.forEach(function(row) { ?>
+              <tr>
+                <td><?= row.label ?></td>
+                <td><?= row.detail || '' ?></td>
+                <td class="amount"><?= formatBillingCurrency_(row.amount) ?> 円</td>
+              </tr>
+            <? }); ?>
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colspan="2">合計</td>
+              <td class="amount"><?= formatBillingCurrency_(representativeDetail.grandTotal) ?> 円</td>
+            </tr>
+          </tfoot>
+        </table>
+      <? } else { ?>
+        <table>
+          <thead>
+            <tr><th>項目</th><th>詳細</th><th class="amount">金額</th></tr>
+          </thead>
+          <tbody>
+            <? data.rows.forEach(function(row) { ?>
+              <tr>
+                <td><?= row.label ?></td>
+                <td><?= row.detail || '' ?></td>
+                <td class="amount"><?= formatBillingCurrency_(row.amount) ?> 円</td>
+              </tr>
+            <? }); ?>
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colspan="2">合計</td>
+              <td class="amount"><?= formatBillingCurrency_(data.grandTotal) ?> 円</td>
+            </tr>
+          </tfoot>
+        </table>
+      <? } ?>
       <div class="note"><?= isAggregateInvoice ? '未回収期間を含めた合計金額です。' : '前月繰越を含む合計金額です。' ?>口座振替日：毎月20日（祝日の場合は翌営業日）</div>
       <? if (data.aggregateRemark) { ?>
         <div class="note"><strong>備考:</strong> <?= data.aggregateRemark ?></div>

--- a/tests/billingInvoiceLayout.test.js
+++ b/tests/billingInvoiceLayout.test.js
@@ -21,7 +21,12 @@ function createContext(overrides = {}) {
 
 const context = createContext();
 
-const { calculateInvoiceChargeBreakdown_, buildBillingInvoiceHtml_, buildInvoiceTemplateData_ } = context;
+const {
+  calculateInvoiceChargeBreakdown_,
+  buildAggregateInvoiceTemplateData_,
+  buildBillingInvoiceHtml_,
+  buildInvoiceTemplateData_
+} = context;
 
 if (typeof calculateInvoiceChargeBreakdown_ !== 'function' || typeof buildBillingInvoiceHtml_ !== 'function') {
   throw new Error('Invoice helpers failed to load in the test context');
@@ -122,6 +127,138 @@ function testInvoiceTemplateAddsReceiptDecision() {
   assert.strictEqual(payable.receiptRemark, '', '備考は付与しない');
 }
 
+function testAggregateInvoiceTemplateStacksPerMonth() {
+  const patientId = 'patient-1';
+  const entriesByMonth = {
+    '202501': { billingMonth: '202501', patientId, visitCount: 2, burdenRate: 1, insuranceType: '鍼灸', carryOverAmount: 100 },
+    '202502': { billingMonth: '202502', patientId, visitCount: 3, burdenRate: 1, insuranceType: '鍼灸', carryOverAmount: 0 },
+    '202503': { billingMonth: '202503', patientId, visitCount: 4, burdenRate: 1, insuranceType: '鍼灸', carryOverAmount: 50 }
+  };
+
+  const aggregateContext = createContext({
+    billingNormalizePatientId_: (value) => value,
+    normalizePreparedBilling_: (value) => value,
+    loadPreparedBillingWithSheetFallback_: (monthKey) => ({
+      billingMonth: monthKey,
+      billingJson: entriesByMonth[monthKey] ? [entriesByMonth[monthKey]] : []
+    })
+  });
+  const { buildAggregateInvoiceTemplateData_ } = aggregateContext;
+
+  const data = buildAggregateInvoiceTemplateData_(entriesByMonth['202503'], ['202501', '202502', '202503']);
+
+  assert.strictEqual(data.aggregateInvoiceDetails.length, 3, '合算対象月ごとに明細が作成される');
+  assert.strictEqual(data.representativeInvoiceDetail.month, '202503', '代表月は billingMonth と一致する');
+  const januaryDetail = data.aggregateInvoiceDetails.find(detail => detail.month === '202501');
+  const marchDetail = data.aggregateInvoiceDetails.find(detail => detail.month === '202503');
+  assert(januaryDetail && marchDetail, '各月の明細が含まれる');
+  assert.strictEqual(januaryDetail.rows.some(row => row.label === '前月繰越'), false, '過去月の繰越は表示しない');
+  const carryOverRow = marchDetail.rows.find(row => row.label === '前月繰越');
+  assert(carryOverRow, '代表月には繰越行を表示する');
+  assert.strictEqual(carryOverRow.amount, 50, '代表月の繰越額を表示する');
+}
+
+function testAggregateInvoiceTemplateSummarizesWhenManyMonths() {
+  const patientId = 'patient-2';
+  const entriesByMonth = {
+    '202501': { billingMonth: '202501', patientId, visitCount: 1, burdenRate: 1, insuranceType: '鍼灸', carryOverAmount: 200 },
+    '202502': { billingMonth: '202502', patientId, visitCount: 1, burdenRate: 1, insuranceType: '鍼灸', carryOverAmount: 0 },
+    '202503': { billingMonth: '202503', patientId, visitCount: 1, burdenRate: 1, insuranceType: '鍼灸', carryOverAmount: 0 },
+    '202504': { billingMonth: '202504', patientId, visitCount: 1, burdenRate: 1, insuranceType: '鍼灸', carryOverAmount: 0 }
+  };
+
+  const aggregateContext = createContext({
+    billingNormalizePatientId_: (value) => value,
+    normalizePreparedBilling_: (value) => value,
+    loadPreparedBillingWithSheetFallback_: (monthKey) => ({
+      billingMonth: monthKey,
+      billingJson: entriesByMonth[monthKey] ? [entriesByMonth[monthKey]] : []
+    })
+  });
+  const { buildAggregateInvoiceTemplateData_ } = aggregateContext;
+
+  const data = buildAggregateInvoiceTemplateData_(entriesByMonth['202504'], ['202501', '202502', '202503', '202504']);
+
+  assert.strictEqual(data.aggregateInvoiceDetails.length, 4, '全ての合算月の明細が収集される');
+  assert.strictEqual(data.aggregateSummaryRows.length, 4, '簡略内訳に月別行が含まれる');
+  const januaryDetail = data.aggregateInvoiceDetails.find(detail => detail.month === '202501');
+  const januarySummary = data.aggregateSummaryRows.find(row => row.month === '202501');
+  assert(januaryDetail && januarySummary, '1月分のデータが存在する');
+  assert.strictEqual(
+    januarySummary.subtotal,
+    januaryDetail.treatmentAmount + januaryDetail.transportAmount,
+    '簡略内訳では繰越を含めずに小計を計算する'
+  );
+  assert.strictEqual(januaryDetail.grandTotal, januarySummary.subtotal, '過去月の繰越を金額に加算しない');
+  assert.strictEqual(
+    data.representativeInvoiceDetail.rows.some(row => row.label === '前月繰越'),
+    true,
+    '代表月の詳細明細には繰越を表示する'
+  );
+}
+
+function testAggregateInvoiceRepresentativeMonthMatchesBillingMonth() {
+  const patientId = 'patient-3';
+  const entriesByMonth = {
+    '202501': { billingMonth: '202501', patientId, visitCount: 1, burdenRate: 1, insuranceType: '鍼灸', carryOverAmount: 0 },
+    '202502': { billingMonth: '202502', patientId, visitCount: 2, burdenRate: 1, insuranceType: '鍼灸', carryOverAmount: 150 },
+    '202503': { billingMonth: '202503', patientId, visitCount: 1, burdenRate: 1, insuranceType: '鍼灸', carryOverAmount: 300 }
+  };
+
+  const aggregateContext = createContext({
+    billingNormalizePatientId_: (value) => value,
+    normalizePreparedBilling_: (value) => value,
+    loadPreparedBillingWithSheetFallback_: (monthKey) => ({
+      billingMonth: monthKey,
+      billingJson: entriesByMonth[monthKey] ? [entriesByMonth[monthKey]] : []
+    })
+  });
+  const { buildAggregateInvoiceTemplateData_ } = aggregateContext;
+
+  const data = buildAggregateInvoiceTemplateData_(entriesByMonth['202502'], ['202503', '202501', '202502']);
+
+  assert.strictEqual(data.representativeInvoiceDetail.month, '202502', '代表月は billingMonth を優先する');
+  const februaryDetail = data.aggregateInvoiceDetails.find(detail => detail.month === '202502');
+  const marchDetail = data.aggregateInvoiceDetails.find(detail => detail.month === '202503');
+  const carryOverRow = februaryDetail.rows.find(row => row.label === '前月繰越');
+  assert(carryOverRow, 'billingMonth の月には繰越を表示する');
+  assert.strictEqual(carryOverRow.amount, 150, 'billingMonth の繰越額を表示する');
+  assert.strictEqual(marchDetail.rows.some(row => row.label === '前月繰越'), false, 'billingMonth 以外では繰越を表示しない');
+}
+
+function testAggregateInvoiceFallsBackToLatestMonthWhenBillingMonthAbsent() {
+  const patientId = 'patient-4';
+  const entriesByMonth = {
+    '202501': { billingMonth: '202501', patientId, visitCount: 1, burdenRate: 1, insuranceType: '鍼灸', carryOverAmount: 400 },
+    '202502': { billingMonth: '202502', patientId, visitCount: 2, burdenRate: 1, insuranceType: '鍼灸', carryOverAmount: 0 },
+    '202503': { billingMonth: '202503', patientId, visitCount: 3, burdenRate: 1, insuranceType: '鍼灸', carryOverAmount: 0 }
+  };
+
+  const aggregateContext = createContext({
+    billingNormalizePatientId_: (value) => value,
+    normalizePreparedBilling_: (value) => value,
+    loadPreparedBillingWithSheetFallback_: (monthKey) => ({
+      billingMonth: monthKey,
+      billingJson: entriesByMonth[monthKey] ? [entriesByMonth[monthKey]] : []
+    })
+  });
+  const { buildAggregateInvoiceTemplateData_ } = aggregateContext;
+
+  const data = buildAggregateInvoiceTemplateData_(
+    Object.assign({}, entriesByMonth['202501'], { billingMonth: '202412' }),
+    ['202501', '202502', '202503']
+  );
+
+  assert.strictEqual(data.representativeInvoiceDetail.month, '202503', 'billingMonth が含まれない場合は最新月を代表月とする');
+  const januaryDetail = data.aggregateInvoiceDetails.find(detail => detail.month === '202501');
+  const marchDetail = data.aggregateInvoiceDetails.find(detail => detail.month === '202503');
+  assert(januaryDetail && marchDetail, '各月の明細が存在する');
+  assert.strictEqual(januaryDetail.rows.some(row => row.label === '前月繰越'), false, '代表月以外では繰越を表示しない');
+  const carryOverRow = marchDetail.rows.find(row => row.label === '前月繰越');
+  assert(carryOverRow, '代表月には繰越行が含まれる');
+  assert.strictEqual(carryOverRow.amount, 0, '代表月の繰越額は対象月の値を用いる');
+}
+
 function run() {
   testInvoiceChargeBreakdown();
   testInvoiceChargeBreakdownUsesCustomTransportPrice();
@@ -129,6 +266,10 @@ function run() {
   testInvoiceHtmlEscapesUserInput();
   testInvoiceTemplateRecalculatesSelfPaidBreakdown();
   testInvoiceTemplateAddsReceiptDecision();
+  testAggregateInvoiceTemplateStacksPerMonth();
+  testAggregateInvoiceTemplateSummarizesWhenManyMonths();
+  testAggregateInvoiceRepresentativeMonthMatchesBillingMonth();
+  testAggregateInvoiceFallsBackToLatestMonthWhenBillingMonthAbsent();
   console.log('billingInvoiceLayout tests passed');
 }
 


### PR DESCRIPTION
## Summary
- pick the representative aggregate invoice month by billingMonth when present or otherwise the latest aggregated month and propagate that through detail building
- keep carryover suppressed on non-representative months and resolve the representative detail consistently in the invoice template
- add regression coverage for aggregates where billingMonth is outside the target months

## Testing
- node tests/billingInvoiceLayout.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a90778cfc83258f5401c79f21d0bd)