### PR TITLE
Refine receipt target month resolution to require prior prepared billing entry

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -407,20 +407,15 @@ function normalizeAggregateStatus_(status) {
   return normalized || '';
 }
 
-function isAggregateConfirmedByBankFlags_(item) {
-  return !!(item && item.bankFlags && item.bankFlags.af === true);
-}
-
 function resolveInvoiceReceiptDisplay_(item, options) {
   const billingMonthKey = normalizeInvoiceMonthKey_(item && item.billingMonth);
-  const aggregateEligible = isAggregateConfirmedByBankFlags_(item);
   const explicitReceiptMonths = normalizePastInvoiceMonths_(
     normalizeReceiptMonths_(item && item.receiptMonths),
     billingMonthKey,
-    aggregateEligible
+    false
   );
-  const aggregateStatus = aggregateEligible ? normalizeAggregateStatus_(item && item.aggregateStatus) : '';
-  const aggregateConfirmed = aggregateEligible;
+  const aggregateStatus = '';
+  const aggregateConfirmed = false;
   const receiptMonths = explicitReceiptMonths;
   const customReceiptRemark = item && item.receiptRemark ? String(item.receiptRemark) : '';
   const receiptRemark = customReceiptRemark || (receiptMonths.length > 1


### PR DESCRIPTION
### Motivation
- Enforce PDF-time-only receipt display logic so a previous-month receipt is shown only when the prior `prepared` billing exists and contains a row for the given `patientId`, and remove any dependence on bank flags or AF/AE logic. 
- Simplify and make the resolver auditable by consolidating lookup logic into a single function and loading prior-month prepared data with sheet-fallback.

### Description
- Replace the bank-flag driven resolution with a new `resolveReceiptTargetMonths` implementation that loads the previous month via `loadPreparedBillingWithSheetFallback_`, verifies `prepared.billingJson` is an array, and returns `[previousMonthKey]` only when a matching `patientId` row exists (using `billingNormalizePatientId_` when available). 
- Update `attachPreviousReceiptAmounts_` to load the previous prepared billing via the fallback loader and to call the new `resolveReceiptTargetMonths` instead of the removed bank-flag logic. 
- Update `finalizeInvoiceAmountDataForPdf_` to call `resolveReceiptTargetMonths` for `receiptMonths`, to derive `aggregateConfirmed` from the `receiptDisplay` decision, and to simplify debug logging by removing direct bank-flag fields. 
- Simplify invoice display logic in `src/output/billingOutput.js` by removing aggregate eligibility derived from bank flags and forcing `aggregateStatus` to `''` and `aggregateConfirmed` to `false`, and remove the old bank-flag based resolver variants.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967345d03ac832182ea050f3595dfab)