### PR TITLE
Guard billing sheet access without SpreadsheetApp

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -1278,7 +1278,8 @@ function resolveBillingHistoryColumns_(sheet) {
 
 function ensureBillingHistorySheet_() {
   const SHEET_NAME = '請求履歴';
-  const workbook = ss();
+  const workbook = billingSs();
+  if (!workbook) return null;
   let sheet = workbook.getSheetByName(SHEET_NAME);
   if (!sheet) {
     sheet = workbook.insertSheet(SHEET_NAME);
@@ -1289,7 +1290,8 @@ function ensureBillingHistorySheet_() {
 }
 
 function ensureUnpaidHistorySheet_() {
-  const workbook = ss();
+  const workbook = billingSs();
+  if (!workbook) return null;
   let sheet = workbook.getSheetByName(UNPAID_HISTORY_SHEET_NAME);
   if (!sheet) {
     sheet = workbook.insertSheet(UNPAID_HISTORY_SHEET_NAME);
@@ -1307,6 +1309,9 @@ function ensureUnpaidHistorySheet_() {
 
 function appendUnpaidHistoryEntries_(entries) {
   const sheet = ensureUnpaidHistorySheet_();
+  if (!sheet) {
+    return { added: 0, skipped: entries && entries.length ? entries.length : 0 };
+  }
   const lastRow = sheet.getLastRow();
   const existing = lastRow >= 2
     ? sheet.getRange(2, 1, lastRow - 1, 6).getValues()
@@ -1351,6 +1356,7 @@ function appendUnpaidHistoryEntries_(entries) {
 function appendBillingHistoryRows(billingJson, options) {
   const opts = options || {};
   const ensured = ensureBillingHistorySheet_();
+  if (!ensured) return { billingMonth: opts.billingMonth || '', inserted: 0 };
   const sheet = ensured.sheet;
   const columns = ensured.columns;
   const headers = ensured.headers;
@@ -1452,6 +1458,7 @@ function appendBillingHistoryRows(billingJson, options) {
 
 function applyPaymentResultsToHistory(billingMonth, bankStatuses) {
   const ensured = ensureBillingHistorySheet_();
+  if (!ensured) return { billingMonth, updated: 0 };
   const sheet = ensured.sheet;
   const columns = ensured.columns;
   const headers = ensured.headers;


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when `SpreadsheetApp` is unavailable so billing code can run in non-GAS/DoGet/HTML test environments.
- Separate responsibilities so billing-specific flows use the billing-targeted workbook resolver instead of the global `ss()` helper.
- Avoid unbounded loops when backtracking months for aggregate lookups.
- Preserve existing billing calculations and payload formats while making sheet access non-fatal.

### Description
- Replace direct `ss()` usage with `billingSs()` in billing-related code paths in `src/main.gs` and `src/output/billingOutput.js`, and return safely when no workbook is available. 
- Add null guards to prepared-billing helpers (`ensurePreparedBillingMetaSheet_`, `ensurePreparedBillingMetaJsonSheet_`, `ensurePreparedBillingJsonSheet_`, `savePreparedBillingJsonRows_`, `savePreparedBillingMeta_`, `getPreparedBillingMonths`, and `loadPreparedBillingFromSheet_`) so calls become no-ops or return safe defaults when sheets cannot be accessed.
- Add a fallback in `getPreparedBillingForMonthCached_` to call `loadPreparedBillingWithSheetFallback_` when a sheet-based summary is missing, and populate `totalsByPatient` from `billingJson` in `reducePreparedBillingSummary_` when necessary. 
- Prevent unbounded backtracking by adding a `guard` counter to `collectAggregateBankFlagMonthsForPatient_` and make history/unpaid-history writers no-op when `billingSs()` is unavailable (`ensureBillingHistorySheet_`, `ensureUnpaidHistorySheet_`, `appendUnpaidHistoryEntries_`, `appendBillingHistoryRows`, `applyPaymentResultsToHistory`).

### Testing
- Ran the targeted unit test `node tests/aggregateBillingFromBankFlags.test.js`, and it passed.
- The aggregate-billing logic exercised the changes to confirm totals and aggregate-month behavior remained correct under the guarded code paths.
- No additional automated test suites were run as part of this change.
- Manual logging guards were left in place to aid investigation if sheet resolution fails in other environments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e375007ec8325b9cbf73db1c04f6d)