### PR TITLE
Reflect bank `af` flag when resolving aggregateTargetMonths

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1282,7 +1282,8 @@ function resolveAggregateMonthsFromUnpaid_(billingMonth, patientId, options, pre
     : null;
   const currentFlags = prepared && prepared.bankFlagsByPatient && prepared.bankFlagsByPatient[pid];
   const currentUnpaid = !!(currentFlags && currentFlags.ae);
-  if (currentUnpaid) return [];
+  const currentAggregate = !!(currentFlags && currentFlags.af);
+  if (currentUnpaid && !currentAggregate) return [];
 
   const unpaidSet = new Set(unpaidHistory.map(normalizeBillingMonthKeySafe_));
   unpaidSet.add(monthKey);


### PR DESCRIPTION
### Motivation
- The aggregate target month selection should respect the bank aggregate checkbox (`af`) in addition to the unpaid flag (`ae`).
- When the current month has `af === true`, aggregation should be allowed to include the current month plus unpaid-history months if `resolveAggregateMonthsFromUnpaid_` yields results.
- When `af === false`, preserve the existing `ae`-based automatic aggregation behavior.
- Do not change display, UI, or data structures.

### Description
- Updated `resolveAggregateMonthsFromUnpaid_` in `src/main.gs` to detect the current bank aggregate flag via `currentFlags.af` and store it as `currentAggregate`.
- Replaced the early-return guard `if (currentUnpaid) return []` with `if (currentUnpaid && !currentAggregate) return []` so aggregation proceeds when `ae` is true but `af` is also true.
- No other logic, UI, or data structure changes were made.

### Testing
- No automated tests were executed for this change.
- Manual verification was not included in automated test runs.
- Existing code paths remain unchanged except for the modified guard in `resolveAggregateMonthsFromUnpaid_`.
- Recommend adding unit tests for `resolveAggregateMonthsFromUnpaid_` to cover combinations of `ae`/`af` in future work.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e0668ef408321b2996a82f1065f15)