### PR TITLE
Separate auto aggregate flag from manual confirmation

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1579,7 +1579,7 @@ function applyAggregateInvoiceRulesFromBankFlags_(prepared, cache) {
     const aggregateRemark = formatAggregateBillingRemark_(targetMonths);
 
     return Object.assign({}, entry, {
-      aggregateStatus: 'confirmed',
+      aggregateAutoConfirmed: true,
       aggregateRemark,
       receiptMonths: targetMonths,
       billingAmount: aggregateTotal,


### PR DESCRIPTION
### Motivation

- Bank-driven auto aggregation (`bankFlags.af === true`) was forcing `aggregateStatus = 'confirmed'`, which re-enabled aggregate-confirmed behavior without manual confirmation.
- `aggregateStatus` should represent manual confirmation only, so automatic aggregation needs a separate marker to avoid changing manual confirmation state.

### Description

- Replaced setting `aggregateStatus: 'confirmed'` with a new `aggregateAutoConfirmed: true` in `applyAggregateInvoiceRulesFromBankFlags_` in `src/main.gs`.
- Kept the computed aggregate fields (`aggregateRemark`, `receiptMonths`, `billingAmount`, `total`, `grandTotal`, `aggregateTargetMonths`) and `skipReceipt: false` unchanged.
- The function now returns a transformed prepared billing JSON that marks rows as auto-aggregated without altering manual confirmation status.

### Testing

- No automated tests were run for this change.
- No test failures reported because no tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965d2c9a5fc8321bc34467de8171303)