### PR TITLE
Enable patient ID textarea for partial invoice when PDF month is selected

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -219,7 +219,7 @@ function isReceiptEditingLocked() {
 
 function updateInvoiceModeControls() {
   const loading = billingState.loading;
-  const prepared = !!(billingState.prepared && billingState.prepared.billingMonth);
+  const hasPdfTarget = !!getSelectedPreparedMonth();
   const mode = getInvoiceMode();
   const patientInput = qs('invoicePatientIds');
   const note = qs('invoicePatientIdsNote');
@@ -234,7 +234,7 @@ function updateInvoiceModeControls() {
   });
 
   if (patientInput) {
-    patientInput.disabled = loading || !prepared || !isPartial;
+    patientInput.disabled = loading || !hasPdfTarget || !isPartial;
     if (!isPartial && !loading) {
       patientInput.value = billingState.invoicePatientIdsInput || patientInput.value;
     }


### PR DESCRIPTION
### Motivation
- Fix a bug where the patient ID textarea (`#invoicePatientIds`) remained disabled when selecting “個別再発行（患者ID指定）”.
- The control previously required freshly prepared billing data instead of merely a selected PDF target month.
- Allow users to enter patient IDs for partial PDF reissues once a PDF month is selected.

### Description
- Update `updateInvoiceModeControls` in `src/main.js.html` to compute `hasPdfTarget` via `getSelectedPreparedMonth()` instead of checking `billingState.prepared`.
- Change the textarea disabling logic to `patientInput.disabled = loading || !hasPdfTarget || !isPartial;` so the field is enabled when a PDF month is selected and partial mode is active.
- Preserve existing loading and radio-button behavior; no other UI changes were made.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e194eb7fc8325a72179b3ebe4efd4)