### PR TITLE
Fix receipt target month filtering for bank flags

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1415,7 +1415,6 @@ function resolveReceiptTargetMonthsFromBankFlags_(patientId, currentMonth, prepa
   if (!previousMonthKey) return [];
 
   const previousPrepared = getPreparedBillingForMonthCached_(previousMonthKey, cache);
-  if (!getPreparedBillingEntryForPatient_(previousPrepared, pid)) return [];
   const previousFlags = previousPrepared && previousPrepared.bankFlagsByPatient && previousPrepared.bankFlagsByPatient[pid];
   const currentFlags = prepared && prepared.bankFlagsByPatient && prepared.bankFlagsByPatient[pid];
 


### PR DESCRIPTION
### Motivation
- Fix bug where `resolveReceiptTargetMonthsFromBankFlags_` excluded the previous month when `getPreparedBillingEntryForPatient_` was missing, even though inclusion should be determined only by AE/AF flags.

### Description
- Remove the early return that called `getPreparedBillingEntryForPatient_` inside `resolveReceiptTargetMonthsFromBankFlags_` so previous months are evaluated solely by bank flag logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966ffb8ac2c832197d80296c1b162b1)