### PR TITLE
Add receipt debug logging before invoice PDF return

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -3249,6 +3249,7 @@ function finalizeInvoiceAmountDataForPdf_(entry, billingMonth, aggregateMonths, 
   const aggregateConfirmed = !!(entry && entry.bankFlags && entry.bankFlags.af === true);
   const watermark = buildInvoiceWatermark_(entry);
   const receiptMonths = receiptDisplay && receiptDisplay.receiptMonths ? receiptDisplay.receiptMonths : [];
+  const carryOverAmount = normalizeBillingCarryOver_(entry);
   logReceiptDebug_(entry && entry.patientId, {
     step: 'finalizeInvoiceAmountDataForPdf_',
     billingMonth,
@@ -3257,6 +3258,19 @@ function finalizeInvoiceAmountDataForPdf_(entry, billingMonth, aggregateMonths, 
     previousFlags: entry && entry.previousBankFlags,
     receiptTargetMonths: normalizedAggregateMonths,
     receiptMonths
+  });
+  logReceiptDebug_(entry && entry.patientId, {
+    step: 'finalizeInvoiceAmountDataForPdf_ pre-return',
+    billingMonth,
+    patientId: entry && entry.patientId,
+    isAggregateInvoice,
+    carryOverAmount,
+    previousReceipt,
+    previousReceiptAmount: entry && entry.previousReceiptAmount != null ? entry.previousReceiptAmount : undefined,
+    receiptMonths,
+    receiptDisplayVisible: !!(receiptDisplay && receiptDisplay.visible),
+    bankFlags: entry && entry.bankFlags,
+    previousBankFlags: entry && entry.previousBankFlags
   });
 
   return Object.assign({}, amount, {


### PR DESCRIPTION
### Motivation
- Add guarded debug logging to capture the invoice/receipt-related variables immediately before `finalizeInvoiceAmountDataForPdf_` returns so the root cause of Issue #1082 can be observed without speculative changes.

### Description
- Inserted a `logReceiptDebug_` call in `src/main.gs` right before the return of `finalizeInvoiceAmountDataForPdf_` to emit a one-line JSON payload when `BILLING_DEBUG_PID` matches the patient, including `carryOverAmount`, `previousReceipt`, `previousReceiptAmount`, `receiptMonths`, `isAggregateInvoice`, and bank flag fields.
- The change only adds logging (no behavior changes to rendering or business logic) and is guarded by the existing `BILLING_DEBUG_PID`/`logReceiptDebug_` mechanism; modified file: `src/main.gs`.

### Testing
- No automated tests were run for this change (no test execution requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69671ed46de083219d9f84db3a857791)