### PR TITLE
Keep receipt months for af bank flags in prepared billing

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1106,14 +1106,6 @@ function attachPreviousReceiptAmounts_(prepared, cache) {
       && !(previousFlags && previousFlags.af);
 
     if (receiptTargetMonths.length > 1) {
-      if (!hasPreviousReceiptSheet && receiptTargetMonths.indexOf(previousMonthKey) >= 0) {
-        return Object.assign({}, entry, {
-          hasPreviousReceiptSheet: false,
-          receiptMonths: [],
-          receiptRemark: '',
-          receiptMonthBreakdown: []
-        });
-      }
       const receiptBreakdown = buildReceiptMonthBreakdownForEntry_(pid, receiptTargetMonths, previousPrepared || prepared, monthCache);
       const aggregateRemark = formatAggregateReceiptDescription_(receiptTargetMonths);
       const previousReceipt = entry && entry.previousReceipt ? entry.previousReceipt : {
@@ -1132,7 +1124,6 @@ function attachPreviousReceiptAmounts_(prepared, cache) {
     if (!receiptTargetMonths.length) {
       return Object.assign({}, entry, {
         hasPreviousReceiptSheet,
-        receiptMonths: [],
         receiptRemark: '',
         receiptMonthBreakdown: hasPreviousReceiptSheet ? (entry && entry.receiptMonthBreakdown) : []
       });
@@ -1141,7 +1132,6 @@ function attachPreviousReceiptAmounts_(prepared, cache) {
     if (!hasPreviousReceiptSheet && receiptTargetMonths[0] === previousMonthKey) {
       return Object.assign({}, entry, {
         hasPreviousReceiptSheet: false,
-        receiptMonths: [],
         receiptRemark: '',
         receiptMonthBreakdown: []
       });
@@ -1416,9 +1406,6 @@ function resolveReceiptTargetMonthsFromBankFlags_(patientId, currentMonth, prepa
   const monthKey = normalizeBillingMonthKeySafe_(currentMonth);
   const pid = billingNormalizePatientId_(patientId);
   if (!monthKey || !pid) return [];
-
-  const currentFlags = prepared && prepared.bankFlagsByPatient && prepared.bankFlagsByPatient[pid];
-  if (currentFlags && currentFlags.af) return [];
 
   const previousMonthKey = resolvePreviousBillingMonthKey_(monthKey);
   if (!previousMonthKey) return [];


### PR DESCRIPTION
### Motivation
- Prevent entries with bank flag `af` from losing their `receiptMonths` during prepared-data enrichment so historical receipt targets are preserved.
- Ensure receipt target resolution uses prior unpaid history plus the current month even when the current prepared entry has `af=true`.
- Keep changes minimal and constrained to the prepared-generation layer without altering UI or other display logic.

### Description
- Remove the early `af` short-circuit in `resolveReceiptTargetMonthsFromBankFlags_` so the function can return past months plus the current month instead of `[]` when `af` is set.
- Stop clearing `receiptMonths` in `attachPreviousReceiptAmounts_` by removing branches that overwrote or emptied `receiptMonths` when `af=true` and by respecting explicit `receiptMonths` from `prepared.billingJson`.
- Preserve aggregate/receipt remark and breakdown behavior while ensuring multi-month aggregate cases still build breakdowns and set `receiptMonths` appropriately using `buildReceiptMonthBreakdownForEntry_` and related helpers.

### Testing
- No automated tests were executed as part of this change.
- Static inspection and local file edits were performed and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965edcb4c808321a1728ac7480383c8)