### PR TITLE
Restore global doGet entrypoint

### DIFF
--- a/.clasp.json
+++ b/.clasp.json
@@ -16,6 +16,7 @@
     "dashboard/api/getDashboardData.js",
     "dashboard/api/markAsRead.js",
     "dashboard/tests/dashboardMockData.gs",
-    "Code.js"
+    "Code.js",
+    "entrypoint.gs"
   ]
 }

--- a/src/entrypoint.gs
+++ b/src/entrypoint.gs
@@ -1,0 +1,23 @@
+/**
+ * Ensure the web app entrypoint doGet is always available in the global scope.
+ *
+ * Some deployments may omit files that declare doGet directly; this shim restores
+ * the global function and delegates to whichever handler is present.
+ */
+(function ensureGlobalDoGet() {
+  if (typeof globalThis === 'undefined') return;
+  if (typeof globalThis.doGet === 'function') return;
+
+  globalThis.doGet = function(e) {
+    if (typeof handleDashboardDoGet_ === 'function') {
+      const response = handleDashboardDoGet_(e);
+      if (response != null) return response;
+    }
+
+    if (typeof handleBillingDoGet_ === 'function') {
+      return handleBillingDoGet_(e);
+    }
+
+    throw new Error('doGet handler is not configured');
+  };
+})();


### PR DESCRIPTION
### Motivation
- Recent deploys can fail with "スクリプト関数が見つかりません: doGet" when the `doGet` entrypoint is removed or becomes out of scope. 
- Ensure a stable global `doGet` is always present so the web app can be redeployed without that runtime error. 
- Provide a safe delegation layer so existing billing and dashboard handlers continue to be used when present. 
- Ensure the shim file is included in the `clasp` push order so it is deployed reliably.

### Description
- Added `src/entrypoint.gs`, an IIFE that installs `globalThis.doGet` when absent and delegates handling to `handleDashboardDoGet_` then `handleBillingDoGet_` as appropriate. 
- The shim returns a non-null dashboard response if provided, otherwise falls back to billing, and throws an error if no handlers are configured. 
- Updated `.clasp.json` to include `entrypoint.gs` in the `filePushOrder` so the file is pushed during deployments. 
- No other application logic was modified; this is a compatibility shim to restore the global entry function.

### Testing
- No automated tests were executed as part of this change. 
- The repository contains unit tests that exercise `doGet` behavior such as `tests/dashboardDoGet.test.js` and `tests/billingMainIsolation.test.js`, which should be run in CI to validate the shim.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69636f7aa8488321aa722b83054ea310)