### PR TITLE
Only create bank info checkboxes for rows with patient ID

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -2054,12 +2054,10 @@ function ensureBankWithdrawalFlagColumns_(sheet, headers) {
       const hasValue_ = value => value !== '' && value !== null && value !== undefined && String(value).trim() !== '';
       const validRows = [];
 
-      if (pidCol && billingMonthCol && amountCol) {
+      if (pidCol) {
         values.forEach((row, index) => {
           const pid = row[pidCol - 1];
-          const billingMonth = row[billingMonthCol - 1];
-          const amount = Number(row[amountCol - 1]) || 0;
-          if (hasValue_(pid) && hasValue_(billingMonth) && amount !== 0) {
+          if (hasValue_(pid)) {
             validRows.push(index + 2);
           }
         });


### PR DESCRIPTION
### Motivation
- Prevent checkboxes from being added to empty rows in the bank information sheet where there is no patient present.  
- Previous logic required `billingMonth` and `amount` to be present which caused missing or extra checkbox behavior; this change simplifies the criteria.  

### Description
- Update `ensureBankWithdrawalFlagColumns_` to only consider `pidCol` when building `validRows` and to add rows to `validRows` only if `hasValue_(pid)` is true.  
- Remove the requirement that `billingMonth` and `amount` be present/non-zero when deciding which rows receive checkboxes.  
- Preserve existing behavior for creating checkbox segments and inserting checkboxes into `unpaidCol` and `aggregateCol`.  
- `enforceBankWithdrawalAggregateConstraint_` and the overall return shape `{ unpaidCol, aggregateCol }` remain unchanged.  

### Testing
- No automated tests were executed for this change.  
- The change was limited to checkbox creation logic in `ensureBankWithdrawalFlagColumns_` and committed after local inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e42fa08d08325b184a8173c593f03)