### PR TITLE
Use aggregate invoice PDF generation when applicable

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -1134,7 +1134,16 @@ function saveInvoicePdf(item, pdfBlob, options) {
 }
 
 function generateInvoicePdf(item, options) {
-  const blob = createInvoicePdfBlob_(item, options);
+  const billingMonth = item && item.billingMonth;
+  const initialReceipt = resolveInvoiceReceiptDisplay_(item);
+  const aggregateDecision = resolveAggregateInvoiceDecision_(item, initialReceipt, billingMonth);
+  const aggregateDecisionMonths = aggregateDecision && aggregateDecision.aggregateDecisionMonths
+    ? aggregateDecision.aggregateDecisionMonths
+    : [];
+  const shouldUseAggregateTemplate = !!(aggregateDecision && aggregateDecision.isAggregateInvoice);
+  const blob = shouldUseAggregateTemplate
+    ? createAggregateInvoicePdfBlob_(item, Object.assign({}, options, { aggregateMonths: aggregateDecisionMonths }))
+    : createInvoicePdfBlob_(item, options);
   return saveInvoicePdf(item, blob, options);
 }
 


### PR DESCRIPTION
### Motivation
- Ensure aggregate invoice template is used when the aggregate decision indicates an aggregate invoice.
- Previously `generateInvoicePdf` always invoked `createInvoicePdfBlob_` and did not respect `aggregateDecision.isAggregateInvoice`.

### Description
- Update `generateInvoicePdf` to call `resolveInvoiceReceiptDisplay_` and `resolveAggregateInvoiceDecision_` to determine the aggregate decision for the item.
- Extract `aggregateDecision.aggregateDecisionMonths` and set `shouldUseAggregateTemplate` when `aggregateDecision.isAggregateInvoice` is truthy.
- Branch to call `createAggregateInvoicePdfBlob_` with merged options including `{ aggregateMonths: aggregateDecisionMonths }` when appropriate, otherwise call `createInvoicePdfBlob_`.

### Testing
- No automated tests were executed for this change.
- Manual verification was not recorded in automated test logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69608dba7c0883219b554a8d7b0492c3)