### PR TITLE
Fix doGet delegation for dashboard & billing handlers

### DIFF
--- a/.clasp.json
+++ b/.clasp.json
@@ -15,6 +15,7 @@
     "dashboard/api/getTodayVisits.js",
     "dashboard/api/getDashboardData.js",
     "dashboard/api/markAsRead.js",
+    "dashboard/main.gs",
     "dashboard/tests/dashboardMockData.gs",
     "Code.js",
     "entrypoint.gs"

--- a/src/dashboard/main.gs
+++ b/src/dashboard/main.gs
@@ -23,10 +23,6 @@ function handleDashboardDoGet_(e) {
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
 }
 
-function doGet(e) {
-  return handleDashboardDoGet_(e);
-}
-
 function shouldHandleDashboardRequest_(e) {
   const path = (e && e.pathInfo ? String(e.pathInfo) : '').replace(/^\/+|\/+$/g, '').toLowerCase();
   if (path === 'dashboard' || path === 'getdashboarddata') return true;

--- a/src/entrypoint.gs
+++ b/src/entrypoint.gs
@@ -1,9 +1,11 @@
 function doGet(e) {
   if (typeof handleDashboardDoGet_ === 'function') {
-    return handleDashboardDoGet_(e);
+    const response = handleDashboardDoGet_(e);
+    if (response) return response;
   }
   if (typeof handleBillingDoGet_ === 'function') {
-    return handleBillingDoGet_(e);
+    const response = handleBillingDoGet_(e);
+    if (response) return response;
   }
   throw new Error('doGet handler is not configured');
 }


### PR DESCRIPTION
### Motivation

- The web app raised `doGet handler is not configured` because delegated handlers were not always available at runtime under Apps Script global scope rules.
- A duplicate `doGet` in the dashboard module caused multiple global entry points and prevented the central entrypoint from delegating correctly.
- The delegation logic should only return when a delegated handler actually produces a response so that fallback/guards can run.

### Description

- Update `src/entrypoint.gs` so `doGet` calls `handleDashboardDoGet_` and `handleBillingDoGet_` but only `return`s when those handlers produce a non-falsy response.
- Remove the duplicate `doGet` from `src/dashboard/main.gs` so the global `doGet` lives only in the entrypoint.
- Add `dashboard/main.gs` to the `filePushOrder` in `.clasp.json` so the dashboard handler is included at runtime and available to the entrypoint.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69637574871c8321a27fa46303df4859)