### PR TITLE
Fix receipt target month fallback for AF bank flags

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1427,7 +1427,7 @@ function resolveReceiptTargetMonthsFromBankFlags_(patientId, currentMonth, prepa
 
   if (previousFlags && previousFlags.af) {
     const unpaidMonths = collectAggregateBankFlagMonthsForPatient_(previousMonthKey, pid, null, cache);
-    if (!unpaidMonths.length) return [];
+    if (!unpaidMonths.length) return normalizePastBillingMonths_([previousMonthKey], monthKey);
     return normalizePastBillingMonths_(unpaidMonths.concat(previousMonthKey), monthKey);
   }
 


### PR DESCRIPTION
### Motivation
- Ensure that when the previous month has AF bank flags but no aggregated unpaid months, the previous month is still included as a receipt target instead of returning an empty set.

### Description
- Update `resolveReceiptTargetMonthsFromBankFlags_` in `src/main.gs` to return `normalizePastBillingMonths_([previousMonthKey], monthKey)` when `collectAggregateBankFlagMonthsForPatient_` returns an empty array in the AF branch.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966fc770788832180276b7e372bbd8e)