### PR TITLE
Attach previous receipt amounts before aggregate invoice PDF generation

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -3435,7 +3435,10 @@ function generateAggregatedInvoice(billingMonth, options) {
   const aggregateMonths = normalizeAggregateInvoiceMonths_(mergedMonths, prepared, month.key);
 
   const monthCache = createBillingMonthCache_();
-  const aggregateContext = buildAggregateInvoicePdfContext_(entry, aggregateMonths, prepared, monthCache);
+  const receiptPrepared = attachPreviousReceiptAmounts_(prepared, monthCache);
+  const receiptEntry = (receiptPrepared && receiptPrepared.billingJson || [])
+    .find(row => billingNormalizePatientId_(row && row.patientId) === patientId) || entry;
+  const aggregateContext = buildAggregateInvoicePdfContext_(receiptEntry, aggregateMonths, receiptPrepared || prepared, monthCache);
   const file = generateAggregateInvoicePdf(aggregateContext, { billingMonth: month.key });
   return { billingMonth: month.key, patientId, aggregateMonths, file };
 }


### PR DESCRIPTION
### Motivation
- Aggregate invoice PDF generation used `prepared` data that did not include previous receipt amounts, causing prior-month receipt amounts to appear as 0 in PDFs.
- The code path that builds aggregate PDFs must use the enriched prepared payload which has previous receipt amounts attached so templates see correct `previousReceipt` data.

### Description
- Call `attachPreviousReceiptAmounts_(prepared, monthCache)` inside `generateAggregatedInvoice` before building the PDF context.
- Use the enriched prepared object (`receiptPrepared`) and the corresponding enriched entry (`receiptEntry`) when calling `buildAggregateInvoicePdfContext_`.
- Keep fallback to the original `entry`/`prepared` if no enriched data is available.

### Testing
- No automated tests were executed for this change.
- No test failures reported (no tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963551b1df88321b18e29b6cb178ad0)