### PR TITLE
Do not attach receipt fields when no receipt target months; remove legacy previous-month fallback

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1147,12 +1147,7 @@ function attachPreviousReceiptAmounts_(prepared, cache) {
         receiptTargetMonths,
         receiptMonths: []
       });
-      return Object.assign({}, entry, {
-        hasPreviousReceiptSheet,
-        receiptMonths: [],
-        receiptRemark: '',
-        receiptMonthBreakdown: hasPreviousReceiptSheet ? (entry && entry.receiptMonthBreakdown) : []
-      });
+      return entry;
     }
 
     if (!hasPreviousReceiptSheet && receiptTargetMonths[0] === previousMonthKey) {
@@ -1163,21 +1158,7 @@ function attachPreviousReceiptAmounts_(prepared, cache) {
       });
     }
 
-    const resolveLegacyPreviousReceiptAmount = () => {
-      if (!previousPrepared || !Array.isArray(previousPrepared.billingJson)) return 0;
-      const legacyEntry = previousPrepared.billingJson.find(item => normalizePid(item && item.patientId) === pid);
-      if (!legacyEntry) return 0;
-      if (legacyEntry.grandTotal != null && legacyEntry.grandTotal !== '') {
-        return normalizeMoneyNumber_(legacyEntry.grandTotal);
-      }
-      return normalizeMoneyNumber_(legacyEntry.billingAmount);
-    };
-
-    const receiptBreakdown = receiptTargetMonths.length === 1
-      && receiptTargetMonths[0] === previousMonthKey
-      && !hasPreviousReceiptSheet
-      ? [{ month: previousMonthKey, amount: resolveLegacyPreviousReceiptAmount() }]
-      : buildReceiptMonthBreakdownForEntry_(pid, receiptTargetMonths, previousPrepared || prepared, monthCache);
+    const receiptBreakdown = buildReceiptMonthBreakdownForEntry_(pid, receiptTargetMonths, previousPrepared || prepared, monthCache);
 
     logReceiptDebug_(pid, {
       step: 'attachPreviousReceiptAmounts_',


### PR DESCRIPTION
### Motivation
- The change ensures `attachPreviousReceiptAmounts_` does not generate or fill `receiptMonths`/`receiptMonthBreakdown`/`receiptRemark` (including legacy behavior) when `resolveReceiptTargetMonthsFromBankFlags_` returns an empty array. 
- It also removes the legacy previous-month amount fallback so single-month previous-month filling (when previous sheet is missing) is no longer applied.

### Description
- Added an early return in `attachPreviousReceiptAmounts_` to return the original entry when `receiptTargetMonths` is empty, avoiding mutation of receipt-related fields. 
- Removed the special-case legacy logic that computed `resolveLegacyPreviousReceiptAmount` and injected a single-month breakdown for a missing previous sheet, and always use `buildReceiptMonthBreakdownForEntry_` for breakdown construction. 
- Did not modify `resolveReceiptTargetMonthsFromBankFlags_` or any UI/PDF/display logic; the change is limited to `attachPreviousReceiptAmounts_` only.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69671a3707b083218e4eb76bfee2725c)