### PR TITLE
Enforce AE/AF-only receipt rules and restrict aggregation to AF-next-month

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -419,32 +419,22 @@ function resolveInvoiceReceiptDisplay_(item, options) {
     billingMonthKey,
     aggregateEligible
   );
-  const overrideMonths = options && Array.isArray(options.aggregateMonths)
-    ? options.aggregateMonths
-    : [];
-  const aggregateDecisionMonths = overrideMonths.length
-    ? normalizeAggregateMonthsForInvoice_(overrideMonths, billingMonthKey)
-    : [];
   const aggregateStatus = aggregateEligible ? normalizeAggregateStatus_(item && item.aggregateStatus) : '';
   const aggregateConfirmed = aggregateEligible;
-  const receiptMonths = aggregateDecisionMonths.length ? aggregateDecisionMonths : explicitReceiptMonths;
+  const receiptMonths = explicitReceiptMonths;
   const customReceiptRemark = item && item.receiptRemark ? String(item.receiptRemark) : '';
   const receiptRemark = customReceiptRemark || (receiptMonths.length > 1
     ? formatAggregatedReceiptRemark_(receiptMonths)
     : '');
-  const receiptStatus = item && item.receiptStatus ? String(item.receiptStatus).toUpperCase() : '';
-  const shouldHideByStatus = receiptStatus === 'UNPAID' || receiptStatus === 'HOLD';
-  const visible = !shouldHideByStatus && !item.skipReceipt && receiptMonths.length > 0;
-  const receiptMonthsSource = aggregateDecisionMonths.length
-    ? 'aggregateDecisionMonths'
-    : (receiptMonths.length ? 'explicit' : 'none');
+  const visible = receiptMonths.length > 0;
+  const receiptMonthsSource = receiptMonths.length ? 'explicit' : 'none';
 
   return {
     visible,
     receiptRemark,
     receiptMonths,
     explicitReceiptMonths,
-    aggregateDecisionMonths,
+    aggregateDecisionMonths: [],
     receiptMonthsSource,
     aggregateStatus,
     aggregateConfirmed


### PR DESCRIPTION
### Motivation
- Align receipt visibility and aggregation strictly with bank flags so only `AE`/`AF` drive behavior and AF never produces receipts in its own month.
- Ensure aggregation is only applied in the month after an `AF` month and that aggregated target months consist solely of AE-held months plus the AF month.

### Description
- Update `resolveInvoiceModeFromBankFlags_` to treat any current-month `AE`/`AF` as `skip` and to return `aggregate` only when the previous month has `AF`, collecting unpaid months from the previous month via `collectAggregateBankFlagMonthsForPatient_`.
- Replace legacy/extra aggregation branches in `resolveAggregateMonthsFromUnpaid_` with AE/AF-only rules that block aggregation for current AE/AF months and require previous-month `AF` before returning normalized unpaid months plus the AF month.
- Change `resolveReceiptTargetMonthsFromBankFlags_` to return `[]` for current-month `AE`/`AF`, to return aggregated unpaid months when previous month has `AF`, to return `[]` when previous month has `AE`, and to default to the single previous month when no AE/AF flags exist.
- Simplify `attachPreviousReceiptAmounts_` to compute `receiptTargetMonths` only from `resolveReceiptTargetMonthsFromBankFlags_`, explicitly clear `receiptMonths` when none are resolved, and retain legacy previous-receipt amount logic only for the single-previous-month legacy case.
- Harden `applyAggregateInvoiceRulesFromBankFlags_` to sanitize entries for AE/AF patients, require previous-month `AF` to compute aggregate totals, and clear `receiptMonths` when aggregate targets are insufficient.
- Simplify output in `resolveInvoiceReceiptDisplay_` to use only computed `receiptMonths`, remove manual aggregate overrides, set `aggregateDecisionMonths` to `[]`, and make visibility solely `receiptMonths.length > 0`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696707d6863883219d70b133b2e790a4)