### PR TITLE
Generate aggregate-only receipts for month after aggregate invoices

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -321,9 +321,10 @@ function resolveInvoiceReceiptDisplay_(item) {
   const hasPreviousReceiptSheet = resolveHasPreviousReceiptSheet_(item);
   const fallbackMonth = resolvePreviousBillingMonthKey_(item && item.billingMonth);
   const receiptMonths = normalizeReceiptMonths_(item && item.receiptMonths, fallbackMonth);
-  const receiptRemark = receiptMonths.length > 1
+  const customReceiptRemark = item && item.receiptRemark ? String(item.receiptRemark) : '';
+  const receiptRemark = customReceiptRemark || (receiptMonths.length > 1
     ? formatAggregatedReceiptRemark_(receiptMonths)
-    : '';
+    : '');
   const receiptStatus = item && item.receiptStatus ? String(item.receiptStatus).toUpperCase() : '';
   const bankFlags = item && item.bankFlags;
   const unpaidFlag = bankFlags && (bankFlags.ae || bankFlags.AE);


### PR DESCRIPTION
### Motivation

- Automatically issue a single aggregate receipt in the month after an aggregate invoice when previous-month bank flag `af` is set. 
- Ensure the receipt covers the same continuous aggregate months used by the aggregate invoice and is issued once per aggregate group. 
- Calculate aggregate receipt totals using only `treatmentAmount` (ignore transport and carry-over values). 
- Suppress the normal previous-month receipt when an aggregate receipt is issued.

### Description

- Added helper functions to `src/main.gs`: `resolveTreatmentAmountForEntry_`, `resolveTreatmentAmountForMonthAndPatient_`, `formatAggregateReceiptDescription_`, `formatAggregateReceiptMonthLabel_`, and `resolveAggregateReceiptForEntry_` to compute treatment-only totals and aggregate month groups. 
- Updated `attachPreviousReceiptAmounts_` in `src/main.gs` to detect previous-month `af` flags, build the aggregate receipt breakdown, set `previousReceipt` metadata (`addressee: '株式会社べるつりー'` and `note`), populate `receiptMonths` and `receiptRemark`, and replace the normal previous-month receipt when an aggregate receipt is present. 
- Modified `src/output/billingOutput.js` to allow a custom `receiptRemark` (from prepared data) to override the default aggregated remark used in the invoice output. 
- Amount computation for aggregate receipts sums only per-month `treatmentAmount` (via the new helpers) and intentionally ignores transport, `carryOver`, and historical carry-overs, conforming to the receipt rules.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cc629597c83258ff75f6a420a3f43)