### PR TITLE
Align aggregate receipt flow with unpaid and aggregate month rules

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -946,60 +946,69 @@ function attachPreviousReceiptAmounts_(prepared, cache) {
   const previousMonthKey = resolvePreviousBillingMonthKey_(monthKey);
   if (!previousMonthKey) return prepared;
 
-  const previousReceipt = collectPreviousReceiptAmountsFromBankSheet_(previousMonthKey, prepared);
-  const hasPreviousReceiptSheet = !!(previousReceipt && previousReceipt.hasSheet);
-  const previousAmounts = previousReceipt && previousReceipt.amounts;
+  const normalizePid = typeof billingNormalizePatientId_ === 'function'
+    ? billingNormalizePatientId_
+    : value => String(value || '').trim();
   const monthCache = cache || {
     preparedByMonth: {},
     bankWithdrawalUnpaidByMonth: {},
     bankWithdrawalAmountsByMonth: {}
   };
-  if (previousMonthKey && previousAmounts) {
-    monthCache.bankWithdrawalAmountsByMonth[previousMonthKey] = previousAmounts;
-  }
-
-  const normalizePid = typeof billingNormalizePatientId_ === 'function'
-    ? billingNormalizePatientId_
-    : value => String(value || '').trim();
+  const previousPrepared = getPreparedBillingForMonthCached_(previousMonthKey, monthCache);
 
   const enrichedJson = prepared.billingJson.map(entry => {
     const pid = normalizePid(entry && entry.patientId);
-    const aggregateReceipt = hasPreviousReceiptSheet
-      ? resolveAggregateReceiptForEntry_(pid, previousMonthKey, prepared, monthCache)
+    const previousEntry = previousPrepared
+      ? getPreparedBillingEntryForMonthCached_(previousMonthKey, pid, monthCache)
       : null;
-    const receiptMonths = aggregateReceipt
-      ? aggregateReceipt.months
-      : (hasPreviousReceiptSheet ? buildReceiptMonthsFromBankUnpaid_(pid, previousMonthKey, prepared, monthCache) : []);
-    const filteredReceiptMonths = normalizePastBillingMonths_(receiptMonths, monthKey);
-    const receiptBreakdown = aggregateReceipt
-      ? aggregateReceipt.breakdown
-      : buildReceiptMonthBreakdownForEntry_(pid, filteredReceiptMonths, prepared, monthCache);
-    const previousReceiptAmount = aggregateReceipt
-      ? aggregateReceipt.total
-      : (Array.isArray(receiptBreakdown)
-        ? receiptBreakdown.reduce((sum, item) => sum + (Number(item && item.amount) || 0), 0)
-        : 0);
+    const aggregateUntilMonth = normalizeBillingMonthKeySafe_(previousEntry && previousEntry.aggregateUntilMonth)
+      || normalizeBillingMonthKeySafe_(previousPrepared && previousPrepared.aggregateUntilMonth);
+    const previousUnpaid = isPatientCheckedUnpaidInBankWithdrawalSheet_(pid, previousMonthKey, previousPrepared || prepared, monthCache);
+    const hadAggregateInvoice = !!(previousUnpaid && aggregateUntilMonth);
 
-    const previousReceipt = aggregateReceipt
-      ? {
+    if (hadAggregateInvoice) {
+      const aggregateSourceMonths = resolveAggregateMonthsFromUnpaid_(monthKey, pid, aggregateUntilMonth, previousPrepared || prepared, monthCache)
+        .concat(Array.isArray(previousEntry && previousEntry.aggregateTargetMonths) ? previousEntry.aggregateTargetMonths : []);
+      const aggregateReceiptMonths = normalizePastBillingMonths_(aggregateSourceMonths, monthKey);
+      const receiptMonths = Array.from(new Set(aggregateReceiptMonths));
+      const receiptBreakdown = buildReceiptMonthBreakdownForEntry_(pid, aggregateReceiptMonths, previousPrepared || prepared, monthCache);
+      const aggregateRemark = formatAggregateReceiptDescription_(receiptMonths);
+      const previousReceipt = {
         addressee: '株式会社べるつりー',
-        note: aggregateReceipt.remark
-      }
-      : null;
+        note: aggregateRemark
+      };
+      return Object.assign({}, entry, {
+        hasPreviousReceiptSheet: true,
+        receiptMonths,
+        receiptRemark: aggregateRemark,
+        receiptMonthBreakdown: receiptBreakdown,
+        previousReceipt: entry && entry.previousReceipt ? entry.previousReceipt : previousReceipt
+      });
+    }
+
+    if (previousUnpaid) {
+      return Object.assign({}, entry, {
+        hasPreviousReceiptSheet: !!previousPrepared,
+        receiptMonths: [],
+        receiptRemark: '',
+        receiptMonthBreakdown: entry && entry.receiptMonthBreakdown
+      });
+    }
+
+    const receiptMonths = normalizePastBillingMonths_([previousMonthKey], monthKey);
+    const receiptBreakdown = buildReceiptMonthBreakdownForEntry_(pid, receiptMonths, previousPrepared || prepared, monthCache);
 
     return Object.assign({}, entry, {
-      previousReceiptAmount,
-      hasPreviousReceiptSheet,
-      receiptMonths: filteredReceiptMonths,
-      receiptRemark: aggregateReceipt ? aggregateReceipt.remark : entry && entry.receiptRemark,
-      receiptMonthBreakdown: aggregateReceipt ? receiptBreakdown : entry && entry.receiptMonthBreakdown,
-      previousReceipt: previousReceipt || entry && entry.previousReceipt
+      hasPreviousReceiptSheet: !!previousPrepared,
+      receiptMonths,
+      receiptRemark: entry && entry.receiptRemark,
+      receiptMonthBreakdown: receiptBreakdown
     });
   });
 
   return Object.assign({}, prepared, {
     billingJson: enrichedJson,
-    hasPreviousReceiptSheet
+    hasPreviousReceiptSheet: !!previousPrepared
   });
 }
 
@@ -1231,6 +1240,29 @@ function formatAggregateBillingRemark_(months) {
   return labels.join('・') + ' 合算請求';
 }
 
+function resolveAggregateMonthsFromUnpaid_(billingMonth, patientId, aggregateUntilMonth, prepared, cache) {
+  // aggregateUntilMonth を起点に、過去の未回収月と指定の合算月を列挙する
+  const monthKey = normalizeBillingMonthKeySafe_(billingMonth);
+  const pid = billingNormalizePatientId_(patientId);
+  const anchorMonth = normalizeBillingMonthKeySafe_(aggregateUntilMonth);
+  if (!monthKey || !pid || !anchorMonth) return [];
+
+  const unpaidMonths = buildReceiptMonthsFromBankUnpaid_(pid, anchorMonth, prepared, cache);
+  const normalized = normalizePastBillingMonths_(unpaidMonths, monthKey);
+  if (unpaidMonths && unpaidMonths.indexOf(anchorMonth) >= 0 && normalized.indexOf(anchorMonth) < 0) {
+    normalized.push(anchorMonth);
+  }
+  const seen = new Set();
+  const unique = [];
+  normalized.forEach(ym => {
+    if (!seen.has(ym)) {
+      seen.add(ym);
+      unique.push(ym);
+    }
+  });
+  return unique;
+}
+
 function applyAggregateInvoiceRulesFromBankFlags_(prepared, cache) {
   const normalized = normalizePreparedBilling_(prepared);
   const monthKey = normalizeBillingMonthKeySafe_(normalized && normalized.billingMonth);
@@ -1248,26 +1280,12 @@ function applyAggregateInvoiceRulesFromBankFlags_(prepared, cache) {
     if (!pid) return entry;
 
     const bankFlags = bankFlagsByPatient[pid] || {};
-    const isAggregateOngoing = !!(bankFlags.ae || bankFlags.af);
-    if (isAggregateOngoing) {
-      // 'scheduled' means the aggregate invoice should be auto-generated (instead of a
-      // standard invoice) once invoice generation runs. The amounts remain zeroed here
-      // so the aggregate PDF can reconstruct totals across months without double billing.
-      return Object.assign({}, entry, {
-        aggregateStatus: 'scheduled',
-        skipInvoice: true,
-        billingAmount: 0,
-        transportAmount: 0,
-        total: 0,
-        grandTotal: 0,
-        receiptMonths: []
-      });
-    }
-
     const aggregateUntilMonth = normalizeBillingMonthKeySafe_(entry && entry.aggregateUntilMonth)
       || normalizeBillingMonthKeySafe_(normalized.aggregateUntilMonth);
-    const aggregateMonths = collectAggregateBankFlagMonthsForPatient_(monthKey, pid, aggregateUntilMonth, monthCache);
-    const targetMonths = normalizePastBillingMonths_(aggregateMonths, monthKey);
+    const shouldAggregate = !!(bankFlags.ae && aggregateUntilMonth);
+    if (!shouldAggregate) return entry;
+
+    const targetMonths = resolveAggregateMonthsFromUnpaid_(monthKey, pid, aggregateUntilMonth, normalized, monthCache);
     if (!targetMonths.length) return entry;
     const aggregateTotal = targetMonths.reduce(
       (sum, ym) => sum + resolveBillingAmountForMonthAndPatient_(ym, pid, null, monthCache),
@@ -1283,7 +1301,8 @@ function applyAggregateInvoiceRulesFromBankFlags_(prepared, cache) {
       transportAmount: 0,
       total: aggregateTotal,
       grandTotal: aggregateTotal,
-      aggregateTargetMonths: targetMonths
+      aggregateTargetMonths: targetMonths,
+      skipReceipt: true
     });
   });
 

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -377,49 +377,29 @@ function normalizeAggregateStatus_(status) {
 
 function resolveInvoiceReceiptDisplay_(item) {
   const hasPreviousReceiptSheet = resolveHasPreviousReceiptSheet_(item);
-  const fallbackMonth = resolvePreviousBillingMonthKey_(item && item.billingMonth);
   const billingMonthKey = normalizeInvoiceMonthKey_(item && item.billingMonth);
   const explicitReceiptMonths = normalizePastInvoiceMonths_(
     normalizeReceiptMonths_(item && item.receiptMonths),
     billingMonthKey
   );
-  const aggregateTargetReceiptMonths = normalizeAggregateMonthsForInvoice_(
-    Array.isArray(item && item.aggregateTargetMonths) ? item.aggregateTargetMonths : [],
-    billingMonthKey
-  );
-  const fallbackReceiptMonths = normalizePastInvoiceMonths_(
-    normalizeReceiptMonths_([], fallbackMonth),
-    billingMonthKey
-  );
   const aggregateStatus = normalizeAggregateStatus_(item && item.aggregateStatus);
   const aggregateConfirmed = aggregateStatus === 'confirmed';
-  let receiptMonths = explicitReceiptMonths.length
-    ? explicitReceiptMonths
-    : aggregateTargetReceiptMonths;
-  const shouldUseFallbackReceiptMonths = !aggregateConfirmed
-    && !explicitReceiptMonths.length
-    && !aggregateTargetReceiptMonths.length
-    && fallbackReceiptMonths.length;
-  if (shouldUseFallbackReceiptMonths) {
-    receiptMonths = fallbackReceiptMonths;
-  }
+  const fallbackMonth = resolvePreviousBillingMonthKey_(billingMonthKey);
+  const fallbackReceiptMonths = normalizePastInvoiceMonths_(
+    normalizeReceiptMonths_(fallbackMonth ? [fallbackMonth] : [], fallbackMonth),
+    billingMonthKey
+  );
+  const receiptMonths = explicitReceiptMonths.length ? explicitReceiptMonths : fallbackReceiptMonths;
   const customReceiptRemark = item && item.receiptRemark ? String(item.receiptRemark) : '';
   const receiptRemark = customReceiptRemark || (receiptMonths.length > 1
     ? formatAggregatedReceiptRemark_(receiptMonths)
     : '');
   const receiptStatus = item && item.receiptStatus ? String(item.receiptStatus).toUpperCase() : '';
-  const bankFlags = item && item.bankFlags;
-  const unpaidFlag = bankFlags && (bankFlags.ae || bankFlags.AE);
-  const aggregateFlag = bankFlags && (bankFlags.af || bankFlags.AF);
-  const hasBankRestriction = !!(unpaidFlag || aggregateFlag);
-  const showReceipt = aggregateConfirmed
-    ? true
-    : (hasPreviousReceiptSheet && receiptStatus !== 'UNPAID' && !hasBankRestriction);
+  const shouldHideByStatus = receiptStatus === 'UNPAID' || receiptStatus === 'HOLD';
+  const showReceipt = !shouldHideByStatus && !item.skipReceipt && receiptMonths.length > 0 && hasPreviousReceiptSheet;
   const receiptMonthsSource = receiptMonths.length
-    ? (shouldUseFallbackReceiptMonths
-      ? 'fallback'
-      : (explicitReceiptMonths.length ? 'explicit' : 'aggregate'))
-    : (fallbackReceiptMonths.length ? 'fallback' : 'none');
+    ? (explicitReceiptMonths.length ? 'explicit' : 'fallback')
+    : 'none';
 
   return {
     visible: showReceipt,
@@ -427,7 +407,6 @@ function resolveInvoiceReceiptDisplay_(item) {
     receiptRemark,
     receiptMonths,
     explicitReceiptMonths,
-    fallbackReceiptMonths,
     receiptMonthsSource,
     aggregateStatus,
     aggregateConfirmed
@@ -446,22 +425,14 @@ function resolveAggregateInvoiceDecision_(item, receipt, billingMonth) {
     explicitReceiptMonths.length ? explicitReceiptMonths : aggregateTargetMonths,
     billingMonthKey
   );
-  const normalizedPreviousReceiptAmount = normalizeInvoiceMoney_(item && item.previousReceiptAmount);
-  const usesPreviousReceiptAmount = Number.isFinite(normalizedPreviousReceiptAmount) && normalizedPreviousReceiptAmount > 0;
   const usesExplicitReceiptMonths = explicitReceiptMonths.length > 0;
   const usesAggregateTargetMonths = !usesExplicitReceiptMonths && aggregateDecisionMonths.length > 0;
   const decisionSources = [];
   if (usesExplicitReceiptMonths) decisionSources.push('explicitReceiptMonths');
   if (usesAggregateTargetMonths) decisionSources.push('aggregateTargetMonths');
-  if (usesPreviousReceiptAmount) decisionSources.push('previousReceiptAmount');
   const aggregateMonthsSource = usesExplicitReceiptMonths
     ? 'explicitReceiptMonths'
     : (usesAggregateTargetMonths ? 'aggregateTargetMonths' : 'none');
-  const fallbackReceiptMonths = Array.isArray(receipt && receipt.fallbackReceiptMonths)
-    ? normalizeAggregateMonthsForInvoice_(receipt.fallbackReceiptMonths, billingMonthKey)
-    : (receipt && receipt.receiptMonthsSource === 'fallback'
-      ? normalizeAggregateMonthsForInvoice_(receipt.receiptMonths || [], billingMonthKey)
-      : []);
 
   const trace = {
     billingMonth: billingMonthKey,
@@ -469,16 +440,12 @@ function resolveAggregateInvoiceDecision_(item, receipt, billingMonth) {
     explicitReceiptMonths,
     aggregateTargetMonths,
     aggregateDecisionMonths,
-    aggregateMonthsSource,
-    fallbackReceiptMonthsUsedInDecision: false,
-    fallbackReceiptMonths,
-    previousReceiptAmount: normalizedPreviousReceiptAmount,
-    usesPreviousReceiptAmount
+    aggregateMonthsSource
   };
 
   return {
     aggregateDecisionMonths,
-    isAggregateInvoice: !!((aggregateDecisionMonths && aggregateDecisionMonths.length > 1) || usesPreviousReceiptAmount),
+    isAggregateInvoice: !!(aggregateDecisionMonths && aggregateDecisionMonths.length > 1),
     decisionSources,
     trace
   };
@@ -535,17 +502,19 @@ function buildInvoicePreviousReceipt_(item, display) {
   const aggregateAmount = Array.isArray(aggregateBreakdown)
     ? aggregateBreakdown.reduce((sum, row) => sum + (Number(row && row.amount) || 0), 0)
     : 0;
-  const fallbackReceiptAmount = normalizeInvoiceMoney_(item && item.previousReceiptAmount);
-  const amount = isAggregateInvoice
-    ? (aggregateAmount || fallbackReceiptAmount)
-    : fallbackReceiptAmount;
   const note = receiptDisplay && receiptDisplay.receiptRemark ? receiptDisplay.receiptRemark : '';
+
+  const resolvedAmount = isAggregateInvoice
+    ? aggregateAmount
+    : (Array.isArray(aggregateBreakdown) && aggregateBreakdown.length
+      ? Number(aggregateBreakdown[0] && aggregateBreakdown[0].amount) || 0
+      : 0);
 
   return {
     visible: !!(receiptDisplay && receiptDisplay.visible),
     addressee,
     date,
-    amount: Number.isFinite(amount) ? amount : 0,
+    amount: Number.isFinite(resolvedAmount) ? resolvedAmount : 0,
     note,
     receiptMonths: receiptDisplay && receiptDisplay.receiptMonths ? receiptDisplay.receiptMonths : [],
     aggregateStatus: receiptDisplay && receiptDisplay.aggregateStatus ? receiptDisplay.aggregateStatus : '',
@@ -677,7 +646,6 @@ function buildAggregateInvoiceTemplateData_(item, aggregateMonths) {
   );
   const aggregateRemark = formatAggregateInvoiceRemark_(months);
   const hasPreviousReceiptSheet = resolveHasPreviousReceiptSheet_(item);
-  const normalizedPreviousReceiptAmount = normalizeInvoiceMoney_(item && item.previousReceiptAmount);
   const normalizedPatientId = typeof billingNormalizePatientId_ === 'function'
     ? billingNormalizePatientId_(item && item.patientId)
     : String(item && item.patientId || '').trim();

--- a/tests/aggregateBillingFromBankFlags.test.js
+++ b/tests/aggregateBillingFromBankFlags.test.js
@@ -1,3 +1,4 @@
+// Phase2仕様で暗黙的な自動合算（scheduled / 金額起点 / bankFlags 自動合算）を廃止したため、関連テストは削除済み。
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
@@ -32,21 +33,25 @@ function createContext(preparedByMonth) {
   };
   ctx.billingNormalizePatientId_ = pid => (pid ? String(pid).trim() : '');
   ctx.loadPreparedBillingWithSheetFallback_ = monthKey => ctx.preparedByMonth[monthKey] || null;
+  ctx.buildReceiptMonthsFromBankUnpaid_ = (patientId, anchorMonth) => {
+    const prev = ctx.resolvePreviousBillingMonthKey_(anchorMonth);
+    return prev ? [prev, anchorMonth] : [anchorMonth];
+  };
 
   return ctx;
 }
 
-(function testAggregateInvoiceCombinesPreviousFlaggedMonths() {
+(function testAggregateInvoiceCombinesUnpaidMonthsWhenAggregateMonthSpecified() {
   const preparedByMonth = {
     '202401': {
       billingMonth: '202401',
       billingJson: [{ patientId: 'P01', grandTotal: 1000 }],
-      bankFlagsByPatient: { P01: { af: true, ae: false } }
+      bankFlagsByPatient: { P01: { ae: true, af: false } }
     },
     '202402': {
       billingMonth: '202402',
-      billingJson: [{ patientId: 'P01', grandTotal: 2000 }],
-      bankFlagsByPatient: { P01: { af: false, ae: false } }
+      billingJson: [{ patientId: 'P01', grandTotal: 2000, aggregateUntilMonth: '202402' }],
+      bankFlagsByPatient: { P01: { ae: true, af: false } }
     }
   };
 
@@ -56,11 +61,11 @@ function createContext(preparedByMonth) {
 
   assert.strictEqual(entry.aggregateStatus, 'confirmed');
   assert.strictEqual(entry.grandTotal, 3000);
-  assert.deepStrictEqual([].concat(entry.receiptMonths || []), ['202401', '202402']);
-  assert.ok(entry.aggregateRemark.includes('合算請求'));
+  assert.deepStrictEqual([].concat(entry.aggregateTargetMonths || []), ['202401', '202402']);
+  assert.strictEqual(entry.skipReceipt, true);
 })();
 
-(function testAggregateOngoingSkipsInvoiceGeneration() {
+(function testUnpaidWithoutAggregateMonthDoesNotAggregate() {
   const preparedByMonth = {
     '202403': {
       billingMonth: '202403',
@@ -73,148 +78,7 @@ function createContext(preparedByMonth) {
   const result = context.applyAggregateInvoiceRulesFromBankFlags_(preparedByMonth['202403']);
   const entry = result.billingJson[0];
 
-  assert.strictEqual(entry.skipInvoice, true);
-  assert.strictEqual(entry.grandTotal, 0);
-})();
-
-(function testAggregateInvoicePdfGeneratedForScheduledEntries() {
-  const preparedByMonth = {
-    '202404': {
-      billingMonth: '202404',
-      billingJson: [{ patientId: 'P99', billingMonth: '202404', grandTotal: 4000 }],
-      bankFlagsByPatient: { P99: { ae: true, af: false } }
-    },
-    '202405': {
-      billingMonth: '202405',
-      billingJson: [{ patientId: 'P99', billingMonth: '202405', grandTotal: 5000, aggregateUntilMonth: '202403' }],
-      bankFlagsByPatient: { P99: { ae: true, af: false } }
-    }
-  };
-
-  const aggregateCalls = [];
-  const ctx = {
-    console: { log: () => {}, warn: () => {} },
-    preparedByMonth,
-    CacheService: { getScriptCache: () => ({}) },
-    normalizeMoneyNumber_: value => Number(value) || 0,
-    billingLogger_: { log: () => {} },
-    normalizePreparedBilling_: payload => payload,
-    attachPreviousReceiptAmounts_: payload => payload,
-    normalizeBillingMonthKeySafe_: value => String(value || '').trim(),
-    billingNormalizePatientId_: pid => (pid ? String(pid).trim() : ''),
-    loadPreparedBillingWithSheetFallback_: monthKey => preparedByMonth[monthKey] || null,
-    exportBankTransferDataForPrepared_: () => null,
-    generateInvoicePdfs: () => ({ billingMonth: '202405', files: [], missingPatientIds: [] }),
-    generateAggregateInvoicePdf: (entry, opts) => {
-      aggregateCalls.push({ entry, opts });
-      return { fileId: 'agg', patientId: entry && entry.patientId, nameKanji: entry && entry.nameKanji };
-    }
-  };
-
-  ctx.normalizeBillingMonthInput = value => ({
-    key: String(value || ''),
-    year: Number(String(value || '').slice(0, 4)) || 2024,
-    month: Number(String(value || '').slice(4, 6)) || 1
-  });
-  ctx.resolvePreviousBillingMonthKey_ = billingMonth => {
-    const normalized = ctx.normalizeBillingMonthKeySafe_(billingMonth);
-    if (!normalized) return '';
-    const year = Number(normalized.slice(0, 4));
-    const month = Number(normalized.slice(4, 6));
-    const prevMonth = month === 1 ? 12 : month - 1;
-    const prevYear = month === 1 ? year - 1 : year;
-    return String(prevYear).padStart(4, '0') + String(prevMonth).padStart(2, '0');
-  };
-
-  vm.createContext(ctx);
-  vm.runInContext(mainCode, ctx);
-
-  ctx.loadPreparedBillingWithSheetFallback_ = monthKey => preparedByMonth[monthKey] || null;
-  ctx.attachPreviousReceiptAmounts_ = payload => payload;
-  ctx.exportBankTransferDataForPrepared_ = () => null;
-  ctx.generateInvoicePdfs = () => ({ billingMonth: '202405', files: [], missingPatientIds: [] });
-  ctx.generateAggregateInvoicePdf = (entry, opts) => {
-    aggregateCalls.push({ entry, opts });
-    return { fileId: 'agg', patientId: entry && entry.patientId, nameKanji: entry && entry.nameKanji };
-  };
-
-  const result = ctx.generatePreparedInvoices_(preparedByMonth['202405']);
-
-  assert.ok(result && Array.isArray(result.files), 'invoice generation returns files');
-  // Aggregate invoices should be auto-generated for the confirmed "scheduled" state.
-  assert.strictEqual(aggregateCalls.length, 1, 'aggregate invoice is generated for scheduled entries');
-  const aggregateMonths = aggregateCalls[0] && aggregateCalls[0].opts && aggregateCalls[0].opts.aggregateMonths;
-  assert.deepStrictEqual(Array.from(new Set(aggregateMonths)), ['202404', '202405']);
-  assert.strictEqual(aggregateCalls[0].entry && aggregateCalls[0].entry.grandTotal, 9000);
-})();
-
-(function testAggregateSummaryPdfGeneratedForConfirmedEntries() {
-  const preparedByMonth = {
-    '202401': {
-      billingMonth: '202401',
-      billingJson: [{ patientId: 'P10', billingMonth: '202401', grandTotal: 1000 }],
-      bankFlagsByPatient: { P10: { af: true, ae: false } }
-    },
-    '202402': {
-      billingMonth: '202402',
-      billingJson: [{ patientId: 'P10', billingMonth: '202402', grandTotal: 2000 }],
-      bankFlagsByPatient: { P10: { af: false, ae: false } }
-    }
-  };
-
-  const aggregateCalls = [];
-  const ctx = {
-    console: { log: () => {}, warn: () => {} },
-    preparedByMonth,
-    CacheService: { getScriptCache: () => ({}) },
-    normalizeMoneyNumber_: value => Number(value) || 0,
-    billingLogger_: { log: () => {} },
-    normalizePreparedBilling_: payload => payload,
-    attachPreviousReceiptAmounts_: payload => payload,
-    normalizeBillingMonthKeySafe_: value => String(value || '').trim(),
-    billingNormalizePatientId_: pid => (pid ? String(pid).trim() : ''),
-    loadPreparedBillingWithSheetFallback_: monthKey => preparedByMonth[monthKey] || null,
-    exportBankTransferDataForPrepared_: () => null,
-    generateInvoicePdfs: () => ({ billingMonth: '202402', files: [], missingPatientIds: [] }),
-    generateAggregateInvoicePdf: (entry, opts) => {
-      aggregateCalls.push({ entry, opts });
-      return { fileId: 'agg', patientId: entry && entry.patientId, nameKanji: entry && entry.nameKanji };
-    }
-  };
-
-  ctx.normalizeBillingMonthInput = value => ({
-    key: String(value || ''),
-    year: Number(String(value || '').slice(0, 4)) || 2024,
-    month: Number(String(value || '').slice(4, 6)) || 1
-  });
-  ctx.resolvePreviousBillingMonthKey_ = billingMonth => {
-    const normalized = ctx.normalizeBillingMonthKeySafe_(billingMonth);
-    if (!normalized) return '';
-    const year = Number(normalized.slice(0, 4));
-    const month = Number(normalized.slice(4, 6));
-    const prevMonth = month === 1 ? 12 : month - 1;
-    const prevYear = month === 1 ? year - 1 : year;
-    return String(prevYear).padStart(4, '0') + String(prevMonth).padStart(2, '0');
-  };
-
-  vm.createContext(ctx);
-  vm.runInContext(mainCode, ctx);
-
-  ctx.loadPreparedBillingWithSheetFallback_ = monthKey => preparedByMonth[monthKey] || null;
-  ctx.attachPreviousReceiptAmounts_ = payload => payload;
-  ctx.exportBankTransferDataForPrepared_ = () => null;
-  ctx.generateInvoicePdfs = () => ({ billingMonth: '202402', files: [], missingPatientIds: [] });
-  ctx.generateAggregateInvoicePdf = (entry, opts) => {
-    aggregateCalls.push({ entry, opts });
-    return { fileId: 'agg', patientId: entry && entry.patientId, nameKanji: entry && entry.nameKanji };
-  };
-
-  const result = ctx.generatePreparedInvoices_(preparedByMonth['202402']);
-
-  assert.ok(result && Array.isArray(result.files), 'invoice generation returns files');
-  assert.strictEqual(aggregateCalls.length, 1, 'aggregate summary is generated for confirmed entries');
-  const aggregateMonths = aggregateCalls[0] && aggregateCalls[0].opts && aggregateCalls[0].opts.aggregateMonths;
-  assert.deepStrictEqual(Array.from(new Set(aggregateMonths)), ['202401', '202402']);
-})();
-
-console.log('aggregate billing from bank flags tests passed');
+  assert.strictEqual(entry.aggregateStatus, undefined);
+  assert.strictEqual(entry.grandTotal, 1500);
+  assert.strictEqual(entry.skipReceipt, undefined);
+})();  


### PR DESCRIPTION
## Summary
- keep aggregate receipt generation tied to unpaid history and explicit aggregate months while hiding receipts during aggregation
- remove aggregateStatus from aggregate decision so only unpaid/aggregate months drive invoice mode
- document Phase2 decisions by clarifying aggregate month enumeration responsibility and noting removal of implicit auto-aggregation tests

## Testing
- node tests/billingOutput.test.js
- node tests/aggregateBillingFromBankFlags.test.js && node tests/receiptAggregationFromBankSheet.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955c393023c83219b4593871d4c6a45)