### PR TITLE
Refine aggregate billing and receipt handling

### DIFF
--- a/tests/aggregateBillingFromBankFlags.test.js
+++ b/tests/aggregateBillingFromBankFlags.test.js
@@ -32,21 +32,25 @@ function createContext(preparedByMonth) {
   };
   ctx.billingNormalizePatientId_ = pid => (pid ? String(pid).trim() : '');
   ctx.loadPreparedBillingWithSheetFallback_ = monthKey => ctx.preparedByMonth[monthKey] || null;
+  ctx.buildReceiptMonthsFromBankUnpaid_ = (patientId, anchorMonth) => {
+    const prev = ctx.resolvePreviousBillingMonthKey_(anchorMonth);
+    return prev ? [prev, anchorMonth] : [anchorMonth];
+  };
 
   return ctx;
 }
 
-(function testAggregateInvoiceCombinesPreviousFlaggedMonths() {
+(function testAggregateInvoiceCombinesUnpaidMonthsWhenAggregateMonthSpecified() {
   const preparedByMonth = {
     '202401': {
       billingMonth: '202401',
       billingJson: [{ patientId: 'P01', grandTotal: 1000 }],
-      bankFlagsByPatient: { P01: { af: true, ae: false } }
+      bankFlagsByPatient: { P01: { ae: true, af: false } }
     },
     '202402': {
       billingMonth: '202402',
-      billingJson: [{ patientId: 'P01', grandTotal: 2000 }],
-      bankFlagsByPatient: { P01: { af: false, ae: false } }
+      billingJson: [{ patientId: 'P01', grandTotal: 2000, aggregateUntilMonth: '202402' }],
+      bankFlagsByPatient: { P01: { ae: true, af: false } }
     }
   };
 
@@ -56,11 +60,11 @@ function createContext(preparedByMonth) {
 
   assert.strictEqual(entry.aggregateStatus, 'confirmed');
   assert.strictEqual(entry.grandTotal, 3000);
-  assert.deepStrictEqual([].concat(entry.receiptMonths || []), ['202401', '202402']);
-  assert.ok(entry.aggregateRemark.includes('合算請求'));
+  assert.deepStrictEqual([].concat(entry.aggregateTargetMonths || []), ['202401', '202402']);
+  assert.strictEqual(entry.skipReceipt, true);
 })();
 
-(function testAggregateOngoingSkipsInvoiceGeneration() {
+(function testUnpaidWithoutAggregateMonthDoesNotAggregate() {
   const preparedByMonth = {
     '202403': {
       billingMonth: '202403',
@@ -73,148 +77,7 @@ function createContext(preparedByMonth) {
   const result = context.applyAggregateInvoiceRulesFromBankFlags_(preparedByMonth['202403']);
   const entry = result.billingJson[0];
 
-  assert.strictEqual(entry.skipInvoice, true);
-  assert.strictEqual(entry.grandTotal, 0);
-})();
-
-(function testAggregateInvoicePdfGeneratedForScheduledEntries() {
-  const preparedByMonth = {
-    '202404': {
-      billingMonth: '202404',
-      billingJson: [{ patientId: 'P99', billingMonth: '202404', grandTotal: 4000 }],
-      bankFlagsByPatient: { P99: { ae: true, af: false } }
-    },
-    '202405': {
-      billingMonth: '202405',
-      billingJson: [{ patientId: 'P99', billingMonth: '202405', grandTotal: 5000, aggregateUntilMonth: '202403' }],
-      bankFlagsByPatient: { P99: { ae: true, af: false } }
-    }
-  };
-
-  const aggregateCalls = [];
-  const ctx = {
-    console: { log: () => {}, warn: () => {} },
-    preparedByMonth,
-    CacheService: { getScriptCache: () => ({}) },
-    normalizeMoneyNumber_: value => Number(value) || 0,
-    billingLogger_: { log: () => {} },
-    normalizePreparedBilling_: payload => payload,
-    attachPreviousReceiptAmounts_: payload => payload,
-    normalizeBillingMonthKeySafe_: value => String(value || '').trim(),
-    billingNormalizePatientId_: pid => (pid ? String(pid).trim() : ''),
-    loadPreparedBillingWithSheetFallback_: monthKey => preparedByMonth[monthKey] || null,
-    exportBankTransferDataForPrepared_: () => null,
-    generateInvoicePdfs: () => ({ billingMonth: '202405', files: [], missingPatientIds: [] }),
-    generateAggregateInvoicePdf: (entry, opts) => {
-      aggregateCalls.push({ entry, opts });
-      return { fileId: 'agg', patientId: entry && entry.patientId, nameKanji: entry && entry.nameKanji };
-    }
-  };
-
-  ctx.normalizeBillingMonthInput = value => ({
-    key: String(value || ''),
-    year: Number(String(value || '').slice(0, 4)) || 2024,
-    month: Number(String(value || '').slice(4, 6)) || 1
-  });
-  ctx.resolvePreviousBillingMonthKey_ = billingMonth => {
-    const normalized = ctx.normalizeBillingMonthKeySafe_(billingMonth);
-    if (!normalized) return '';
-    const year = Number(normalized.slice(0, 4));
-    const month = Number(normalized.slice(4, 6));
-    const prevMonth = month === 1 ? 12 : month - 1;
-    const prevYear = month === 1 ? year - 1 : year;
-    return String(prevYear).padStart(4, '0') + String(prevMonth).padStart(2, '0');
-  };
-
-  vm.createContext(ctx);
-  vm.runInContext(mainCode, ctx);
-
-  ctx.loadPreparedBillingWithSheetFallback_ = monthKey => preparedByMonth[monthKey] || null;
-  ctx.attachPreviousReceiptAmounts_ = payload => payload;
-  ctx.exportBankTransferDataForPrepared_ = () => null;
-  ctx.generateInvoicePdfs = () => ({ billingMonth: '202405', files: [], missingPatientIds: [] });
-  ctx.generateAggregateInvoicePdf = (entry, opts) => {
-    aggregateCalls.push({ entry, opts });
-    return { fileId: 'agg', patientId: entry && entry.patientId, nameKanji: entry && entry.nameKanji };
-  };
-
-  const result = ctx.generatePreparedInvoices_(preparedByMonth['202405']);
-
-  assert.ok(result && Array.isArray(result.files), 'invoice generation returns files');
-  // Aggregate invoices should be auto-generated for the confirmed "scheduled" state.
-  assert.strictEqual(aggregateCalls.length, 1, 'aggregate invoice is generated for scheduled entries');
-  const aggregateMonths = aggregateCalls[0] && aggregateCalls[0].opts && aggregateCalls[0].opts.aggregateMonths;
-  assert.deepStrictEqual(Array.from(new Set(aggregateMonths)), ['202404', '202405']);
-  assert.strictEqual(aggregateCalls[0].entry && aggregateCalls[0].entry.grandTotal, 9000);
-})();
-
-(function testAggregateSummaryPdfGeneratedForConfirmedEntries() {
-  const preparedByMonth = {
-    '202401': {
-      billingMonth: '202401',
-      billingJson: [{ patientId: 'P10', billingMonth: '202401', grandTotal: 1000 }],
-      bankFlagsByPatient: { P10: { af: true, ae: false } }
-    },
-    '202402': {
-      billingMonth: '202402',
-      billingJson: [{ patientId: 'P10', billingMonth: '202402', grandTotal: 2000 }],
-      bankFlagsByPatient: { P10: { af: false, ae: false } }
-    }
-  };
-
-  const aggregateCalls = [];
-  const ctx = {
-    console: { log: () => {}, warn: () => {} },
-    preparedByMonth,
-    CacheService: { getScriptCache: () => ({}) },
-    normalizeMoneyNumber_: value => Number(value) || 0,
-    billingLogger_: { log: () => {} },
-    normalizePreparedBilling_: payload => payload,
-    attachPreviousReceiptAmounts_: payload => payload,
-    normalizeBillingMonthKeySafe_: value => String(value || '').trim(),
-    billingNormalizePatientId_: pid => (pid ? String(pid).trim() : ''),
-    loadPreparedBillingWithSheetFallback_: monthKey => preparedByMonth[monthKey] || null,
-    exportBankTransferDataForPrepared_: () => null,
-    generateInvoicePdfs: () => ({ billingMonth: '202402', files: [], missingPatientIds: [] }),
-    generateAggregateInvoicePdf: (entry, opts) => {
-      aggregateCalls.push({ entry, opts });
-      return { fileId: 'agg', patientId: entry && entry.patientId, nameKanji: entry && entry.nameKanji };
-    }
-  };
-
-  ctx.normalizeBillingMonthInput = value => ({
-    key: String(value || ''),
-    year: Number(String(value || '').slice(0, 4)) || 2024,
-    month: Number(String(value || '').slice(4, 6)) || 1
-  });
-  ctx.resolvePreviousBillingMonthKey_ = billingMonth => {
-    const normalized = ctx.normalizeBillingMonthKeySafe_(billingMonth);
-    if (!normalized) return '';
-    const year = Number(normalized.slice(0, 4));
-    const month = Number(normalized.slice(4, 6));
-    const prevMonth = month === 1 ? 12 : month - 1;
-    const prevYear = month === 1 ? year - 1 : year;
-    return String(prevYear).padStart(4, '0') + String(prevMonth).padStart(2, '0');
-  };
-
-  vm.createContext(ctx);
-  vm.runInContext(mainCode, ctx);
-
-  ctx.loadPreparedBillingWithSheetFallback_ = monthKey => preparedByMonth[monthKey] || null;
-  ctx.attachPreviousReceiptAmounts_ = payload => payload;
-  ctx.exportBankTransferDataForPrepared_ = () => null;
-  ctx.generateInvoicePdfs = () => ({ billingMonth: '202402', files: [], missingPatientIds: [] });
-  ctx.generateAggregateInvoicePdf = (entry, opts) => {
-    aggregateCalls.push({ entry, opts });
-    return { fileId: 'agg', patientId: entry && entry.patientId, nameKanji: entry && entry.nameKanji };
-  };
-
-  const result = ctx.generatePreparedInvoices_(preparedByMonth['202402']);
-
-  assert.ok(result && Array.isArray(result.files), 'invoice generation returns files');
-  assert.strictEqual(aggregateCalls.length, 1, 'aggregate summary is generated for confirmed entries');
-  const aggregateMonths = aggregateCalls[0] && aggregateCalls[0].opts && aggregateCalls[0].opts.aggregateMonths;
-  assert.deepStrictEqual(Array.from(new Set(aggregateMonths)), ['202401', '202402']);
-})();
-
-console.log('aggregate billing from bank flags tests passed');
+  assert.strictEqual(entry.aggregateStatus, undefined);
+  assert.strictEqual(entry.grandTotal, 1500);
+  assert.strictEqual(entry.skipReceipt, undefined);
+})();  

--- a/tests/billingOutput.test.js
+++ b/tests/billingOutput.test.js
@@ -264,28 +264,21 @@ function testReceiptVisibilityRespectsBankFlagsAndStatus() {
   assert.deepStrictEqual(Array.from(defaultStatus.receiptMonths || []), ['202412'], '前月の領収書を作成する');
 
   const withoutPreviousSheet = resolveInvoiceReceiptDisplay_({ billingMonth: '202501', hasPreviousPrepared: false });
-  assert.strictEqual(withoutPreviousSheet.showReceipt, false, '銀行引落シートが無ければ前月領収書を非表示にする');
+  assert.strictEqual(withoutPreviousSheet.showReceipt, false, '前月請求が無ければ領収書を非表示にする');
 
-  const withUnpaidFlag = resolveInvoiceReceiptDisplay_({
+  const withUnpaidStatus = resolveInvoiceReceiptDisplay_({
     billingMonth: '202501',
     hasPreviousPrepared: true,
-    bankFlags: { ae: true, af: false }
+    receiptStatus: 'UNPAID'
   });
-  assert.strictEqual(withUnpaidFlag.showReceipt, false, '未回収フラグがONのときは領収書を非表示にする');
+  assert.strictEqual(withUnpaidStatus.showReceipt, false, '領収ステータスが UNPAID のときは非表示にする');
 
-  const withAggregateFlag = resolveInvoiceReceiptDisplay_({
+  const withSkipReceipt = resolveInvoiceReceiptDisplay_({
     billingMonth: '202501',
     hasPreviousPrepared: true,
-    bankFlags: { ae: false, af: true }
+    skipReceipt: true
   });
-  assert.strictEqual(withAggregateFlag.showReceipt, false, '合算フラグがONのときは領収書を非表示にする');
-
-  const bankFlagsCleared = resolveInvoiceReceiptDisplay_({
-    billingMonth: '202501',
-    hasPreviousPrepared: true,
-    bankFlags: { ae: false, af: false }
-  });
-  assert.strictEqual(bankFlagsCleared.showReceipt, true, '両方OFFなら従来どおり領収書を表示する');
+  assert.strictEqual(withSkipReceipt.showReceipt, false, 'skipReceipt が指定された場合は非表示にする');
 }
 
 function testInvoiceTemplateSwitchesAggregateModeForUnpaid() {
@@ -297,19 +290,23 @@ function testInvoiceTemplateSwitchesAggregateModeForUnpaid() {
 
   const aggregate = buildInvoiceTemplateData_({
     billingMonth: '202502',
+    aggregateStatus: 'confirmed',
+    aggregateTargetMonths: ['202412', '202501', '202502'],
     receiptMonths: ['202412', '202501', '202502'],
-    hasPreviousReceiptSheet: true,
-    previousReceiptAmount: 1500
+    skipReceipt: true,
+    hasPreviousReceiptSheet: true
   });
 
-  assert.strictEqual(aggregate.isAggregateInvoice, true, '未回収や合算対象があれば合算モードになる');
+  assert.strictEqual(aggregate.isAggregateInvoice, true, '合算対象があれば合算モードになる');
   assert.strictEqual(aggregate.invoiceMode, 'aggregate', 'モード名を保持する');
   assert.strictEqual(aggregate.chargeMonthLabel, '2025年02月', '請求月のみを表示する');
+  assert.strictEqual(aggregate.showReceipt, false, '合算請求時は領収書を出力しない');
 
-  const standard = buildInvoiceTemplateData_({ billingMonth: '202502', hasPreviousPrepared: false });
+  const standard = buildInvoiceTemplateData_({ billingMonth: '202502', hasPreviousPrepared: true });
   assert.strictEqual(standard.isAggregateInvoice, false, '未回収が無ければ通常モード');
   assert.strictEqual(standard.invoiceMode, 'standard', '通常モードを示す');
   assert.strictEqual(standard.chargeMonthLabel, '2025年02月', '請求月のみを表示する');
+  assert.strictEqual(standard.showReceipt, true, '通常モードでは領収書を表示する');
 }
 
 function testInvoiceTemplateIgnoresFallbackReceiptMonthForAggregate() {
@@ -328,7 +325,6 @@ function testInvoiceTemplateIgnoresFallbackReceiptMonthForAggregate() {
   assert.ok(trace, '合算判定トレースを含める');
   assert.strictEqual(trace.receiptMonthsSource, 'fallback', '領収月のソースを明示する');
   assert.deepStrictEqual(Array.from(trace.decisionSources || []), [], 'フォールバック領収月は判定ソースに含めない');
-  assert.strictEqual(trace.fallbackReceiptMonthsUsedInDecision, false, 'フォールバック月を意思決定に利用しない');
 }
 
 function testReceiptDisplayFallsBackToPreviousMonthWhenDefault() {
@@ -355,16 +351,16 @@ function testAggregateStatusDoesNotFinalizeWithoutConfirmation() {
 
   const aggregate = buildInvoiceTemplateData_({
     billingMonth: '202501',
-    previousReceiptAmount: 1000,
+    aggregateTargetMonths: ['202411', '202412'],
     aggregateStatus: 'scheduled'
   });
-  assert.strictEqual(aggregate.isAggregateInvoice, true, '未収金があれば合算判定は true');
+  assert.strictEqual(aggregate.isAggregateInvoice, true, '明示的な合算対象があれば合算判定は true');
   assert.strictEqual(aggregate.aggregateConfirmed, false, 'scheduled では確定扱いにしない');
   assert.strictEqual(aggregate.finalized, false, '合算でも confirmed でなければ確定扱いにしない');
 
   const confirmed = buildInvoiceTemplateData_({
     billingMonth: '202501',
-    previousReceiptAmount: 1000,
+    aggregateTargetMonths: ['202411', '202412'],
     aggregateStatus: 'confirmed'
   });
   assert.strictEqual(confirmed.aggregateConfirmed, true, 'confirmed のときのみ確定扱いにする');
@@ -409,7 +405,7 @@ function testPreviousReceiptVisibilityFollowsReceiptDecision() {
   assert.strictEqual(payable.previousReceipt.visible, true, '銀行引落シートがあれば前月領収書も表示する');
 
   const onHold = buildInvoiceTemplateData_({ billingMonth: '202501', receiptStatus: 'HOLD', hasPreviousPrepared: true });
-  assert.strictEqual(onHold.previousReceipt.visible, true, '領収ステータスに依存せず表示する');
+  assert.strictEqual(onHold.previousReceipt.visible, false, 'HOLD の場合は領収書を非表示にする');
 }
 
 function testPreviousReceiptIsHiddenWhenPreviousPreparedMissing() {

--- a/tests/receiptAggregationFromBankSheet.test.js
+++ b/tests/receiptAggregationFromBankSheet.test.js
@@ -30,23 +30,26 @@ function createContext() {
   return ctx;
 }
 
-(function testReceiptMonthsBackfillFromBankSheet() {
+(function testAggregateReceiptGeneratedFromPreviousAggregateInvoice() {
   const context = createContext();
 
-  const bankAmounts = {
-    '202411': { P01: 1200 },
-    '202410': { P01: 800 }
-  };
-
-  context.collectPreviousReceiptAmountsFromBankSheet_ = monthKey => ({
-    hasSheet: true,
-    amounts: bankAmounts[monthKey] || {}
-  });
-  context.buildReceiptMonthsFromBankUnpaid_ = patientId => (patientId === 'P01'
-    ? ['202410', '202411']
-    : ['202411']
+  context.buildReceiptMonthsFromBankUnpaid_ = (patientId, anchorMonth) => (patientId === 'P01' && anchorMonth === '202411'
+    ? ['202409', '202410', '202411']
+    : []
   );
-  context.collectBankWithdrawalAmountsByPatient_ = monthKey => bankAmounts[monthKey] || {};
+  context.isPatientCheckedUnpaidInBankWithdrawalSheet_ = (patientId, monthKey) => patientId === 'P01' && monthKey === '202411';
+  context.getPreparedBillingForMonthCached_ = monthKey => (monthKey === '202411'
+    ? { billingMonth: '202411', billingJson: [{ patientId: 'P01', aggregateUntilMonth: '202411' }], aggregateUntilMonth: '202411' }
+    : null
+  );
+  context.getPreparedBillingEntryForMonthCached_ = (monthKey, patientId) => (monthKey === '202411' && patientId === 'P01'
+    ? { patientId: 'P01', aggregateUntilMonth: '202411' }
+    : null
+  );
+  context.buildReceiptMonthBreakdownForEntry_ = (patientId, months) => months.map((month, idx) => ({
+    month,
+    amount: (idx + 1) * 1000
+  }));
 
   const prepared = {
     billingMonth: '202412',
@@ -61,24 +64,18 @@ function createContext() {
   const patientWithoutUnpaid = enriched.billingJson[1];
 
   assert.deepStrictEqual(
-    patientWithUnpaid.receiptMonths,
-    ['202410', '202411'],
-    'receipt months include unpaid history'
+    Array.from(patientWithUnpaid.receiptMonths || []),
+    ['202409', '202410', '202411'],
+    'aggregate receipt includes designated month and unpaid history'
   );
-  assert.strictEqual(
-    patientWithUnpaid.previousReceiptAmount,
-    2000,
-    'previousReceiptAmount aggregates all receipt months'
+  assert.ok(
+    Array.isArray(patientWithUnpaid.receiptMonthBreakdown) && patientWithUnpaid.receiptMonthBreakdown.length === 3,
+    'aggregate receipt keeps month breakdown'
   );
   assert.deepStrictEqual(
-    patientWithoutUnpaid.receiptMonths,
+    Array.from(patientWithoutUnpaid.receiptMonths || []),
     ['202411'],
-    'patients without unpaid history only include anchor month'
-  );
-  assert.strictEqual(
-    patientWithoutUnpaid.previousReceiptAmount,
-    0,
-    'patients without amounts keep zero aggregate'
+    'patients without aggregate invoices keep the default single-month receipt'
   );
 })();
 


### PR DESCRIPTION
## Summary
- align aggregate invoice generation with unpaid checks plus specified aggregate month and suppress receipt output during aggregation
- separate receipt enrichment from billing logic so aggregated receipts are produced the following cycle from prior aggregate invoices
- simplify receipt display/aggregate decisions and remove previous fallback-based heuristics, with updated coverage for new rules

## Testing
- node tests/aggregateBillingFromBankFlags.test.js
- node tests/receiptAggregationFromBankSheet.test.js
- node tests/billingOutput.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955c393023c83219b4593871d4c6a45)