### PR TITLE
Reuse prepared billing for already-prepared months

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -2726,6 +2726,16 @@ function serializeBillingPayload_(payload) {
 
 function prepareBillingData(billingMonth) {
   const normalizedMonth = normalizeBillingMonthInput(billingMonth);
+  const existingResult = loadPreparedBillingWithSheetFallback_(normalizedMonth.key, { withValidation: true });
+  const existingPrepared = existingResult && existingResult.prepared !== undefined ? existingResult.prepared : existingResult;
+  const existingValidation = existingResult && existingResult.validation
+    ? existingResult.validation
+    : (existingResult && existingResult.ok !== undefined ? existingResult : null);
+  if (existingPrepared && (!existingValidation || existingValidation.ok)) {
+    billingLogger_.log('[billing] prepareBillingData using existing prepared billing for ' + normalizedMonth.key);
+    return existingPrepared;
+  }
+
   const prepared = buildPreparedBillingPayload_(normalizedMonth);
   const normalizedPrepared = normalizePreparedBilling_(prepared);
   const clientPayload = toClientBillingPayload_(normalizedPrepared, { alreadyNormalized: true });


### PR DESCRIPTION
### Motivation
- Avoid re-aggregating billing data for a month when a previously saved `PreparedBilling` exists for that `billingMonth`.
- Preserve existing saved payloads for durability and performance while still aggregating months that are not yet prepared.
- Keep the current save/schema/workflow unchanged (no UI, history, diffing, or refactor work).
- Reduce unnecessary compute and ensure consistent responses when prepared data is available.

### Description
- In `prepareBillingData` call `loadPreparedBillingWithSheetFallback_(normalizedMonth.key, { withValidation: true })` and use the returned prepared payload when present and valid.
- Return early from `prepareBillingData` with the cached sheet/cache payload to avoid running `buildPreparedBillingPayload_` for already-prepared months.
- Add a log line via `billingLogger_.log` to indicate when existing prepared billing is reused for a month.
- Leave the downstream aggregation and save flow (`buildPreparedBillingPayload_`, `savePreparedBilling_`, `savePreparedBillingToSheet_`) intact for months that are not already prepared.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fb16028748325a9271bf561c41691)