### PR TITLE
Hide zero carryover row and require `amount.showReceipt === true` for previous-month receipt

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -150,9 +150,6 @@
     <hr class="divider">
 
     <? var receipt = amount.previousReceipt || amount.receipt || {}; ?>
-    <?
-      var showReceipt = !!receipt.visible;
-    ?>
     <? var receiptAddressee = receipt.addressee || data.name || ''; ?>
     <? var receiptDate = receipt.date || receipt.receiptDate || ''; ?>
     <? var receiptBreakdown = Array.isArray(amount && amount.receiptMonthBreakdown) ? amount.receiptMonthBreakdown : (Array.isArray(receipt && receipt.receiptMonthBreakdown) ? receipt.receiptMonthBreakdown : []); ?>
@@ -160,10 +157,9 @@
     <? var previousReceiptAmount = amount && amount.previousReceiptAmount != null ? Number(amount.previousReceiptAmount) : (receipt && receipt.previousReceiptAmount != null ? Number(receipt.previousReceiptAmount) : null); ?>
     <? var receiptAmount = receiptBreakdownAmount != null ? receiptBreakdownAmount : previousReceiptAmount != null ? previousReceiptAmount : (receipt.amount != null ? receipt.amount : receipt.total != null ? receipt.total : receipt.price); ?>
     <? var receiptNote = receipt.note || receipt.description || ''; ?>
-    <? if (!amount.forceHideReceipt) { ?>
+    <? if (!amount.forceHideReceipt && amount.showReceipt === true) { ?>
       <section class="card">
         <h3 class="section-title">前月分領収書</h3>
-        <? if (showReceipt) { ?>
         <div class="info">
           <div class="label">宛名</div>
           <div><?= receiptAddressee || '―' ?></div>
@@ -176,9 +172,6 @@
           <div class="label">発行者</div>
           <div>株式会社べるつりー</div>
         </div>
-      <? } else { ?>
-          <div class="note">前月分は未入金のため、後日合算して請求されます</div>
-        <? } ?>
       </section>
     <? } ?>
   </div>

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -998,10 +998,12 @@ function buildInvoiceTemplateData_(item) {
   }
 
   const rows = [
-    { label: '前月繰越', detail: '', amount: carryOverAmount },
     { label: '施術料', detail: formatBillingCurrency_(unitPrice) + '円 × ' + visits + '回', amount: breakdown.treatmentAmount },
     { label: '交通費', detail: transportDetail, amount: breakdown.transportAmount }
   ];
+  if (carryOverAmount !== 0) {
+    rows.unshift({ label: '前月繰越', detail: '', amount: carryOverAmount });
+  }
 
   return Object.assign({}, item, {
     monthLabel,


### PR DESCRIPTION
### Motivation
- Suppress the “前月繰越” line when the carryover amount is zero so invoices do not show a 0円 carryover entry.
- Ensure the entire “前月分領収書” section (heading, details and notes) is rendered only when `amount.showReceipt === true` to avoid showing the receipt block for AE/AF-unset cases.

### Description
- In `src/output/billingOutput.js` the invoice `rows` construction was changed to omit the unconditional `{ label: '前月繰越', ... }` entry and instead `unshift` that row only when `carryOverAmount !== 0`.
- In `src/invoice_template.html` the receipt section rendering condition was tightened to `!amount.forceHideReceipt && amount.showReceipt === true`, and the template no longer relies on the previous `receipt.visible` fallback or shows a fallback note when receipt visibility is false.
- Changes are minimal and localized to `buildInvoiceTemplateData_` output shaping and the invoice template rendering logic to keep downstream behavior unchanged except for the two targeted display rules.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696723143c0c83218362b25be24b2d6a)