### PR TITLE
Stop bank transfer export during PDF generation

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -3611,8 +3611,7 @@ function generatePreparedInvoices_(prepared, options) {
 
   const outputOptions = Object.assign({}, opts, { billingMonth: normalized.billingMonth, patientIds: targetPatientIds });
   const pdfs = generateInvoicePdfs(invoiceContexts, outputOptions);
-  const shouldExportBank = !outputOptions || outputOptions.skipBankExport !== true;
-  const bankOutput = shouldExportBank ? exportBankTransferDataForPrepared_(aggregateApplied) : null;
+  const bankOutput = null;
   return {
     billingMonth: normalized.billingMonth,
     billingJson: receiptEnriched.billingJson,


### PR DESCRIPTION
### Motivation
- Prevent `exportBankTransferDataForPrepared_` from running during the invoice PDF generation flow because it triggered Sheet I/O when the prepared payload was incomplete, while keeping PDF output behavior unchanged.

### Description
- In `src/main.gs` the bank export invocation in `generatePreparedInvoices_` was removed by replacing the conditional export with a `bankOutput = null` placeholder so PDF generation no longer triggers bank transfer export.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696854f7d6748321892c716a80409dfa)