### PR TITLE
Disable simple bank withdrawal UI and initialization

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -194,7 +194,7 @@
         </div>
       </section>
 
-    <section class="card" id="bankWithdrawalFlow">
+    <section class="card" id="bankWithdrawalFlow" hidden aria-hidden="true">
       <h2>簡易銀行引落</h2>
       <p class="muted">銀行情報シートを丸ごとコピーし、名前一致の患者に請求金額をS列へ転記します。</p>
       <div class="bank-flow-grid">

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -2252,23 +2252,9 @@ function initBillingPage() {
     input.onchange = updateBillingControls;
     input.oninput = updateBillingControls;
   }
-  const bankMonthInput = qs('bankWithdrawalMonth');
-  if (bankMonthInput && !bankMonthInput.value) {
-    bankMonthInput.value = input && input.value ? input.value : getDefaultMonth();
-  }
-  if (bankMonthInput) {
-    simpleBankState.targetMonth = normalizeYm(bankMonthInput.value);
-    bankMonthInput.onchange = function () {
-      simpleBankState.targetMonth = normalizeYm(this.value);
-      updateSimpleBankControls();
-      renderSimpleBankSummary();
-    };
-  }
   updateBillingControls();
   refreshPreparedBillingMonths();
-  updateSimpleBankControls();
   renderBillingResult();
-  renderSimpleBankDetail();
   loadBillingAdminInfo();
 }
 
@@ -2293,6 +2279,5 @@ if (billingGlobal) {
   billingGlobal.handleBillingAggregation = handleBillingAggregation;
   billingGlobal.handleBillingPdfGeneration = handleBillingPdfGeneration;
   billingGlobal.handleBillingSaveEdits = handleBillingSaveEdits;
-  billingGlobal.handleSimpleBankSheetGeneration = handleSimpleBankSheetGeneration;
 }
 </script>


### PR DESCRIPTION
### Motivation
- Completely disable the "簡易銀行引落" UI and related page-level interactions while preserving backend/GAS functions and billing logic.
- Ensure no changes to billing calculations, data structures, or GAS APIs, only stop UI exposure and client-side event wiring for the simple bank feature.

### Description
- Hide the bank withdrawal section in `src/billing.html` by adding `hidden` and `aria-hidden="true"` to the `#bankWithdrawalFlow` section.
- Remove client-side initialization of the bank-month input and related simple-bank state updates from `initBillingPage()` in `src/main.js.html` so the simple bank controls are not wired on load.
- Stop exporting the `handleSimpleBankSheetGeneration` function to the global `window` object so the button (now hidden) cannot invoke it from the UI.
- No GAS functions, data structures, billing aggregation or PDF/receipt logic were modified.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696728cecef48321ae3d17b8da600e65)