### PR TITLE
Simplify aggregate confirmed receipt breakdown display

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -101,7 +101,39 @@
         }
         var aggregateSummaryRows = Array.isArray(data.aggregateSummaryRows) ? data.aggregateSummaryRows : [];
       ?>
-      <? if (useStackedAggregate) { ?>
+      <? var isConfirmedAggregate = data.aggregateStatus === 'confirmed' && aggregateDetailCount > 0; ?>
+      <? var aggregateMonthTotals = Array.isArray(data.aggregateMonthTotals)
+        ? data.aggregateMonthTotals
+        : aggregateDetails.map(function(detail) {
+          return {
+            month: detail && detail.month,
+            monthLabel: detail && detail.monthLabel,
+            total: detail && detail.grandTotal
+          };
+        });
+      ?>
+      <? if (isConfirmedAggregate) { ?>
+        <div class="subsection-title">月別内訳</div>
+        <table class="subtable">
+          <thead>
+            <tr><th>年月</th><th class="amount">月合計金額</th></tr>
+          </thead>
+          <tbody>
+            <? aggregateMonthTotals.forEach(function(row) { ?>
+              <tr>
+                <td><?= row.monthLabel || normalizeBillingMonthLabel_(row.month) ?></td>
+                <td class="amount"><?= formatBillingCurrency_(row.total || 0) ?> 円</td>
+              </tr>
+            <? }); ?>
+          </tbody>
+          <tfoot>
+            <tr>
+              <td>合算請求額</td>
+              <td class="amount"><?= formatBillingCurrency_(data.grandTotal) ?> 円</td>
+            </tr>
+          </tfoot>
+        </table>
+      <? } else if (useStackedAggregate) { ?>
         <? aggregateDetails.forEach(function(detail) { ?>
           <div class="subsection-title"><?= detail.monthLabel || normalizeBillingMonthLabel_(detail.month) ?> ご請求</div>
           <table>

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -564,6 +564,11 @@ function buildAggregateInvoiceTemplateData_(item, aggregateMonths) {
     transportAmount: detail && detail.transportAmount,
     subtotal: detail ? (detail.treatmentAmount + detail.transportAmount) : 0
   }));
+  const aggregateMonthTotals = aggregateInvoiceDetails.map(detail => ({
+    month: detail && detail.month,
+    monthLabel: detail && detail.monthLabel,
+    total: detail && detail.grandTotal
+  }));
 
   return Object.assign({}, item, {
     monthLabel: aggregateLabel,
@@ -571,11 +576,13 @@ function buildAggregateInvoiceTemplateData_(item, aggregateMonths) {
     isAggregateInvoice: true,
     invoiceMode: 'aggregate',
     watermark,
+    aggregateStatus: item && item.aggregateStatus ? String(item.aggregateStatus) : '',
     receiptMonths: months,
     receiptRemark: aggregateRemark,
     aggregateRemark,
     aggregateInvoiceDetails,
     aggregateSummaryRows,
+    aggregateMonthTotals,
     representativeMonth: normalizedRepresentativeMonth,
     representativeInvoiceDetail,
     showReceipt: false,


### PR DESCRIPTION
### Motivation
- For entries with `aggregateStatus === 'confirmed'` the receipt PDF should show only a per-month summary (年月 + 月合計金額) and not the itemized rows like 施術料/交通費/回数, matching the aggregate billing UX requirement.
- The receipt total must always display the consolidated `grandTotal` value on the aggregate PDF footer.
- Provide a stable data shape to the template so the template can decide when to render the simplified table versus detailed rows.

### Description
- Add `aggregateMonthTotals` and `aggregateStatus` to the aggregate template payload in `buildAggregateInvoiceTemplateData_` (file `src/output/billingOutput.js`).
- Populate `aggregateMonthTotals` from `aggregateInvoiceDetails` (month + `grandTotal`) so the template has month-level totals available.
- Update `src/invoice_template.html` to render a simplified month-total table when `data.aggregateStatus === 'confirmed'` and `aggregateDetailCount > 0`, instead of itemized per-item rows, and use `data.grandTotal` for the final amount.
- Keep existing behavior for other aggregate display modes (stacked per-month details or aggregate summary) when not a confirmed aggregate.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f360cf2048325b7633d8bb8fdbe30)