### PR TITLE
Respect aggregate flag when normalizing past billing/invoice months

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -559,6 +559,7 @@ function normalizePastBillingMonths_(months, billingMonth) {
   const monthList = Array.isArray(months) ? months : [];
   const billingKey = normalizeBillingMonthKeySafe_(billingMonth);
   const billingNum = Number(billingKey) || 0;
+  const isAggregate = monthList.length > 1;
   const seen = new Set();
   const normalized = [];
 
@@ -566,7 +567,10 @@ function normalizePastBillingMonths_(months, billingMonth) {
     const ym = normalizeBillingMonthKeySafe_(value);
     if (!ym || seen.has(ym)) return;
     const ymNum = Number(ym) || 0;
-    if (billingNum && ymNum >= billingNum) return;
+    if (billingNum) {
+      if (ymNum > billingNum) return;
+      if (!isAggregate && ymNum === billingNum) return;
+    }
     seen.add(ym);
     normalized.push(ym);
   });

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -379,11 +379,11 @@ function normalizeReceiptMonths_(months) {
   return normalized;
 }
 
-function normalizePastInvoiceMonths_(months, billingMonth) {
+function normalizePastInvoiceMonths_(months, billingMonth, allowAggregate) {
   const list = Array.isArray(months) ? months : [];
   const billingKey = normalizeInvoiceMonthKey_(billingMonth);
   const billingNum = Number(billingKey) || 0;
-  const isAggregate = list.length > 1;
+  const isAggregate = allowAggregate !== false && list.length > 1;
   const seen = new Set();
   const normalized = [];
 
@@ -413,9 +413,11 @@ function isAggregateConfirmedByBankFlags_(item) {
 
 function resolveInvoiceReceiptDisplay_(item, options) {
   const billingMonthKey = normalizeInvoiceMonthKey_(item && item.billingMonth);
+  const aggregateEligible = isAggregateConfirmedByBankFlags_(item);
   const explicitReceiptMonths = normalizePastInvoiceMonths_(
     normalizeReceiptMonths_(item && item.receiptMonths),
-    billingMonthKey
+    billingMonthKey,
+    aggregateEligible
   );
   const overrideMonths = options && Array.isArray(options.aggregateMonths)
     ? options.aggregateMonths
@@ -423,7 +425,6 @@ function resolveInvoiceReceiptDisplay_(item, options) {
   const aggregateDecisionMonths = overrideMonths.length
     ? normalizeAggregateMonthsForInvoice_(overrideMonths, billingMonthKey)
     : [];
-  const aggregateEligible = isAggregateConfirmedByBankFlags_(item);
   const aggregateStatus = aggregateEligible ? normalizeAggregateStatus_(item && item.aggregateStatus) : '';
   const aggregateConfirmed = aggregateEligible;
   const receiptMonths = aggregateDecisionMonths.length ? aggregateDecisionMonths : explicitReceiptMonths;


### PR DESCRIPTION
### Motivation
- Resolve inconsistency between aggregate (合算) behavior and single-month logic in past-month normalization functions.
- Ensure aggregate inclusion is only allowed when the bank aggregate permission flag (`bankFlags.af`) indicates eligibility.
- Allow the current billing month to be retained for aggregated multi-month receipts/invoices while preserving previous exclusion for single-month cases.

### Description
- Updated `src/main.gs` in `normalizePastBillingMonths_` to set `isAggregate` when `months.length > 1` and only exclude the billing month for non-aggregate cases.
- Changed `src/output/billingOutput.js` to add an `allowAggregate` parameter to `normalizePastInvoiceMonths_` and make `isAggregate` depend on `allowAggregate !== false && list.length > 1`.
- Modified `resolveInvoiceReceiptDisplay_` to compute `aggregateEligible` via `isAggregateConfirmedByBankFlags_` and pass it into `normalizePastInvoiceMonths_`, gating aggregate behavior on `bankFlags.af`.
- Files modified: `src/main.gs`, `src/output/billingOutput.js`.

### Testing
- No automated tests were executed for this change.
- Manual validation is recommended to confirm aggregate inclusion behavior when `bankFlags.af` is true and single-month exclusion when it is false.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965efff81d08321b11f85130577d6f3)