### PR TITLE
Add dashboard data flow logging for setupIncomplete diagnostics

### DIFF
--- a/src/dashboard/api/getTasks.js
+++ b/src/dashboard/api/getTasks.js
@@ -26,6 +26,11 @@ function getTasks(options) {
   const setupIncomplete = !!(patientInfo && patientInfo.setupIncomplete)
     || !!(notesResult && notesResult.setupIncomplete)
     || !!(aiReports && aiReports.setupIncomplete);
+  if (typeof dashboardLogContext_ === 'function') {
+    dashboardLogContext_('getTasks:setupIncomplete', `patientInfo=${!!(patientInfo && patientInfo.setupIncomplete)} notes=${!!(notesResult && notesResult.setupIncomplete)} aiReports=${!!(aiReports && aiReports.setupIncomplete)}`);
+  } else if (typeof dashboardWarn_ === 'function') {
+    dashboardWarn_(`[getTasks:setupIncomplete] patientInfo=${!!(patientInfo && patientInfo.setupIncomplete)} notes=${!!(notesResult && notesResult.setupIncomplete)} aiReports=${!!(aiReports && aiReports.setupIncomplete)}`);
+  }
 
   const notesByPatient = notesResult && notesResult.notes ? notesResult.notes : {};
   const reportsByPatient = aiReports && aiReports.reports ? aiReports.reports : {};

--- a/src/dashboard/api/getTodayVisits.js
+++ b/src/dashboard/api/getTodayVisits.js
@@ -24,6 +24,11 @@ function getTodayVisits(options) {
   if (notesResult && Array.isArray(notesResult.warnings)) warnings.push.apply(warnings, notesResult.warnings);
   const setupIncomplete = !!(treatment && treatment.setupIncomplete)
     || !!(notesResult && notesResult.setupIncomplete);
+  if (typeof dashboardLogContext_ === 'function') {
+    dashboardLogContext_('getTodayVisits:setupIncomplete', `treatmentLogs=${!!(treatment && treatment.setupIncomplete)} notes=${!!(notesResult && notesResult.setupIncomplete)}`);
+  } else if (typeof dashboardWarn_ === 'function') {
+    dashboardWarn_(`[getTodayVisits:setupIncomplete] treatmentLogs=${!!(treatment && treatment.setupIncomplete)} notes=${!!(notesResult && notesResult.setupIncomplete)}`);
+  }
 
   const visits = [];
   logs.forEach(entry => {

--- a/src/dashboard/utils/sheetUtils.js
+++ b/src/dashboard/utils/sheetUtils.js
@@ -27,6 +27,7 @@ function dashboardResolveActiveUserEmail_() {
 
 function dashboardGetSpreadsheet_() {
   const activeUser = dashboardResolveActiveUserEmail_();
+  dashboardLogContext_('dashboardGetSpreadsheet', `start user=${activeUser || 'unknown'}`);
   if (typeof DASHBOARD_SPREADSHEET_ID !== 'undefined' && DASHBOARD_SPREADSHEET_ID) {
     try {
       if (typeof SpreadsheetApp !== 'undefined'
@@ -64,6 +65,7 @@ function dashboardGetSpreadsheet_() {
 
 function dashboardGetInvoiceRootFolder_() {
   const activeUser = dashboardResolveActiveUserEmail_();
+  dashboardLogContext_('dashboardGetInvoiceRootFolder', `start user=${activeUser || 'unknown'}`);
   if (typeof DASHBOARD_INVOICE_FOLDER_ID !== 'undefined' && DASHBOARD_INVOICE_FOLDER_ID) {
     try {
       if (typeof DriveApp !== 'undefined' && DriveApp && typeof DriveApp.getFolderById === 'function') {


### PR DESCRIPTION
### Motivation
- Make the execution flow of dashboard data collection visible to diagnose why the Dashboard shows no data.
- Expose the reasons that contribute to the `setupIncomplete` flag so the source of the condition can be identified.
- Instrument spreadsheet and Drive resolution paths to show whether the sheet/folder resolution succeeds and which user is used.
- Keep changes non-invasive and limited to logging to avoid altering runtime behavior.

### Description
- Added a `logContext` helper and multiple logs in `getDashboardData` to record start, component loads (`loadPatientInfo`, `loadNotes`, `loadAIReports`, `loadInvoices`, `loadTreatmentLogs`, `assignResponsible`, `loadUnpaidAlerts`, `getTasks`, `getTodayVisits`) and final `setupIncomplete` result.
- Instrumented `collectDashboardWarnings_` to log when an entry or specific warning triggers `setupIncomplete`.
- Logged boolean source flags used to compute `setupIncomplete` in `getTasks` and `getTodayVisits` to show which inputs (e.g. `patientInfo`, `notes`, `aiReports`, `treatmentLogs`) contributed.
- Added start/context logs in `dashboardGetSpreadsheet_` and `dashboardGetInvoiceRootFolder_` to surface resolution attempts and the active user.

### Testing
- No automated tests were executed for this log-only change.
- The change is limited to additional calls to `dashboardLogContext_`/`dashboardWarn_` and does not modify existing return values or control flow.
- Manual verification is expected by reviewing the emitted logs when `getDashboardData` is invoked in the target environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963603e9f188321a952521d90b225b8)