### PR TITLE
Ensure invoice header uses billing month

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -128,7 +128,7 @@
           </tfoot>
         </table>
       <? } ?>
-      <div class="note"><?= isAggregateInvoice ? '未回収期間を含めた合計金額です。' : '前月繰越を含む合計金額です。' ?>口座振替日：毎月20日（祝日の場合は翌営業日）</div>
+      <div class="note"><?= isAggregateInvoice ? '未回収期間を含めた合計金額です。（前月未回収分を含む）' : '前月繰越を含む合計金額です。' ?>口座振替日：毎月20日（祝日の場合は翌営業日）</div>
       <? if (data.aggregateRemark) { ?>
         <div class="note"><strong>備考:</strong> <?= data.aggregateRemark ?></div>
       <? } ?>

--- a/tests/billingOutput.test.js
+++ b/tests/billingOutput.test.js
@@ -304,7 +304,7 @@ function testInvoiceTemplateSwitchesAggregateModeForUnpaid() {
 
   assert.strictEqual(aggregate.isAggregateInvoice, true, '未回収や合算対象があれば合算モードになる');
   assert.strictEqual(aggregate.invoiceMode, 'aggregate', 'モード名を保持する');
-  assert.strictEqual(aggregate.chargeMonthLabel, '2024年12月〜2025年02月', '対象月は範囲表示になる');
+  assert.strictEqual(aggregate.chargeMonthLabel, '2025年02月', '請求月のみを表示する');
 
   const standard = buildInvoiceTemplateData_({ billingMonth: '202502', hasPreviousPrepared: false });
   assert.strictEqual(standard.isAggregateInvoice, false, '未回収が無ければ通常モード');


### PR DESCRIPTION
## Summary
- ensure invoice header/対象期間 always shows the billing month while keeping month-by-month breakdowns on receipt months
- add fallbacks for missing Apps Script globals and reuse billing month labels for aggregate invoices
- update aggregate invoice note to mention inclusion of prior unpaid amounts and adjust tests

## Testing
- node tests/billingOutput.test.js *(fails: AssertionError expecting bankFlags enrichment in exportBankTransferDataForPrepared_ when running in Node test harness)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953181a905c83218495c4d7e804a5b1)