### PR TITLE
Add guarded receipt-debug logging to trace receiptMonths selection (issue 1076)

### DIFF
--- a/docs/issue-1076-analysis.md
+++ b/docs/issue-1076-analysis.md
@@ -1,0 +1,14 @@
+# Issue 1076 調査メモ（receipt-debug ログ前提）
+
+## 背景
+AE/AF 未設定でも前月分領収書が出る経路を特定するため、`[receipt-debug]` ログを `receiptMonths` 設定直前に追加し、患者 ID を限定できるガード（`BILLING_DEBUG_PID`）を用意しました。ログには `currentFlags` / `previousFlags` と `receiptTargetMonths` / `receiptMonths` を出力する想定です。
+
+## ログから読み取れる注入経路（想定）
+`resolveReceiptTargetMonthsFromBankFlags_` の判定は以下のため、**現月・前月とも AE/AF が未設定**の場合に「前月のみ」が `receiptTargetMonths` として返されます。
+
+1. 現月に `ae`/`af` がある場合は `receiptTargetMonths = []`。
+2. 前月に `af` がある場合は、未収合算対象月（`collectAggregateBankFlagMonthsForPatient_`）+ 前月を `receiptTargetMonths` にします。
+3. 前月に `ae` がある場合は `receiptTargetMonths = []`。
+4. 上記いずれでもない場合は **`receiptTargetMonths = [previousMonthKey]`**。
+
+このため **AE/AF 未設定でも前月が入る**主要経路は、`resolveReceiptTargetMonthsFromBankFlags_` の「デフォルト分岐（4）」であると結論づけられます。ここで生成された `receiptTargetMonths` が `attachPreviousReceiptAmounts_` によって `receiptMonths` としてセットされ、最終的に `finalizeInvoiceAmountDataForPdf_` の `receiptMonths` に伝播します。


### PR DESCRIPTION
### Motivation

- Investigate why previous-month receipts are set even when `ae`/`af` flags are not present by emitting targeted debug logs immediately before `receiptMonths` is assigned.
- Restrict noisy logging to a single patient via a guard so developers can reproduce the decision path for a specific `patientId` without flooding logs.

### Description

- Add a `BILLING_DEBUG_PID` constant and defensive helpers `shouldLogReceiptDebug_` and `logReceiptDebug_` to emit guarded `[receipt-debug]` entries.
- Instrument `attachPreviousReceiptAmounts_`, `resolveReceiptTargetMonthsFromBankFlags_`, and `applyAggregateInvoiceRulesFromBankFlags_` to log `currentFlags`, `previousFlags`, and `receiptTargetMonths` at the point `receiptMonths` would be set.
- Instrument `finalizeInvoiceAmountDataForPdf_` to log the final `receiptMonths` (and related flags) used for PDF generation.
- Add `docs/issue-1076-analysis.md` summarizing the inferred injection path from the logged decision flow and concluding the default branch in `resolveReceiptTargetMonthsFromBankFlags_` is the primary route that inserts the previous month.

### Testing

- No automated tests were run as part of this change; the patch only adds guarded logging and documentation.
- Manual inspection ensured the new logging calls are guarded by `BILLING_DEBUG_PID` and use existing logging facilities when available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967184139148321aaed427dc6d9de9c)