### PR TITLE
Add formatter to generate western-year receipt remark from `receiptMonths`

### DIFF
--- a/tests/billingInvoiceLayout.test.js
+++ b/tests/billingInvoiceLayout.test.js
@@ -159,7 +159,7 @@ function testInvoiceTemplateAddsReceiptDecision() {
   });
   assert.strictEqual(payable.showReceipt, true, '未回収チェックが無ければ領収書を表示する');
   assert.deepStrictEqual(Array.from(payable.receiptMonths || []), ['202310'], '領収対象月は前月を指す');
-  assert.strictEqual(payable.receiptRemark, '', '備考は付与しない');
+  assert.strictEqual(payable.receiptRemark, '2023年10月分施術料金として', '備考は領収対象月から生成する');
 }
 
 function testAggregateInvoiceTemplateStacksPerMonth() {

--- a/tests/billingOutput.test.js
+++ b/tests/billingOutput.test.js
@@ -291,6 +291,35 @@ function testReceiptVisibilityRespectsBankFlagsAndStatus() {
   assert.strictEqual(withSkipReceipt.visible, false, 'skipReceipt が指定された場合は非表示にする');
 }
 
+function testReceiptRemarkUsesNormalizedMonths() {
+  const context = createContext();
+  vm.createContext(context);
+  vm.runInContext(billingOutputCode, context);
+
+  const { formatReceiptRemarkFromMonths_ } = context;
+
+  assert.strictEqual(
+    formatReceiptRemarkFromMonths_(['202509']),
+    '2025年9月分施術料金として',
+    '単月は西暦で領収書但し書きを生成する'
+  );
+  assert.strictEqual(
+    formatReceiptRemarkFromMonths_(['202509', '202510']),
+    '2025年9月・10月分施術料金として',
+    '同一年の連続月は年を省略して表記する'
+  );
+  assert.strictEqual(
+    formatReceiptRemarkFromMonths_(['202509', '202510', '202511', '202512', '202601']),
+    '2025年9月から2026年1月分施術料金として',
+    '年跨ぎの連続月は期間表記にする'
+  );
+  assert.strictEqual(
+    formatReceiptRemarkFromMonths_(['202509', '202511', '202601']),
+    '2025年9月・11月・2026年1月分施術料金として',
+    '非連続月は年ごとに区切って表記する'
+  );
+}
+
 function testInvoiceTemplateSwitchesAggregateModeForUnpaid() {
   const context = createContext();
   vm.createContext(context);


### PR DESCRIPTION
### Motivation
- Unify receipt PDF remark generation so a single pure function produces the "但し書き" from an array of `receiptMonths` (YYYYMM) using Western year notation. 
- Support single month, consecutive months (same-year condensed or cross-year range), and non-consecutive months grouped by year, while avoiding empty or `-` results. 
- Separate display responsibility from logic so PDF templates simply render the produced remark string.

### Description
- Added `formatReceiptRemarkFromMonths_` to `src/output/billingOutput.js` to normalize, dedupe, sort and format `receiptMonths` into the required remark forms. 
- Replaced prior aggregated-remark usage with the new function in `resolveInvoiceReceiptDisplay_` so `receiptRemark` is produced by `formatReceiptRemarkFromMonths_`. 
- Kept Western-year fixed formatting and handled single-month, same-year consecutive, year-crossing consecutive, and non-consecutive/year-grouped cases per the spec. 
- Updated tests: added `testReceiptRemarkUsesNormalizedMonths` in `tests/billingOutput.test.js` and adjusted expected remark in `tests/billingInvoiceLayout.test.js` to assert generated remark is used.

### Testing
- Unit tests were added/updated under `tests/billingOutput.test.js` and `tests/billingInvoiceLayout.test.js` to validate single, consecutive (same-year and cross-year), and non-consecutive formatting. 
- No automated test runner was executed as part of this change; the new/modified tests are included for CI or local execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69673ab7786083218f9097478d918124)