### PR TITLE
Disable dashboard caching in data loaders

### DIFF
--- a/src/dashboard/data/loadAIReports.js
+++ b/src/dashboard/data/loadAIReports.js
@@ -3,9 +3,7 @@
  * @return {{reports: Object<string, string>, warnings: string[]}}
  */
 function loadAIReports(options) {
-  const opts = options || {};
-  const fetchFn = () => loadAIReportsUncached_();
-  return dashboardCacheFetch_(dashboardCacheKey_('aiReports:v1'), fetchFn, DASHBOARD_CACHE_TTL_SECONDS, opts);
+  return loadAIReportsUncached_();
 }
 
 function loadAIReportsUncached_() {

--- a/src/dashboard/data/loadInvoices.js
+++ b/src/dashboard/data/loadInvoices.js
@@ -11,12 +11,7 @@ function loadInvoices(options) {
   const opts = options || {};
   const now = dashboardCoerceDate_(opts.now) || new Date();
   const fetchOptions = Object.assign({}, opts, { now });
-  const fetchFn = () => loadInvoicesUncached_(fetchOptions);
-  if (typeof dashboardCacheFetch_ === 'function') {
-    const keyMonth = dashboardFormatDate_(now, dashboardResolveTimeZone_(), 'yyyyMM');
-    return dashboardCacheFetch_(dashboardCacheKey_(`invoices:v1:${keyMonth}`), fetchFn, DASHBOARD_CACHE_TTL_SECONDS, fetchOptions);
-  }
-  return fetchFn();
+  return loadInvoicesUncached_(fetchOptions);
 }
 
 function loadInvoicesUncached_(options) {

--- a/src/dashboard/data/loadNotes.js
+++ b/src/dashboard/data/loadNotes.js
@@ -4,8 +4,7 @@
 function loadNotes(options) {
   const opts = options || {};
   const email = opts.email;
-  const fetchFn = () => loadNotesUncached_(opts);
-  const base = dashboardCacheFetch_(dashboardCacheKey_('notes:v1'), fetchFn, DASHBOARD_CACHE_TTL_SECONDS, opts);
+  const base = loadNotesUncached_(opts);
 
   const lastReadAt = loadHandoverLastRead_(email);
   const notes = {};

--- a/src/dashboard/data/loadPatientInfo.js
+++ b/src/dashboard/data/loadPatientInfo.js
@@ -3,8 +3,7 @@
  */
 function loadPatientInfo(options) {
   const opts = options || {};
-  const fetchFn = () => loadPatientInfoUncached_(opts);
-  return dashboardCacheFetch_(dashboardCacheKey_('patientInfo:v1'), fetchFn, DASHBOARD_CACHE_TTL_SECONDS, opts);
+  return loadPatientInfoUncached_(opts);
 }
 
 function loadPatientInfoUncached_(_options) {

--- a/src/dashboard/data/loadTreatmentLogs.js
+++ b/src/dashboard/data/loadTreatmentLogs.js
@@ -5,12 +5,7 @@ function loadTreatmentLogs(options) {
   const opts = options || {};
   const now = dashboardCoerceDate_(opts.now) || new Date();
   const fetchOptions = Object.assign({}, opts, { now });
-  const fetchFn = () => loadTreatmentLogsUncached_(fetchOptions);
-  if (typeof dashboardCacheFetch_ === 'function') {
-    const keyMonth = dashboardFormatDate_(now, dashboardResolveTimeZone_(), 'yyyyMM');
-    return dashboardCacheFetch_(dashboardCacheKey_(`treatmentLogs:v1:${keyMonth}`), fetchFn, DASHBOARD_CACHE_TTL_SECONDS, fetchOptions);
-  }
-  return fetchFn();
+  return loadTreatmentLogsUncached_(fetchOptions);
 }
 
 function loadTreatmentLogsUncached_(options) {

--- a/src/dashboard/data/loadUnpaidAlerts.js
+++ b/src/dashboard/data/loadUnpaidAlerts.js
@@ -11,13 +11,7 @@ function loadUnpaidAlerts(options) {
   const normalizedThreshold = normalizeUnpaidThreshold_(opts.consecutiveMonths);
   const now = dashboardCoerceDate_(opts.now) || new Date();
   const fetchOptions = Object.assign({}, opts, { consecutiveMonths: normalizedThreshold, now });
-  const fetchFn = () => loadUnpaidAlertsUncached_(fetchOptions);
-  return dashboardCacheFetch_(
-    dashboardCacheKey_(`unpaidAlerts:v1:${normalizedThreshold}`),
-    fetchFn,
-    DASHBOARD_CACHE_TTL_SECONDS,
-    fetchOptions
-  );
+  return loadUnpaidAlertsUncached_(fetchOptions);
 }
 
 function loadUnpaidAlertsUncached_(options) {


### PR DESCRIPTION
### Motivation
- Fix an undefined error that occurs when `dashboardCacheFetch_`/`dashboardCacheKey_` are not available to the server-side `getDashboardData` flow.
- Prevent server code from referencing frontend-only helpers by returning raw, uncached data from loaders.

### Description
- Bypass the dashboard cache helpers and call the uncached implementations directly for dashboard data loaders.
- Updated files: `src/dashboard/data/loadPatientInfo.js`, `src/dashboard/data/loadNotes.js`, `src/dashboard/data/loadAIReports.js`, `src/dashboard/data/loadInvoices.js`, `src/dashboard/data/loadTreatmentLogs.js`, and `src/dashboard/data/loadUnpaidAlerts.js`.
- Removed usages of `dashboardCacheFetch_` and `dashboardCacheKey_` in those loaders so each now returns the result of the corresponding `*Uncached_` function.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696368cbbd548321862b96846f8d9285)