### PR TITLE
Guard aggregate confirmation by bank flag

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1564,6 +1564,10 @@ function applyAggregateInvoiceRulesFromBankFlags_(prepared, cache) {
   const transformed = normalized.billingJson.map(entry => {
     const pid = billingNormalizePatientId_(entry && entry.patientId);
     if (!pid) return entry;
+    const flags = bankFlagsByPatient && Object.prototype.hasOwnProperty.call(bankFlagsByPatient, pid)
+      ? bankFlagsByPatient[pid]
+      : null;
+    if (!(flags && flags.af === true)) return entry;
 
     // 自動合算では skipReceipt を立てず、合算済みであっても領収書対象とする。
     const targetMonths = resolveAggregateMonthsFromUnpaid_(monthKey, pid, { useLegacyAggregate: false }, normalized, monthCache);


### PR DESCRIPTION
### Motivation
- Automatic aggregate invoice flags were being set unconditionally which could mark entries as `confirmed` even when bank confirmation was not present.
- The change aims to restrict automatic aggregate confirmation to cases where the prepared billing explicitly indicates bank confirmation via `bankFlags.af === true`.

### Description
- Added a guard in `applyAggregateInvoiceRulesFromBankFlags_` to read `bankFlagsByPatient` and skip aggregation unless `flags.af === true` for the patient. 
- The modification is implemented in `src/main.gs` and returns the original entry when the bank flag check fails. 
- This prevents unconditional setting of `aggregateStatus: 'confirmed'` and related aggregate fields for patients without bank confirmation.

### Testing
- No automated tests were executed as part of this change.
- Existing behavior for aggregate PDF generation and invoice pipelines should remain unchanged for patients with `bankFlags.af === true` based on code inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965ced04b348321a3f2233bbce8ef09)