### PR TITLE
Remove billing finalization state from bank flow

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -2853,29 +2853,6 @@ function generateBankWithdrawalSheetFromCache(billingMonth) {
   });
 }
 
-function confirmBankWithdrawalDataReady(billingMonth) {
-  const month = normalizeBillingMonthInput(billingMonth);
-  const loaded = loadPreparedBillingWithSheetFallback_(month.key, { withValidation: true, restoreCache: true });
-  const prepared = normalizePreparedBilling_(loaded && loaded.prepared);
-  const validation = loaded && loaded.validation ? loaded.validation : null;
-
-  if (!prepared || !prepared.billingJson || (validation && validation.ok === false)) {
-    throw new Error('請求データが未集計です。先に「請求データ集計」を実行してください。');
-  }
-
-  ensureBankWithdrawalSheet_(month, {
-    refreshFromTemplate: false,
-    billingJson: prepared && prepared.billingJson,
-    bankRecords: prepared && prepared.bankRecords
-  });
-  const sheetSummary = summarizeBankWithdrawalSheet_(month);
-
-  return summarizeBankWithdrawalState_(month, prepared, sheetSummary, {
-    ready: true,
-    validation
-  });
-}
-
 function applyBankWithdrawalUnpaidFromUi(billingMonth) {
   const result = applyBankWithdrawalUnpaidEntries(billingMonth);
   const summary = summarizeBankWithdrawalSheet_(billingMonth);
@@ -4003,7 +3980,7 @@ function updateBillingReceiptStatus(billingMonth, options) {
     }
 
     if (!month) {
-      throw new Error('銀行データを出力できません。請求月が指定されていません。先に請求データを集計・確定してください。');
+      throw new Error('銀行データを出力できません。請求月が指定されていません。先に請求データを集計してください。');
     }
 
     if (!validation || !validation.ok || !normalizedPrepared || !Array.isArray(normalizedPrepared.billingJson)) {
@@ -4042,13 +4019,13 @@ function resolveBankExportErrorMessage_(validation) {
     return '銀行データを生成できません。繰越金データを確認してください。';
   }
   if (missingReasons.indexOf(reason) >= 0 || !reason) {
-    return '銀行データを出力できません。請求データが見つかりません。先に請求データを集計・確定してください。';
+    return '銀行データを出力できません。請求データが見つかりません。先に請求データを集計してください。';
   }
   if (corruptReasons.indexOf(reason) >= 0) {
     return '銀行データを生成できません。請求データが破損しています。再集計してください。';
   }
   if (reason === 'billingMonth mismatch') {
-    return '銀行データを生成できません。請求月が一致する請求データを集計・確定してください。';
+    return '銀行データを生成できません。請求月が一致する請求データを集計してください。';
   }
   return '銀行データを生成できません。請求データは存在しますが、検証に失敗しました。';
 }

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -29,7 +29,6 @@ const bankFlowState = {
   error: '',
   aggregation: null,
   sheet: null,
-  finalized: null,
   unpaid: null,
   targetMonth: ''
 };
@@ -451,7 +450,6 @@ function formatDateTimeDisplay(value) {
 
 function getBankSheetSummary() {
   if (bankFlowState.sheet && bankFlowState.sheet.sheetSummary) return bankFlowState.sheet.sheetSummary;
-  if (bankFlowState.finalized && bankFlowState.finalized.sheetSummary) return bankFlowState.finalized.sheetSummary;
   if (bankFlowState.aggregation && bankFlowState.aggregation.sheetSummary) return bankFlowState.aggregation.sheetSummary;
   return null;
 }
@@ -460,7 +458,6 @@ function updateBankControls() {
   const monthInput = qs('bankWithdrawalMonth');
   const aggregateBtn = qs('bankAggregateBtn');
   const sheetBtn = qs('bankSheetBtn');
-  const finalizeBtn = qs('bankFinalizeBtn');
   const unpaidBtn = qs('bankUnpaidBtn');
   const loading = bankFlowState.loading;
   const selectedMonth = getBankTargetMonth();
@@ -495,12 +492,6 @@ function updateBankControls() {
     unpaidBtn.disabled = disabled;
     unpaidBtn.setAttribute('aria-busy', loading ? 'true' : 'false');
     unpaidBtn.title = disabled && !hasSheet ? '銀行引落シート生成後に実行できます' : '';
-  }
-  if (finalizeBtn) {
-    const disabled = loading || !hasMonth || !hasAggregation;
-    finalizeBtn.disabled = disabled;
-    finalizeBtn.setAttribute('aria-busy', loading ? 'true' : 'false');
-    finalizeBtn.title = disabled && !hasAggregation ? '先に「請求データ集計」を実行してください' : '';
   }
   renderBankFlowSummary();
 }
@@ -540,11 +531,6 @@ function renderBankFlowDetail() {
       if (summary.unpaidChecked) {
         lines.push(`未回収チェック: ${summary.unpaidChecked} 件`);
       }
-    }
-    if (bankFlowState.finalized) {
-      const finalized = bankFlowState.finalized;
-      const summary = finalized.sheetSummary || {};
-      lines.push(`確定済み: ${finalized.billingMonth || ''}（行数 ${summary.rows || 0}）`);
     }
     if (bankFlowState.unpaid) {
       const unpaid = bankFlowState.unpaid;
@@ -1760,7 +1746,6 @@ function handleBankFlowAggregation() {
     .withSuccessHandler(function(result) {
       bankFlowState.aggregation = result || null;
       bankFlowState.sheet = null;
-      bankFlowState.finalized = null;
       bankFlowState.status = '請求データ集計が完了しました。銀行引落シート生成へ進んでください。';
       bankFlowState.loading = false;
       renderBankFlowDetail();
@@ -1798,29 +1783,6 @@ function handleBankSheetGeneration() {
       setBankError('銀行引落シート生成に失敗しました', err);
     })
     .generateBankWithdrawalSheetFromCache(ym);
-}
-
-function handleBankFinalize() {
-  const ym = getBankTargetMonth();
-  if (!ym) {
-    alert('対象月を入力してください (YYYY-MM)');
-    return;
-  }
-  bankFlowState.targetMonth = ym;
-  setBankLoading(true, '確定処理中…');
-  google.script.run
-    .withSuccessHandler(function(result) {
-      bankFlowState.finalized = result || null;
-      bankFlowState.status = '当月の銀行引落データを確定としてマークしました。';
-      bankFlowState.loading = false;
-      markReaggregationRequired(ym);
-      renderBankFlowDetail();
-      updateBankControls();
-    })
-    .withFailureHandler(function(err) {
-      setBankError('確定処理に失敗しました', err);
-    })
-    .confirmBankWithdrawalDataReady(ym);
 }
 
 function handleBankUnpaidApply() {


### PR DESCRIPTION
### Motivation

- Remove the legacy "確定 / finalized" state from billing bank withdrawal flows to simplify state model and avoid UI locks and misleading displays.
- Treat prepared billing / aggregation and `bankFlags.af` as the single source of truth for aggregation/合算 behavior.
- Make bank sheet generation, unpaid application and PDF/export operations always available without a separate finalization step.

### Description

- Removed `bankFlowState.finalized` tracking and all UI references (removed finalize button logic and `handleBankFinalize`), and stopped rendering finalized summary lines in `renderBankFlowDetail` in `src/main.js.html`.
- Dropped the server-side finalization endpoint `confirmBankWithdrawalDataReady` from `src/main.gs` and its client invocations so there's no finalize RPC path remaining.
- Updated bank export / error messages in `resolveBankExportErrorMessage_` and related error paths to remove wording that required "集計・確定" and instead instruct only to run `集計` (aggregation).
- Kept all calculation logic (e.g. `finalizeInvoiceAmountDataForPdf_`) intact and preserved unpaid/apply/export flows (`generateBankWithdrawalSheetFromCache`, `applyBankWithdrawalUnpaidFromUi`, etc.).

### Testing

- No automated tests were executed for this change.
- Basic static checks performed by code edit and commit succeeded (no runtime tests run).
- Manual/interactive verification is recommended for the bank withdrawal UI path and export error messages after deployment.
- Ensure callers relying on `confirmBankWithdrawalDataReady` are removed or replaced before publishing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965e97c6610832192e6ab7595439a16)