### PR TITLE
Generate aggregate summary PDFs for confirmed aggregate invoices

### DIFF
--- a/tests/aggregateBillingFromBankFlags.test.js
+++ b/tests/aggregateBillingFromBankFlags.test.js
@@ -148,4 +148,73 @@ function createContext(preparedByMonth) {
   assert.strictEqual(aggregateCalls[0].entry && aggregateCalls[0].entry.grandTotal, 9000);
 })();
 
+(function testAggregateSummaryPdfGeneratedForConfirmedEntries() {
+  const preparedByMonth = {
+    '202401': {
+      billingMonth: '202401',
+      billingJson: [{ patientId: 'P10', billingMonth: '202401', grandTotal: 1000 }],
+      bankFlagsByPatient: { P10: { af: true, ae: false } }
+    },
+    '202402': {
+      billingMonth: '202402',
+      billingJson: [{ patientId: 'P10', billingMonth: '202402', grandTotal: 2000 }],
+      bankFlagsByPatient: { P10: { af: false, ae: false } }
+    }
+  };
+
+  const aggregateCalls = [];
+  const ctx = {
+    console: { log: () => {}, warn: () => {} },
+    preparedByMonth,
+    CacheService: { getScriptCache: () => ({}) },
+    normalizeMoneyNumber_: value => Number(value) || 0,
+    billingLogger_: { log: () => {} },
+    normalizePreparedBilling_: payload => payload,
+    attachPreviousReceiptAmounts_: payload => payload,
+    normalizeBillingMonthKeySafe_: value => String(value || '').trim(),
+    billingNormalizePatientId_: pid => (pid ? String(pid).trim() : ''),
+    loadPreparedBillingWithSheetFallback_: monthKey => preparedByMonth[monthKey] || null,
+    exportBankTransferDataForPrepared_: () => null,
+    generateInvoicePdfs: () => ({ billingMonth: '202402', files: [], missingPatientIds: [] }),
+    generateAggregateInvoicePdf: (entry, opts) => {
+      aggregateCalls.push({ entry, opts });
+      return { fileId: 'agg', patientId: entry && entry.patientId, nameKanji: entry && entry.nameKanji };
+    }
+  };
+
+  ctx.normalizeBillingMonthInput = value => ({
+    key: String(value || ''),
+    year: Number(String(value || '').slice(0, 4)) || 2024,
+    month: Number(String(value || '').slice(4, 6)) || 1
+  });
+  ctx.resolvePreviousBillingMonthKey_ = billingMonth => {
+    const normalized = ctx.normalizeBillingMonthKeySafe_(billingMonth);
+    if (!normalized) return '';
+    const year = Number(normalized.slice(0, 4));
+    const month = Number(normalized.slice(4, 6));
+    const prevMonth = month === 1 ? 12 : month - 1;
+    const prevYear = month === 1 ? year - 1 : year;
+    return String(prevYear).padStart(4, '0') + String(prevMonth).padStart(2, '0');
+  };
+
+  vm.createContext(ctx);
+  vm.runInContext(mainCode, ctx);
+
+  ctx.loadPreparedBillingWithSheetFallback_ = monthKey => preparedByMonth[monthKey] || null;
+  ctx.attachPreviousReceiptAmounts_ = payload => payload;
+  ctx.exportBankTransferDataForPrepared_ = () => null;
+  ctx.generateInvoicePdfs = () => ({ billingMonth: '202402', files: [], missingPatientIds: [] });
+  ctx.generateAggregateInvoicePdf = (entry, opts) => {
+    aggregateCalls.push({ entry, opts });
+    return { fileId: 'agg', patientId: entry && entry.patientId, nameKanji: entry && entry.nameKanji };
+  };
+
+  const result = ctx.generatePreparedInvoices_(preparedByMonth['202402']);
+
+  assert.ok(result && Array.isArray(result.files), 'invoice generation returns files');
+  assert.strictEqual(aggregateCalls.length, 1, 'aggregate summary is generated for confirmed entries');
+  const aggregateMonths = aggregateCalls[0] && aggregateCalls[0].opts && aggregateCalls[0].opts.aggregateMonths;
+  assert.deepStrictEqual(Array.from(new Set(aggregateMonths)), ['202401', '202402']);
+})();
+
 console.log('aggregate billing from bank flags tests passed');


### PR DESCRIPTION
### Motivation
- Support generation of combined/summary PDFs for entries that have `aggregateStatus === 'confirmed'` so confirmed aggregate invoices are output as files.
- Reuse existing aggregate PDF generation logic to produce summary PDFs without duplicating rendering code.
- Ensure confirmed aggregate summaries are considered when matching requested invoice patient IDs.

### Description
- In `generatePreparedInvoices_` added collection of rows with `aggregateStatus === 'confirmed'` and generate aggregate summary PDFs using `generateAggregateInvoicePdf`.
- Build `aggregateSummaryFiles` from confirmed entries, normalize and deduplicate aggregate months via `normalizeAggregateInvoiceMonths_`, and include the generated metadata in the output files list.
- Include `aggregateSummaryFiles` in the matched patient ID set so confirmed aggregate summaries affect `missingInvoicePatientIds`.
- Changes applied in `src/main.gs` and a new test case added to `tests/aggregateBillingFromBankFlags.test.js` to cover confirmed-summary generation.

### Testing
- Ran the unit tests in `tests/aggregateBillingFromBankFlags.test.js` with `node`, which passed.
- Verified the existing scheduled-aggregate behavior still triggers `generateAggregateInvoicePdf` for `aggregateStatus === 'scheduled'` via the existing test.
- New test `testAggregateSummaryPdfGeneratedForConfirmedEntries` asserts confirmed entries produce one aggregate summary PDF and passed.
- Overall test suite output: `aggregate billing from bank flags tests passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f288531648325b43157e1f8c84dc3)