### PR TITLE
Suppress zero carryover row and empty receipt section in invoice PDF data

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -3228,7 +3228,7 @@ function finalizeInvoiceAmountDataForPdf_(entry, billingMonth, aggregateMonths, 
       }));
     }
   }
-  const amount = Object.assign({}, baseAmount, {
+  let amount = Object.assign({}, baseAmount, {
     insuranceType: entry && entry.insuranceType ? String(entry.insuranceType).trim() : '',
     burdenRate: entry && entry.burdenRate != null ? entry.burdenRate : '',
     chargeMonthLabel: normalizeBillingMonthLabel_(billingMonth),
@@ -3249,6 +3249,16 @@ function finalizeInvoiceAmountDataForPdf_(entry, billingMonth, aggregateMonths, 
   const aggregateConfirmed = !!(entry && entry.bankFlags && entry.bankFlags.af === true);
   const watermark = buildInvoiceWatermark_(entry);
   const receiptMonths = receiptDisplay && receiptDisplay.receiptMonths ? receiptDisplay.receiptMonths : [];
+  const carryOverAmount = normalizeBillingCarryOver_(entry);
+  if (carryOverAmount === 0 && Array.isArray(amount.rows)) {
+    const filteredRows = amount.rows.filter(row => row && row.label !== '前月繰越');
+    if (filteredRows.length !== amount.rows.length) {
+      amount = Object.assign({}, amount, { rows: filteredRows });
+    }
+  }
+  if (!receiptMonths.length) {
+    amount = Object.assign({}, amount, { forceHideReceipt: true });
+  }
   logReceiptDebug_(entry && entry.patientId, {
     step: 'finalizeInvoiceAmountDataForPdf_',
     billingMonth,


### PR DESCRIPTION
### Motivation
- Prevent the invoice PDF from showing a "前月繰越 0円" row and an empty "前月分領収書" heading/notes when there is no carryover and no receipt months, without modifying templates or display logic.
- Apply the suppression right before data is passed to templates in `finalizeInvoiceAmountDataForPdf_` with minimal changes.

### Description
- Change `amount` to a mutable `let` in `finalizeInvoiceAmountDataForPdf_` and filter out rows whose `label` is `前月繰越` when `normalizeBillingCarryOver_(entry)` returns `0`.
- When there are no `receiptMonths`, explicitly set `forceHideReceipt: true` on the finalized `amount` so the receipt section is suppressed.
- Leave semantics of `receiptMonths`, `showReceipt`, and previous receipt calculations unchanged, and do not alter AE/AF or aggregation logic.
- The change is localized to `src/main.gs` and does not modify any templates or add new display-condition logic in templates.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696720ca213c8321b57920b0a80c1e97)