### PR TITLE
Restore receiptStatus and aggregateUntilMonth in invoice generation payload

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -2861,6 +2861,8 @@ function generatePreparedInvoices_(prepared, options) {
   return {
     billingMonth: normalized.billingMonth,
     billingJson: receiptEnriched.billingJson,
+    receiptStatus: normalized.receiptStatus || '',
+    aggregateUntilMonth: normalized.aggregateUntilMonth || '',
     files: pdfs.files.concat(aggregateFiles),
     invoicePatientIds: targetPatientIds,
     missingInvoicePatientIds: missingPatientIds,


### PR DESCRIPTION
### Motivation
- The UI stopped showing aggregate receipts because `receiptStatus` and `aggregateUntilMonth` were missing from the prepared invoice payload returned after PDF generation.
- These fields are required by the frontend to determine and render aggregate/receipt badges for invoices.

### Description
- Added `receiptStatus` and `aggregateUntilMonth` to the object returned by `generatePreparedInvoices_` in `src/main.gs`.
- Values are sourced from the normalized prepared payload via `normalized.receiptStatus` and `normalized.aggregateUntilMonth` with safe empty-string fallbacks.
- This change restores the minimal receipt metadata required by the client without altering invoice generation logic or aggregate calculations.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e4816ea7c8325ab68335583a54135)