### PR TITLE
Respect `bankFlags.af` for aggregate UI and finalization display

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -970,7 +970,12 @@ function normalizeAggregateStatus(status) {
   return normalized;
 }
 
+function isAggregateEligible(item) {
+  return !!(item && item.bankFlags && item.bankFlags.af === true);
+}
+
 function isBillingRowFinalized(item) {
+  if (!isAggregateEligible(item)) return false;
   const flag = item && item.billingFinalized;
   return flag === true || flag === 'true' || flag === 1 || flag === '1';
 }
@@ -997,6 +1002,7 @@ function resolveAggregateTargetMonths(item) {
 }
 
 function renderAggregateStatusBadge(item) {
+  if (!isAggregateEligible(item)) return '';
   const status = normalizeAggregateStatus(item && item.aggregateStatus);
   const targetMonths = resolveAggregateTargetMonths(item);
   const targetLabel = targetMonths
@@ -1026,6 +1032,7 @@ function renderAggregateStatusBadge(item) {
 }
 
 function renderReceiptStatusBadge(item) {
+  if (!isAggregateEligible(item)) return '';
   const finalized = isBillingRowFinalized(item);
   const status = normalizeReceiptStatus(item && item.receiptStatus);
   const aggregateLabel = status === 'AGGREGATE'
@@ -1191,6 +1198,7 @@ function calculateBillingSummary(rows) {
 function calculateAggregateStatusCounts(rows) {
   return (rows || []).reduce((acc, row) => {
     if (!row || typeof row !== 'object') return acc;
+    if (!isAggregateEligible(row)) return acc;
     const aggregateStatus = normalizeAggregateStatus(row.aggregateStatus);
     if (aggregateStatus === 'scheduled') acc.scheduled += 1;
     if (aggregateStatus === 'confirmed') acc.confirmed += 1;


### PR DESCRIPTION
### Motivation
- Prevent rows with `bankFlags.af === false` from being treated as aggregate candidates or shown as locked/finalized in the billing UI.
- Ensure UI-only behavior change without modifying GAS logic or backend aggregate rules.

### Description
- Added `isAggregateEligible(item)` helper that returns true only when `item.bankFlags.af === true`.
- Guarded `isBillingRowFinalized` to return `false` when a row is not aggregate-eligible so finalized locks do not apply to `af=false` rows.
- Early-returned empty output in `renderAggregateStatusBadge` and `renderReceiptStatusBadge` when a row is not aggregate-eligible so badges are hidden for `af=false` rows.
- Filtered out non-eligible rows in `calculateAggregateStatusCounts` so aggregate counts only include `af === true` rows.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965defc4f7483219177e3855a98ac68)