### PR TITLE
Use `receipt.amount` as single source and fix aggregate receipt breakdown/totals

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -152,10 +152,7 @@
     <? var receipt = amount.previousReceipt || amount.receipt || {}; ?>
     <? var receiptAddressee = receipt.addressee || data.name || ''; ?>
     <? var receiptDate = receipt.date || receipt.receiptDate || ''; ?>
-    <? var receiptBreakdown = Array.isArray(amount && amount.receiptMonthBreakdown) ? amount.receiptMonthBreakdown : (Array.isArray(receipt && receipt.receiptMonthBreakdown) ? receipt.receiptMonthBreakdown : []); ?>
-    <? var receiptBreakdownAmount = receiptBreakdown.length ? receiptBreakdown.reduce(function(sum, row) { return sum + (Number(row && row.amount) || 0); }, 0) : null; ?>
-    <? var previousReceiptAmount = amount && amount.previousReceiptAmount != null ? Number(amount.previousReceiptAmount) : (receipt && receipt.previousReceiptAmount != null ? Number(receipt.previousReceiptAmount) : null); ?>
-    <? var receiptAmount = receiptBreakdownAmount != null ? receiptBreakdownAmount : previousReceiptAmount != null ? previousReceiptAmount : (receipt.amount != null ? receipt.amount : receipt.total != null ? receipt.total : receipt.price); ?>
+    <? var receiptAmount = receipt.amount != null ? receipt.amount : 0; ?>
     <? var receiptNote = receipt.note || receipt.description || ''; ?>
     <? if (!amount.forceHideReceipt && amount.showReceipt === true) { ?>
       <section class="card">


### PR DESCRIPTION
### Motivation
- Ensure aggregate receipt totals are always correct by centralizing amount computation in billing output and preventing the template from recomputing breakdown sums.
- Prevent inconsistent display where an aggregate receipt could show a single-month amount instead of the summed total.

### Description
- Updated `src/invoice_template.html` to read the receipt amount only from `receipt.amount` and default to `0`, removing any template-side breakdown or fallback calculations.
- Modified `buildInvoicePreviousReceipt_` in `src/output/billingOutput.js` to compute `aggregateAmount` from the resolved breakdown and return it as the invoice `amount`, and to include `receiptMonthBreakdown` on the returned receipt object for display purposes.
- Improved `resolveReceiptMonthBreakdown_` to reuse `item.receiptMonthBreakdown` only when it covers all `requestedMonths`, and to order/filter the precomputed rows to exactly match `requestedMonths` before returning them.
- Preserved the single source-of-truth constraint that `receipt.amount` is the canonical value used by the template for rendering.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696833860f788321b4406d4e8883e85e)