### PR TITLE
Use cached summary in resolveReceiptTargetMonths

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1621,16 +1621,9 @@ function resolveReceiptTargetMonths(patientId, billingMonth, cache) {
   const receiptMonths = resolveReceiptTargetMonthsByBankFlags_(patientId, monthKey, cache);
   if (!receiptMonths.length) return [];
 
-  const loaded = loadPreparedBillingWithSheetFallback_(previousMonthKey, { withValidation: true, restoreCache: true });
-  const prepared = normalizePreparedBilling_(loaded && loaded.prepared);
-  if (!prepared || !Array.isArray(prepared.billingJson)) return [];
-
-  const hasEntry = prepared.billingJson.some(entry => (
-    typeof billingNormalizePatientId_ === 'function'
-      ? billingNormalizePatientId_(entry && entry.patientId)
-      : String(entry && entry.patientId || '').trim()
-  ) === pid);
-  if (!hasEntry) return [];
+  const previousPrepared = getPreparedBillingForMonthCached_(previousMonthKey, cache);
+  const totals = previousPrepared && previousPrepared.totalsByPatient;
+  if (!totals || !Object.prototype.hasOwnProperty.call(totals, pid)) return [];
 
   return receiptMonths;
 }


### PR DESCRIPTION
### Motivation
- Avoid loading previous-month prepared billing sheets during receipt target resolution and rely only on the preloaded month cache to determine prior-month patient presence.
- Ensure PDF generation and Sheet/Cache I/O are eliminated from this code path while preserving existing aggregate invoice/receipt output behavior.

### Description
- Replace the `loadPreparedBillingWithSheetFallback_` + `normalizePreparedBilling_` + `billingJson` search with a cached lookup using `getPreparedBillingForMonthCached_` and checking `totalsByPatient` for the patient id.
- No other cache formats, refactorings, or logic changes were introduced.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968504d1a048321a2509949689ae2cf)