### PR TITLE
Optimize bank withdrawal checkbox targeting

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -1552,13 +1552,14 @@ function getBillingSourceData(billingMonth) {
       staffDirectorySize: Object.keys(staffDirectory || {}).length
     }));
     billingLogger_.log('[billing] CarryOverLedger status=' + JSON.stringify(carryOverLedgerMeta));
-    return {
+  return {
       billingMonth: month.key,
     month,
     treatmentVisitCounts,
     visitCounts: treatmentVisitCounts,
     patients: mergedPatients,
     patientMap: mergedPatients,
+    bankRecords,
     bankInfoByName: buildBankLookupByKanji_(bankRecords),
     bankStatuses: getBillingPaymentResultsIfExists_(month),
     staffByPatient: visitCountsResult.staffByPatient || {},


### PR DESCRIPTION
### Motivation
- Improve performance of bank withdrawal sheet checkbox setup by avoiding reading the whole sheet and instead targeting rows using patient IDs.  
- Reduce unnecessary `getValues` work and limit checkbox insertion to relevant contiguous segments.  
- Allow the checkbox setup to be driven by prepared billing payloads and bank record context to avoid scanning unrelated rows.  

### Description
- Update `ensureBankWithdrawalFlagColumns_` and `ensureUnpaidCheckColumn_` to accept an `options` object and use only the patient ID column (`pidCol`) via `getDisplayValues` to detect target rows.  
- Build a `Set` of target patient IDs from `billingJson` and `bankRecords` and filter rows before creating checkbox segments.  
- Thread `billingJson` and `bankRecords` through `ensureBankWithdrawalSheet_`, `syncBankWithdrawalSheetForMonth_`, and `confirmBankWithdrawalDataReady` so the sheet creation can use the prepared context.  
- Expose `bankRecords` in the billing source payload (`getBillingSourceData`) and include it in the prepared payload and normalization (`buildPreparedBillingPayload_` / `normalizePreparedBilling_`).  

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e43d2831c83259179b27e3ccf5de5)