### PR TITLE
Do not default to previous month when AE/AF flags are unset

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1489,7 +1489,7 @@ function resolveReceiptTargetMonthsFromBankFlags_(patientId, currentMonth, prepa
     return [];
   }
 
-  const receiptTargetMonths = normalizePastBillingMonths_([previousMonthKey], monthKey);
+  const receiptTargetMonths = [];
   logReceiptDebug_(pid, {
     step: 'resolveReceiptTargetMonthsFromBankFlags_',
     billingMonth: monthKey,


### PR DESCRIPTION
### Motivation
- Prevent generating previous-month receipts when both the current and previous billing months lack `ae`/`af` bank flags.

### Description
- In `src/main.gs` modified `resolveReceiptTargetMonthsFromBankFlags_` to return an empty array (`[]`) in the default branch instead of calling `normalizePastBillingMonths_([previousMonthKey], monthKey)`, while preserving the other branches and `logReceiptDebug_` behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69671978401c8321849068945426bbd9)