### PR TITLE
Fix `resolveReceiptTargetMonthsFromBankFlags_` to honor current `af` when previous `ae`

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1417,8 +1417,13 @@ function resolveReceiptTargetMonthsFromBankFlags_(patientId, currentMonth, prepa
   const previousPrepared = getPreparedBillingForMonthCached_(previousMonthKey, cache);
   if (!getPreparedBillingEntryForPatient_(previousPrepared, pid)) return [];
   const previousFlags = previousPrepared && previousPrepared.bankFlagsByPatient && previousPrepared.bankFlagsByPatient[pid];
+  const currentFlags = prepared && prepared.bankFlagsByPatient && prepared.bankFlagsByPatient[pid];
 
-  if (previousFlags && previousFlags.ae) return [];
+  if (previousFlags && previousFlags.ae) {
+    if (!(currentFlags && currentFlags.af)) return [];
+    const unpaidMonths = collectAggregateBankFlagMonthsForPatient_(previousMonthKey, pid, null, cache);
+    return normalizePastBillingMonths_(unpaidMonths.concat(previousMonthKey), monthKey);
+  }
 
   if (previousFlags && previousFlags.af) {
     const unpaidMonths = collectAggregateBankFlagMonthsForPatient_(previousMonthKey, pid, null, cache);


### PR DESCRIPTION
### Motivation
- When the previous month had `bankFlags.ae` (unpaid) but the current month has `bankFlags.af` (aggregate), the function should return the aggregate target months instead of immediately returning `[]`.

### Description
- In `resolveReceiptTargetMonthsFromBankFlags_` add `currentFlags` and change the `previousFlags.ae` branch to return the collected aggregate months when `currentFlags.af` is true, otherwise return `[]`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966f8decf7c832193c4a5cc45b3859f)