### PR TITLE
Guard aggregate confirmation and previous-month receipt handling

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -414,6 +414,10 @@ function normalizeAggregateStatus_(status) {
   return normalized || '';
 }
 
+function isAggregateConfirmedByBankFlags_(item) {
+  return !!(item && item.bankFlags && item.bankFlags.af === true);
+}
+
 function resolveInvoiceReceiptDisplay_(item, options) {
   const hasPreviousReceiptSheet = resolveHasPreviousReceiptSheet_(item);
   const billingMonthKey = normalizeInvoiceMonthKey_(item && item.billingMonth);
@@ -428,7 +432,7 @@ function resolveInvoiceReceiptDisplay_(item, options) {
     ? normalizeAggregateMonthsForInvoice_(overrideMonths, billingMonthKey)
     : [];
   const aggregateStatus = normalizeAggregateStatus_(item && item.aggregateStatus);
-  const aggregateConfirmed = aggregateStatus === 'confirmed';
+  const aggregateConfirmed = aggregateStatus === 'confirmed' && isAggregateConfirmedByBankFlags_(item);
   const receiptMonths = aggregateDecisionMonths.length ? aggregateDecisionMonths : explicitReceiptMonths;
   const customReceiptRemark = item && item.receiptRemark ? String(item.receiptRemark) : '';
   const receiptRemark = customReceiptRemark || (receiptMonths.length > 1
@@ -883,7 +887,7 @@ function buildAggregateInvoiceTemplateData_(item, aggregateMonths) {
     ? billingNormalizePatientId_(item && item.patientId)
     : String(item && item.patientId || '').trim();
   const aggregateStatus = receipt ? receipt.aggregateStatus : normalizeAggregateStatus_(item && item.aggregateStatus);
-  const aggregateConfirmed = receipt ? receipt.aggregateConfirmed : aggregateStatus === 'confirmed';
+  const aggregateConfirmed = receipt ? receipt.aggregateConfirmed : (aggregateStatus === 'confirmed' && isAggregateConfirmedByBankFlags_(item));
   const basePreviousReceipt = buildInvoicePreviousReceipt_(item, receipt, months);
   const previousReceipt = item && item.previousReceipt
     ? Object.assign({}, basePreviousReceipt, item.previousReceipt)
@@ -940,7 +944,7 @@ function buildInvoiceTemplateData_(item) {
 
   const initialReceipt = resolveInvoiceReceiptDisplay_(item);
   const aggregateStatus = initialReceipt ? initialReceipt.aggregateStatus : normalizeAggregateStatus_(item && item.aggregateStatus);
-  const aggregateConfirmed = initialReceipt ? initialReceipt.aggregateConfirmed : aggregateStatus === 'confirmed';
+  const aggregateConfirmed = initialReceipt ? initialReceipt.aggregateConfirmed : (aggregateStatus === 'confirmed' && isAggregateConfirmedByBankFlags_(item));
   const monthCache = {};
   const aggregateDecision = resolveAggregateInvoiceDecision_(item, initialReceipt, billingMonth, { monthCache });
   const aggregateDecisionMonths = aggregateDecision && aggregateDecision.aggregateDecisionMonths


### PR DESCRIPTION
### Motivation
- Prevent invoices from showing "aggregate confirmed" or a previous receipt amount when the prior month is not finalized. 
- Avoid performing auto-aggregate logic or filling previous receipt amounts from unfinalized/partial prepared data. 
- Keep existing billing calculations and PDF templates unchanged while adding minimal guards. 

### Description
- Added helper functions `getPreparedBillingEntryForPatient_` and `isPreparedBillingEntryFinalizedForPatient_` in `src/main.gs` to query and check finalized status of prepared entries. 
- Prevented walking/using prior-month prepared data in `collectAggregateBankFlagMonthsForPatient_` and `resolveReceiptTargetMonthsFromBankFlags_` unless the previous month's entry for the patient is present and finalized. 
- Hardened `attachPreviousReceiptAmounts_` and `buildInvoicePdfContextForEntry_` in `src/main.gs` to skip previous-receipt lookups and breakdowns when the prior prepared entry is missing or unfinalized, and avoid treating missing previous amounts as zero. 
- Required explicit bank-flag confirmation for aggregate confirmation in `src/output/billingOutput.js` by adding `isAggregateConfirmedByBankFlags_` and gating `aggregateConfirmed` on `bankFlags.af === true`. 

### Testing
- No automated tests were run as part of this change. 
- Manual verification was not recorded in this PR description.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965b4e23284832185a86c724a6c7fef)