### PR TITLE
Fix legacy previous receipt amount lookup

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1121,8 +1121,18 @@ function attachPreviousReceiptAmounts_(prepared, cache) {
       });
     }
 
+    const resolveLegacyPreviousReceiptAmount = () => {
+      if (!previousPrepared || !Array.isArray(previousPrepared.billingJson)) return 0;
+      const legacyEntry = previousPrepared.billingJson.find(item => normalizePid(item && item.patientId) === pid);
+      if (!legacyEntry) return 0;
+      if (legacyEntry.grandTotal != null && legacyEntry.grandTotal !== '') {
+        return normalizeMoneyNumber_(legacyEntry.grandTotal);
+      }
+      return normalizeMoneyNumber_(legacyEntry.billingAmount);
+    };
+
     const receiptBreakdown = useLegacyPreviousReceipt
-      ? [{ month: previousMonthKey, amount: resolveBillingAmountForMonthAndPatient_(previousMonthKey, pid, null, monthCache) }]
+      ? [{ month: previousMonthKey, amount: resolveLegacyPreviousReceiptAmount() }]
       : buildReceiptMonthBreakdownForEntry_(pid, receiptTargetMonths, previousPrepared || prepared, monthCache);
 
     return Object.assign({}, entry, {


### PR DESCRIPTION
### Motivation

- Fix a bug where the previous-month receipt amount becomes 0 for the normal pattern (no AE/AF) due to the legacy fallback using `resolveBillingAmountForMonthAndPatient_` which does not return the confirmed billed amount.
- Use the actual previous prepared billing data as the source of truth for legacy previous receipt amounts.
- Keep existing aggregation/uncollected logic, billing calculation, and PDF templates unchanged.
- Make a minimal change limited to the legacy branch of `attachPreviousReceiptAmounts_`.

### Description

- Add `resolveLegacyPreviousReceiptAmount` to locate the matching entry in `previousPrepared.billingJson` by normalized `patientId` and return `grandTotal` with a fallback to `billingAmount`.
- Replace the legacy branch usage of `resolveBillingAmountForMonthAndPatient_` with the new `resolveLegacyPreviousReceiptAmount()` so legacy receipts use the previous JSON row directly.
- The change is confined to the legacy previous-receipt path inside `attachPreviousReceiptAmounts_` and does not alter other receipt or billing calculations.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696353aac0648321a3b2f9844af96734)