### PR TITLE
Use `grandTotal` for previous receipt amount in invoice output

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -362,7 +362,7 @@ function buildInvoicePreviousReceipt_(item, display) {
   const addressee = item && item.nameKanji ? String(item.nameKanji).trim() : '';
   const receiptMonths = receiptDisplay && receiptDisplay.receiptMonths ? receiptDisplay.receiptMonths : [];
   const date = formatReceiptSettlementDate_(receiptMonths, formatInvoiceDateLabel_());
-  const amount = normalizeInvoiceMoney_(item && item.previousReceiptAmount);
+  const amount = normalizeInvoiceMoney_(item && item.grandTotal);
   const note = receiptDisplay && receiptDisplay.receiptRemark ? receiptDisplay.receiptRemark : '';
   const breakdown = resolveReceiptMonthBreakdown_(item, receiptDisplay && receiptDisplay.receiptMonths);
 


### PR DESCRIPTION
### Motivation
- The previous receipt amount shown in invoice output was sourced from `previousReceiptAmount` (actual expense) which is incorrect for the receipt total. 
- The intent is to reference the invoice `grandTotal` when building the previous receipt, without changing surrounding logic. 

### Description
- Replace the normalized amount reference in `buildInvoicePreviousReceipt_` from `item.previousReceiptAmount` to `item.grandTotal`.
- The change is a single-line update in `src/output/billingOutput.js` to call `normalizeInvoiceMoney_(item && item.grandTotal)`.
- No other logic or output fields were modified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e3d3028208325980ba5d6da8c5329)