### PR TITLE
Use resolveReceiptTargetMonths_ for PDF receipt months

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -3217,7 +3217,7 @@ function buildAggregateInvoiceAmountDataForPdf_(aggregateMonths, billingMonth, p
   };
 }
 
-function finalizeInvoiceAmountDataForPdf_(entry, billingMonth, aggregateMonths, isAggregateInvoice, cache) {
+function finalizeInvoiceAmountDataForPdf_(entry, billingMonth, aggregateMonths, isAggregateInvoice, cache, prepared) {
   const normalizedAggregateMonths = normalizePastBillingMonths_(aggregateMonths, billingMonth);
   const baseAmount = isAggregateInvoice
     ? buildAggregateInvoiceAmountDataForPdf_(normalizedAggregateMonths, billingMonth, entry && entry.patientId, cache)
@@ -3252,7 +3252,7 @@ function finalizeInvoiceAmountDataForPdf_(entry, billingMonth, aggregateMonths, 
   const aggregateStatus = receiptDisplay ? receiptDisplay.aggregateStatus : normalizeAggregateStatus_(entry && entry.aggregateStatus);
   const aggregateConfirmed = !!(entry && entry.bankFlags && entry.bankFlags.af === true);
   const watermark = buildInvoiceWatermark_(entry);
-  const receiptMonths = receiptDisplay && receiptDisplay.receiptMonths ? receiptDisplay.receiptMonths : [];
+  const receiptMonths = resolveReceiptTargetMonths_(entry && entry.patientId, billingMonth, prepared, cache);
   const carryOverAmount = normalizeBillingCarryOver_(entry);
   logReceiptDebug_(entry && entry.patientId, {
     step: 'finalizeInvoiceAmountDataForPdf_',
@@ -3356,7 +3356,7 @@ function buildInvoicePdfContextForEntry_(entry, prepared, cache) {
   const decisionMonths = decision && Array.isArray(decision.months) ? decision.months : [];
   const aggregateMonths = normalizePastBillingMonths_(decisionMonths, billingMonth);
   const isAggregateInvoice = !!(decision && decision.mode === 'aggregate' && aggregateMonths.length > 1);
-  const amount = finalizeInvoiceAmountDataForPdf_(receiptEntry, billingMonth, aggregateMonths, isAggregateInvoice, cache);
+  const amount = finalizeInvoiceAmountDataForPdf_(receiptEntry, billingMonth, aggregateMonths, isAggregateInvoice, cache, prepared);
 
   return {
     patientId,
@@ -3376,7 +3376,7 @@ function buildAggregateInvoicePdfContext_(entry, aggregateMonths, prepared, cach
   if (!billingMonth || !patientId) return null;
 
   const normalizedMonths = normalizePastBillingMonths_(aggregateMonths, billingMonth);
-  const amount = finalizeInvoiceAmountDataForPdf_(entry, billingMonth, normalizedMonths, true, cache);
+  const amount = finalizeInvoiceAmountDataForPdf_(entry, billingMonth, normalizedMonths, true, cache, prepared);
 
   return {
     patientId,


### PR DESCRIPTION
### Motivation
- Ensure the PDF generation uses `resolveReceiptTargetMonths_` as the single source of truth for `receiptMonths` so the PDF context ignores other receiptMonths sources and stays consistent with bank-flag logic.

### Description
- Added a `prepared` parameter to `finalizeInvoiceAmountDataForPdf_` and used `resolveReceiptTargetMonths_(...)` to populate `receiptMonths` inside it instead of reading from other display fields.
- Wired the new `prepared` parameter through calls from `buildInvoicePdfContextForEntry_` and `buildAggregateInvoicePdfContext_` so PDF amount finalization has the prepared billing context available.
- Kept all billing amount, AE/AF semantics, PDF template, and storage logic unchanged; change is limited to routing receipt months into PDF context.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69672b30f8c08321915b13679e8e1291)