### PR TITLE
Unify receipt amount logic and simplify aggregate invoice rendering

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -74,45 +74,18 @@
         <div><?= data.nameKanji ?></div>
         <div class="label">保険区分</div>
         <div><?= data.insuranceType || '―' ?> / <?= data.burdenRate ? data.burdenRate + '割' : '―' ?></div>
-        <div class="label">対象期間</div>
-        <div><?= chargeMonthLabel || '―' ?></div>
-      </div>
-    </section>
+      <div class="label">対象期間</div>
+      <div><?= chargeMonthLabel || '―' ?></div>
+    </div>
+  </section>
 
-    <section class="card">
-      <h3 class="section-title">ご請求内容（<?= isAggregateInvoice ? '未回収合算' : '当月' ?>）</h3>
-      <?
-        var aggregateDetails = isAggregateInvoice && Array.isArray(data.aggregateInvoiceDetails)
-          ? data.aggregateInvoiceDetails
-          : [];
-        var aggregateDetailCount = aggregateDetails.length;
-        var useStackedAggregate = isAggregateInvoice && aggregateDetailCount > 0 && aggregateDetailCount <= 3;
-        var useAggregateSummary = isAggregateInvoice && aggregateDetailCount >= 4;
-        var normalizedBillingMonth = normalizeInvoiceMonthKey_(data.billingMonth || '');
-        var normalizedRepresentativeMonth = normalizeInvoiceMonthKey_(data.representativeMonth || normalizedBillingMonth);
-        var representativeDetail = data.representativeInvoiceDetail || null;
-        if (!representativeDetail && normalizedRepresentativeMonth) {
-          representativeDetail = aggregateDetails.find(function(detail) {
-            return normalizeInvoiceMonthKey_(detail && detail.month) === normalizedRepresentativeMonth;
-          });
-        }
-        if (!representativeDetail && aggregateDetailCount) {
-          representativeDetail = aggregateDetails[aggregateDetailCount - 1];
-        }
-        var aggregateSummaryRows = Array.isArray(data.aggregateSummaryRows) ? data.aggregateSummaryRows : [];
-      ?>
-      <? var isConfirmedAggregate = data.aggregateStatus === 'confirmed' && aggregateDetailCount > 0; ?>
+  <section class="card">
+    <h3 class="section-title">ご請求内容（<?= isAggregateInvoice ? '未回収合算' : '当月' ?>）</h3>
       <? var aggregateMonthTotals = Array.isArray(data.aggregateMonthTotals)
         ? data.aggregateMonthTotals
-        : aggregateDetails.map(function(detail) {
-          return {
-            month: detail && detail.month,
-            monthLabel: detail && detail.monthLabel,
-            total: detail && detail.grandTotal
-          };
-        });
+        : [];
       ?>
-      <? if (isConfirmedAggregate) { ?>
+      <? if (isAggregateInvoice) { ?>
         <div class="subsection-title">月別内訳</div>
         <table class="subtable">
           <thead>
@@ -130,75 +103,6 @@
             <tr>
               <td>合算請求額</td>
               <td class="amount"><?= formatBillingCurrency_(data.grandTotal) ?> 円</td>
-            </tr>
-          </tfoot>
-        </table>
-      <? } else if (useStackedAggregate) { ?>
-        <? aggregateDetails.forEach(function(detail) { ?>
-          <div class="subsection-title"><?= detail.monthLabel || normalizeBillingMonthLabel_(detail.month) ?> ご請求</div>
-          <table>
-            <thead>
-              <tr><th>項目</th><th>詳細</th><th class="amount">金額</th></tr>
-            </thead>
-            <tbody>
-              <? detail.rows.forEach(function(row) { ?>
-                <tr>
-                  <td><?= row.label ?></td>
-                  <td><?= row.detail || '' ?></td>
-                  <td class="amount"><?= formatBillingCurrency_(row.amount) ?> 円</td>
-                </tr>
-              <? }); ?>
-            </tbody>
-            <tfoot>
-              <tr>
-                <td colspan="2">合計</td>
-                <td class="amount"><?= formatBillingCurrency_(detail.grandTotal) ?> 円</td>
-              </tr>
-            </tfoot>
-          </table>
-        <? }); ?>
-        <div class="note"><strong>合算請求額:</strong> <?= formatBillingCurrency_(data.grandTotal) ?> 円</div>
-      <? } else if (useAggregateSummary && representativeDetail) { ?>
-        <div class="subsection-title">月別簡易内訳</div>
-        <table class="subtable">
-          <thead>
-            <tr><th>月</th><th class="amount">施術料</th><th class="amount">交通費</th><th class="amount">小計</th></tr>
-          </thead>
-          <tbody>
-            <? aggregateSummaryRows.forEach(function(row) { ?>
-              <tr>
-                <td><?= row.monthLabel || normalizeBillingMonthLabel_(row.month) ?></td>
-                <td class="amount"><?= formatBillingCurrency_(row.treatmentAmount || 0) ?> 円</td>
-                <td class="amount"><?= formatBillingCurrency_(row.transportAmount || 0) ?> 円</td>
-                <td class="amount"><?= formatBillingCurrency_(row.subtotal || 0) ?> 円</td>
-              </tr>
-            <? }); ?>
-          </tbody>
-          <tfoot>
-            <tr>
-              <td colspan="3">合算請求額</td>
-              <td class="amount"><?= formatBillingCurrency_(data.grandTotal) ?> 円</td>
-            </tr>
-          </tfoot>
-        </table>
-        <div class="subsection-title">詳細内訳（<?= representativeDetail.monthLabel || normalizeBillingMonthLabel_(representativeDetail.month) ?>）</div>
-        <table>
-          <thead>
-            <tr><th>項目</th><th>詳細</th><th class="amount">金額</th></tr>
-          </thead>
-          <tbody>
-            <? representativeDetail.rows.forEach(function(row) { ?>
-              <tr>
-                <td><?= row.label ?></td>
-                <td><?= row.detail || '' ?></td>
-                <td class="amount"><?= formatBillingCurrency_(row.amount) ?> 円</td>
-              </tr>
-            <? }); ?>
-          </tbody>
-          <tfoot>
-            <tr>
-              <td colspan="2">合計</td>
-              <td class="amount"><?= formatBillingCurrency_(representativeDetail.grandTotal) ?> 円</td>
             </tr>
           </tfoot>
         </table>
@@ -240,9 +144,6 @@
     <? var receiptDate = receipt.date || receipt.receiptDate || ''; ?>
     <? var receiptAmount = receipt.amount != null ? receipt.amount : receipt.total != null ? receipt.total : receipt.price; ?>
     <? var receiptNote = receipt.note || receipt.description || ''; ?>
-    <? var receiptBreakdown = receipt.breakdown || []; ?>
-    <? var hasReceiptBreakdown = Array.isArray(receiptBreakdown) && receiptBreakdown.length > 0; ?>
-
     <? if (!data.forceHideReceipt) { ?>
       <section class="card">
         <h3 class="section-title">前月分領収書</h3>
@@ -259,22 +160,6 @@
           <div class="label">発行者</div>
           <div>株式会社べるつりー</div>
         </div>
-        <? if (hasReceiptBreakdown) { ?>
-          <div class="note">未回収期間の内訳</div>
-          <table class="subtable">
-            <thead>
-              <tr><th>年月</th><th class="amount">金額</th></tr>
-            </thead>
-            <tbody>
-              <? receiptBreakdown.forEach(function(entry) { ?>
-                <tr>
-                  <td><?= normalizeBillingMonthLabel_(entry.month) || entry.month || '―' ?></td>
-                  <td class="amount"><?= formatBillingCurrency_(entry.amount || 0) ?> 円</td>
-                </tr>
-              <? }); ?>
-            </tbody>
-          </table>
-        <? } ?>
       <? } else { ?>
           <div class="note">前月分は未入金のため、後日合算して請求されます</div>
         <? } ?>

--- a/src/main.gs
+++ b/src/main.gs
@@ -2846,37 +2846,9 @@ function generatePreparedInvoices_(prepared, options) {
     const meta = generateAggregateInvoicePdf(aggregateEntry, { aggregateMonths: uniqueAggregateMonths, billingMonth: normalized.billingMonth });
     return Object.assign({}, meta, { patientId: aggregateEntry.patientId, nameKanji: aggregateEntry.nameKanji });
   }).filter(Boolean);
-  const aggregateSummaryTargets = (receiptEnriched.billingJson || []).filter(row => row && row.aggregateStatus === 'confirmed');
-  const aggregateSummaryFiles = aggregateSummaryTargets.map(entry => {
-    const pid = billingNormalizePatientId_(entry && entry.patientId);
-    if (!pid) return null;
-
-    const baseEntry = (normalized.billingJson || []).find(row => billingNormalizePatientId_(row && row.patientId) === pid) || entry;
-    let aggregateMonths = []
-      .concat(entry && entry.aggregateTargetMonths ? entry.aggregateTargetMonths : [])
-      .concat(entry && entry.receiptMonths ? entry.receiptMonths : [])
-      .concat(baseEntry && baseEntry.aggregateTargetMonths ? baseEntry.aggregateTargetMonths : [])
-      .concat(baseEntry && baseEntry.receiptMonths ? baseEntry.receiptMonths : []);
-    if (!aggregateMonths.length) {
-      const aggregateUntilMonth = normalizeBillingMonthKeySafe_(baseEntry.aggregateUntilMonth || normalized.aggregateUntilMonth);
-      const aggregateSourceMonths = collectAggregateBankFlagMonthsForPatient_(normalized.billingMonth, pid, aggregateUntilMonth, monthCache);
-      aggregateMonths = aggregateSourceMonths.concat([normalized.billingMonth]);
-    }
-    const normalizedAggregateMonths = normalizeAggregateInvoiceMonths_(aggregateMonths, normalized, normalized.billingMonth);
-    const uniqueAggregateMonths = Array.from(new Set(normalizedAggregateMonths));
-    const aggregateEntry = Object.assign({}, baseEntry, entry, {
-      billingMonth: normalized.billingMonth,
-      receiptMonths: uniqueAggregateMonths,
-      aggregateTargetMonths: uniqueAggregateMonths
-    });
-
-    const meta = generateAggregateInvoicePdf(aggregateEntry, { aggregateMonths: uniqueAggregateMonths, billingMonth: normalized.billingMonth });
-    return Object.assign({}, meta, { patientId: aggregateEntry.patientId, nameKanji: aggregateEntry.nameKanji });
-  }).filter(Boolean);
   const matchedIds = new Set(
     targetBillingRows
       .concat(aggregateFiles.map(file => ({ patientId: file && file.patientId })))
-      .concat(aggregateSummaryFiles.map(file => ({ patientId: file && file.patientId })))
       .map(row => String(row && row.patientId ? row.patientId : '').trim())
       .filter(Boolean)
   );
@@ -2891,7 +2863,7 @@ function generatePreparedInvoices_(prepared, options) {
     billingJson: receiptEnriched.billingJson,
     receiptStatus: normalized.receiptStatus || '',
     aggregateUntilMonth: normalized.aggregateUntilMonth || '',
-    files: pdfs.files.concat(aggregateFiles, aggregateSummaryFiles),
+    files: pdfs.files.concat(aggregateFiles),
     invoicePatientIds: targetPatientIds,
     missingInvoicePatientIds: missingPatientIds,
     invoiceGenerationMode: targetPatientIds.length ? 'partial' : 'bulk',


### PR DESCRIPTION
### Motivation
- Finalize aggregate invoice behavior so `invoice_template.html` shows only month-by-month totals and remove aggregate summary/detail/breakdown UI.
- Make receipt amount selection unambiguous by using `grandTotal` for aggregated receipts and `previousReceiptAmount` for single-month receipts.
- Normalize receipt visibility so confirmed aggregates always show receipts when `aggregateStatus` is `confirmed`.
- Reduce fragile per-template overrides and duplicate summary file generation by consolidating receipt/template data flow.

### Description
- Updated `invoice_template.html` to remove aggregate detail/summary branches and to render only `aggregateMonthTotals` and the unified receipt block.
- Changed `buildInvoicePreviousReceipt_` to choose the receipt amount based on `receiptMonths` count (aggregate → `grandTotal`, single → `previousReceiptAmount`).
- Modified `resolveInvoiceReceiptDisplay_` to normalize `aggregateStatus` and force receipt display for confirmed aggregates, and removed reliance on separate receipt breakdowns.
- Simplified `buildAggregateInvoiceTemplateData_` and `buildInvoiceTemplateData_` to compute `aggregateMonthTotals` using `resolveBillingAmountForMonthAndPatient_`, reuse `buildInvoicePreviousReceipt_`, and removed generation/inclusion of separate aggregate summary files in `generatePreparedInvoices_`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f3dca597c832587badc73e596984f)