### PR TITLE
Memoize merged billing cache payloads

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -174,6 +174,7 @@ if (typeof globalThis !== 'undefined') {
 
 const BILLING_MONTH_KEY_CACHE_ = {};
 const RECEIPT_TARGET_MONTHS_BY_BANK_FLAGS_CACHE_ = {};
+const BILLING_CACHE_PAYLOAD_MEMO_ = {};
 
 function shouldLogReceiptDebug_(patientId) {
   const debugPid = String(BILLING_DEBUG_PID || '').trim();
@@ -2138,6 +2139,11 @@ function loadBillingCachePayload_(cache, key) {
   const chunkCount = parseBillingCacheChunkCount_(cached);
   if (!chunkCount) return cached;
 
+  const memoized = BILLING_CACHE_PAYLOAD_MEMO_[key];
+  if (memoized && memoized.marker === cached && typeof memoized.payload === 'string') {
+    return memoized.payload;
+  }
+
   const chunks = [];
   for (let idx = 1; idx <= chunkCount; idx++) {
     const chunkValue = cache.get(buildBillingCacheChunkKey_(key, idx));
@@ -2151,6 +2157,7 @@ function loadBillingCachePayload_(cache, key) {
   } catch (err) {
     // ignore logging errors
   }
+  BILLING_CACHE_PAYLOAD_MEMO_[key] = { marker: cached, payload: merged };
   return merged;
 }
 


### PR DESCRIPTION
### Motivation
- Repeated chunked cache merges for the same billing cache key caused duplicate work during a single runtime, so an in-memory memoization avoids re-merging the same chunks.

### Description
- Add an in-memory memo store `BILLING_CACHE_PAYLOAD_MEMO_` to hold merged payloads for cache keys.
- In `loadBillingCachePayload_` check the memo entry and return the memoized `payload` when the cached marker matches the stored `marker` to skip re-merging.
- After merging chunked entries the merged payload is stored in `BILLING_CACHE_PAYLOAD_MEMO_[key] = { marker: cached, payload: merged }` so subsequent calls return the preserved result.
- Cache structure, payload format, and public outputs are unchanged; memoization is purely in-memory and runtime-scoped.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696856598760832186389b2f0e4e34fc)