### PR TITLE
Fix fallback receipt month display for standard invoices

### DIFF
--- a/tests/billingOutput.test.js
+++ b/tests/billingOutput.test.js
@@ -331,6 +331,21 @@ function testInvoiceTemplateIgnoresFallbackReceiptMonthForAggregate() {
   assert.strictEqual(trace.fallbackReceiptMonthsUsedInDecision, false, 'フォールバック月を意思決定に利用しない');
 }
 
+function testReceiptDisplayFallsBackToPreviousMonthWhenDefault() {
+  const context = createContext();
+  vm.createContext(context);
+  vm.runInContext(billingOutputCode, context);
+
+  const display = context.resolveInvoiceReceiptDisplay_({
+    billingMonth: '202411'
+  });
+
+  assert.strictEqual(display.visible, true, '請求月のみ指定でも領収書を表示する');
+  assert.deepStrictEqual(Array.from(display.receiptMonths || []), ['202410'], '前月を単月領収書として表示する');
+  assert.strictEqual(display.receiptMonthsSource, 'fallback', '表示ソースをフォールバックとして保持する');
+  assert.deepStrictEqual(Array.from(display.explicitReceiptMonths || []), [], '明示指定は無いままにする');
+}
+
 function testAggregateStatusDoesNotFinalizeWithoutConfirmation() {
   const context = createContext();
   vm.createContext(context);
@@ -857,6 +872,7 @@ function run() {
   testReceiptVisibilityRespectsBankFlagsAndStatus();
   testInvoiceTemplateSwitchesAggregateModeForUnpaid();
   testInvoiceTemplateIgnoresFallbackReceiptMonthForAggregate();
+  testReceiptDisplayFallsBackToPreviousMonthWhenDefault();
   testAggregateStatusDoesNotFinalizeWithoutConfirmation();
   testPreviousReceiptSettlementRequiresExplicitStatus();
   testPreviousReceiptVisibilityFollowsReceiptDecision();


### PR DESCRIPTION
## Summary
- ensure fallback (previous-month) receipt months are still used to calculate single-month receipt amounts while remaining excluded from aggregate decisions
- preserve existing aggregate/unpaid behavior while keeping changes scoped to billingOutput.js

## Testing
- node tests/billingOutput.test.js
- node tests/billingInvoiceLayout.test.js *(fails: TypeError due to undefined aggregateInvoiceDetails in testAggregateInvoiceTemplateStacksPerMonth; pre-existing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695429c16c1c8321bc2db2d2e15b121f)