### PR TITLE
Recalculate aggregate invoice totals across months

### DIFF
--- a/tests/billingInvoiceLayout.test.js
+++ b/tests/billingInvoiceLayout.test.js
@@ -184,6 +184,8 @@ function testAggregateInvoiceTemplateStacksPerMonth() {
 
   assert.deepStrictEqual(Array.from(data.receiptMonths || []), ['202501', '202502'], '合算対象は billingMonth より前の月に限定される');
   assert.strictEqual(data.aggregateMonthTotals.length, 2, '対象月の合計行のみが含まれる');
+  assert.strictEqual(data.aggregateMonthTotals[0].total, 1000, '合算対象月の前月繰越を含めて月別合計を再計算する');
+  assert.strictEqual(data.aggregateMonthTotals[1].total, 1350, '合算対象月の施術料・交通費を再計算する');
   assert.strictEqual(data.aggregateRemark, '01月・02月分 施術料金として', '合算対象月の備考が付与される');
   assert.strictEqual(data.chargeMonthLabel, '2025年03月', '請求対象月のラベルは billingMonth に基づく');
 }


### PR DESCRIPTION
### Motivation
- The aggregate invoice previously showed per-month remarks and receipts correctly but used only the billingMonth entry for detailed breakdowns, causing incorrect treatment/transport/total values when `aggregateTargetMonths` spanned multiple months.
- The change aims to use `aggregateTargetMonths` (e.g. `[202509, 202510]`) to fetch per-month visit/unit/transport values and include previous-month carryovers in month-level totals.
- Maintain the existing PDF layout and single-month behavior when only one month is targeted.
- Ensure previous receipt/carryover amounts are included in aggregate month totals instead of assuming a fixed "前月繰越 0円".

### Description
- Added `resolveAggregatePreparedBillingEntry_` to load a prepared billing entry for a given month and patient (with sheet fallback and cache support).
- Added `buildAggregateInvoiceBreakdowns_` to compute per-month `calculateInvoiceChargeBreakdown_` results, carry-overs, and aggregated totals across months.
- Updated `buildAggregateInvoiceTemplateData_`, `buildInvoiceTemplateData_`, and `buildBillingInvoiceHtml_` to use the new aggregate breakdowns so visits, unit price display, transport detail, per-month totals, and grand totals are recalculated when multiple months are aggregated.
- Updated tests in `tests/billingInvoiceLayout.test.js` to assert recalculated `aggregateMonthTotals` values include per-month carryovers and recalculated treatment/transport sums.

### Testing
- Ran `node tests/billingInvoiceLayout.test.js` and the suite passed successfully.
- Verified that aggregate template and HTML output include recalculated per-month totals and updated grand total in the invoice representation.
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960828d97ac83219617635bdf806c7f)