### PR TITLE
Fix receipt breakdown fallback for past months

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1237,6 +1237,22 @@ function buildReceiptMonthBreakdownForEntry_(patientId, months, prepared, cache)
       const amount = amountByPatient[pid];
       if (Number.isFinite(amount)) {
         breakdown.push({ month: monthKey, amount });
+        return;
+      }
+    }
+
+    if (preparedMonthKey && Number(monthKey) < Number(preparedMonthKey)) {
+      const previousPrepared = getPreparedBillingForMonthCached_(monthKey, store);
+      if (previousPrepared && Array.isArray(previousPrepared.billingJson)) {
+        const match = previousPrepared.billingJson.find(item => normalizePid(item && item.patientId) === pid);
+        if (match) {
+          const amount = match.grandTotal != null && match.grandTotal !== ''
+            ? normalizeMoneyNumber_(match.grandTotal)
+            : normalizeMoneyNumber_(match.billingAmount);
+          if (Number.isFinite(amount)) {
+            breakdown.push({ month: monthKey, amount });
+          }
+        }
       }
     }
   });


### PR DESCRIPTION
### Motivation
- The receipt month breakdown skipped past months when neither bank withdrawal data nor the current `prepared.billingJson` contained the patient, resulting in empty/partial breakdowns.
- For months earlier than the current `prepared.billingMonth` we should fall back to the prepared billing payload of that past month rather than skipping the month.
- The change must be localized to `buildReceiptMonthBreakdownForEntry_` and avoid touching PDF or finalize logic.

### Description
- In `buildReceiptMonthBreakdownForEntry_` ensure the bank-withdrawal match returns early after adding the amount to avoid falling through.
- Add a fallback that when `monthKey < prepared.billingMonth` loads prior prepared billing via `getPreparedBillingForMonthCached_` and resolves the patient amount from `billingJson` using `grandTotal` with `billingAmount` as fallback.
- The change uses the existing `store` cache and `normalizeMoneyNumber_` to coerce amounts and only pushes months with finite numeric amounts.
- The change is a minimal edit in `src/main.gs` restricted to `buildReceiptMonthBreakdownForEntry_`.

### Testing
- No automated tests were executed as part of this change.
- The change was validated locally via static inspection and a commit was created modifying only `src/main.gs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69636945ba48832190246e566113cad6)