### PR TITLE
Add reset workflow for prepared billing reaggregation

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -121,6 +121,7 @@
           <input type="month" id="billingMonth" />
         </label>
         <button class="btn" id="billingAggregateBtn" type="button" onclick="handleBillingAggregation()">請求データを集計</button>
+        <button class="btn danger small" id="billingReaggregateBtn" type="button" onclick="handleBillingReaggregation()">請求データを初期化して再集計</button>
         <button class="btn secondary" id="billingSaveBtn" type="button" onclick="handleBillingSaveEdits()">変更を保存</button>
         <label>PDF対象月
           <select id="billingPdfMonth" class="billing-prepared-month-select"></select>
@@ -130,6 +131,7 @@
           <div id="billingStatus" class="status-line" style="flex:1"></div>
           <div id="carryOverLedgerStatus" class="pill neutral" style="display:none"></div>
         </div>
+        <p class="field-note warn" style="margin-top:0">※ 「初期化して再集計」は指定月の既存請求データをキャッシュ・シートともに削除します。誤操作にご注意ください。</p>
         <p class="finalized-lock-note" id="finalizedLockNote" style="display:none"></p>
         <div id="billingError" class="alert danger" style="display:none"></div>
       </div>

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -151,6 +151,13 @@ function updateBillingControls() {
     aggregateBtn.setAttribute('aria-busy', loading ? 'true' : 'false');
     aggregateBtn.title = disabled && finalizedLocked ? '確定済みの請求が含まれているため再集計できません' : '';
   }
+  const reaggregateBtn = qs('billingReaggregateBtn');
+  if (reaggregateBtn) {
+    const disabled = loading || finalizedLocked;
+    reaggregateBtn.disabled = disabled;
+    reaggregateBtn.setAttribute('aria-busy', loading ? 'true' : 'false');
+    reaggregateBtn.title = disabled && finalizedLocked ? '確定済みの請求が含まれているため再集計できません' : '指定月の既存請求データを削除して再集計します';
+  }
   if (pdfBtn) {
     const disabled = loading || !hasPdfTarget || finalizedLocked;
     pdfBtn.disabled = disabled;
@@ -1627,6 +1634,29 @@ function handleBillingAggregation() {
       onBillingFailed(err);
     })
     .prepareBillingData(ym);
+}
+
+function handleBillingReaggregation() {
+  if (shouldBlockFinalizedBillingOperation()) return;
+  const ym = normalizeYm(qs('billingMonth').value);
+  if (!ym) {
+    alert('請求月を入力してください (YYYY-MM)');
+    return;
+  }
+  const confirmed = confirm('指定した月の既存請求データ（キャッシュ・スプレッドシート）を削除して再集計します。本当に実行しますか？');
+  if (!confirmed) return;
+  logBillingState('handleBillingReaggregation:start', { ym });
+  setBillingLoading(true, '再集計中…');
+  google.script.run
+    .withSuccessHandler(function(result) {
+      logBillingState('resetPreparedBillingAndPrepare:success', { ym });
+      onBillingPrepared(result);
+    })
+    .withFailureHandler(function(err) {
+      logBillingState('resetPreparedBillingAndPrepare:error', { ym, error: err && err.message ? err.message : err });
+      onBillingFailed(err);
+    })
+    .resetPreparedBillingAndPrepare(ym);
 }
 
 function onBillingPrepared(result) {


### PR DESCRIPTION
## Summary
- add Apps Script helpers to purge prepared billing cache and sheet rows for a month and rerun preparation
- expose a UI control with clear warning to trigger the destructive reaggregation flow
- expand prepared billing tests to cover reset/delete behavior and normalize cross-realm comparisons

## Testing
- node tests/preparedBillingCache.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69528776ad888321a6b54c3fab51adb9)