### PR TITLE
Preload prepared payloads in runtime cache and use sheet-only loader for PDF generation

### DIFF
--- a/docs/issue-1132-summary.md
+++ b/docs/issue-1132-summary.md
@@ -1,0 +1,15 @@
+# Issue #1132 / Issue #8 対応サマリー
+
+## 変更点
+- PDF生成の入口で prepared payload をシートから読み込み、PDF生成中は runtime cache（in-memory）で参照する導線を追加。
+- PDF生成に必要な過去月を洗い出して一括ロードし、PDF生成フェーズではチャンク化キャッシュの merge を発生させない構成に変更。
+- monthCache 参照時に runtime prepared payload を優先して使い、明細計算や合算の参照元を runtime cache に統一。
+
+## 変更理由
+- PDF生成中の `loadBillingCachePayload_ merged chunked cache` ログを排除し、チャンク化キャッシュの結合処理を避けるため。
+- PDF生成の性能改善（読み込み回数とI/O削減）を狙うため。
+
+## 影響範囲
+- PDF生成系の入口関数（対象月・過去月の prepared payload 読み込みと runtime cache 参照）。
+- 永続キャッシュ（CacheService / Drive）や prepared payload スキーマには変更なし。
+- 請求書/領収書の金額計算、合算、表示仕様は変更なし。

--- a/src/main.gs
+++ b/src/main.gs
@@ -658,6 +658,25 @@ function createBillingMonthCache_() {
   };
 }
 
+function getPreparedPayloadRuntimeCache_(cache) {
+  if (!cache || !cache.preparedEntriesByMonth) return null;
+  return cache.preparedEntriesByMonth;
+}
+
+function storePreparedPayloadInRuntimeCache_(prepared, cache) {
+  const monthKey = normalizeBillingMonthKeySafe_(prepared && prepared.billingMonth);
+  const store = getPreparedPayloadRuntimeCache_(cache);
+  if (!monthKey || !store) return;
+  store[monthKey] = normalizePreparedBilling_(prepared);
+}
+
+function getPreparedPayloadForMonthCached_(billingMonth, cache) {
+  const monthKey = normalizeBillingMonthKeySafe_(billingMonth);
+  const store = getPreparedPayloadRuntimeCache_(cache);
+  if (!monthKey || !store || !Object.prototype.hasOwnProperty.call(store, monthKey)) return null;
+  return store[monthKey] || null;
+}
+
 function getPreparedBillingForMonthCached_(billingMonth, cache) {
   const monthKey = normalizeBillingMonthKeySafe_(billingMonth);
   if (!monthKey) return null;
@@ -675,11 +694,98 @@ function getPreparedBillingEntryForMonthCached_(billingMonth, patientId, cache) 
   const monthKey = normalizeBillingMonthKeySafe_(billingMonth);
   const pid = billingNormalizePatientId_(patientId);
   if (!monthKey || !pid) return null;
+  const runtimePayload = getPreparedPayloadForMonthCached_(monthKey, cache);
+  if (runtimePayload && Array.isArray(runtimePayload.billingJson)) {
+    const runtimeEntry = runtimePayload.billingJson
+      .find(entry => billingNormalizePatientId_(entry && entry.patientId) === pid);
+    if (runtimeEntry) {
+      return pickPreparedBillingEntrySummary_(runtimeEntry);
+    }
+  }
   // NOTE: Cache must be preloaded (loadPreparedBillingSummariesIntoCache_).
   const summary = getPreparedBillingForMonthCached_(monthKey, cache);
   const totals = summary && summary.totalsByPatient ? summary.totalsByPatient : null;
   if (!totals || !Object.prototype.hasOwnProperty.call(totals, pid)) return null;
   return totals[pid] || null;
+}
+
+function collectPreparedPayloadMonthsForPdf_(prepared, cache) {
+  const normalized = normalizePreparedBilling_(prepared);
+  const monthKey = normalizeBillingMonthKeySafe_(normalized && normalized.billingMonth);
+  if (!monthKey) return [];
+
+  const monthSet = new Set([monthKey]);
+  if (!normalized || !Array.isArray(normalized.billingJson)) return Array.from(monthSet);
+
+  normalized.billingJson.forEach(entry => {
+    const pid = billingNormalizePatientId_(entry && entry.patientId);
+    if (!pid) return;
+
+    const receiptMonths = resolveReceiptTargetMonths(pid, monthKey, cache);
+    receiptMonths.forEach(targetMonth => {
+      const normalizedMonth = normalizeBillingMonthKeySafe_(targetMonth);
+      if (normalizedMonth) monthSet.add(normalizedMonth);
+    });
+
+    const decision = resolveInvoiceGenerationMode(pid, monthKey, cache);
+    const decisionMonths = decision && Array.isArray(decision.aggregateMonths) ? decision.aggregateMonths : [];
+    decisionMonths.forEach(targetMonth => {
+      const normalizedMonth = normalizeBillingMonthKeySafe_(targetMonth);
+      if (normalizedMonth) monthSet.add(normalizedMonth);
+    });
+
+    const entryMonths = []
+      .concat(entry.aggregateMonths || [])
+      .concat(entry.receiptMonths || [])
+      .concat(entry.aggregateTargetMonths || []);
+    entryMonths.forEach(targetMonth => {
+      const normalizedMonth = normalizeBillingMonthKeySafe_(targetMonth);
+      if (normalizedMonth) monthSet.add(normalizedMonth);
+    });
+
+    const aggregateUntilMonth = normalizeBillingMonthKeySafe_(
+      entry.aggregateUntilMonth || normalized.aggregateUntilMonth
+    );
+    const aggregateSourceMonths = collectAggregateBankFlagMonthsForPatient_(
+      monthKey,
+      pid,
+      aggregateUntilMonth,
+      cache
+    );
+    aggregateSourceMonths.forEach(targetMonth => {
+      const normalizedMonth = normalizeBillingMonthKeySafe_(targetMonth);
+      if (normalizedMonth) monthSet.add(normalizedMonth);
+    });
+  });
+
+  return Array.from(monthSet).filter(Boolean).sort();
+}
+
+function preloadPreparedPayloadsForPdfGeneration_(prepared, cache) {
+  const normalized = normalizePreparedBilling_(prepared);
+  const monthKey = normalizeBillingMonthKeySafe_(normalized && normalized.billingMonth);
+  const store = getPreparedPayloadRuntimeCache_(cache);
+  if (!monthKey || !store) return;
+
+  if (!cache.preparedByMonthLoadedAll) {
+    loadPreparedBillingSummariesIntoCache_(cache);
+  }
+
+  storePreparedPayloadInRuntimeCache_(normalized, cache);
+
+  const monthsToLoad = collectPreparedPayloadMonthsForPdf_(normalized, cache)
+    .filter(targetMonth => targetMonth !== monthKey);
+
+  monthsToLoad.forEach(targetMonth => {
+    if (Object.prototype.hasOwnProperty.call(store, targetMonth)) return;
+    const payload = loadPreparedBillingFromSheet_(targetMonth);
+    const validation = validatePreparedBillingPayload_(payload, targetMonth);
+    if (payload && validation && validation.ok) {
+      store[targetMonth] = normalizePreparedBilling_(Object.assign({}, payload, { billingMonth: targetMonth }));
+    } else {
+      store[targetMonth] = null;
+    }
+  });
 }
 
 function loadPreparedBillingSummariesIntoCache_(cache) {
@@ -2118,6 +2224,25 @@ function loadPreparedBillingWithSheetFallback_(billingMonthKey, options) {
   return wrapResult(null, sheetValidation);
 }
 
+function loadPreparedBillingForPdfGeneration_(billingMonthKey, options) {
+  const opts = options || {};
+  const withValidation = opts.withValidation === true;
+  const allowInvalid = opts.allowInvalid === true;
+  const wrapResult = (payload, validation) => withValidation ? { prepared: payload, validation: validation || null } : payload;
+
+  const monthKey = normalizeBillingMonthKeySafe_(billingMonthKey);
+  if (!monthKey) return wrapResult(null, { ok: false, reason: 'billingMonth missing' });
+
+  const fromSheet = loadPreparedBillingFromSheet_(monthKey);
+  const validation = validatePreparedBillingPayload_(fromSheet, monthKey);
+  if (fromSheet && (validation.ok || allowInvalid)) {
+    const preparedWithMonth = Object.assign({}, fromSheet, { billingMonth: validation.billingMonth || monthKey });
+    return wrapResult(preparedWithMonth, validation);
+  }
+
+  return wrapResult(null, validation);
+}
+
 function savePreparedBilling_(payload) {
   const normalizedPayload = normalizePreparedBilling_(payload);
   const resolvedMonthKey = normalizeBillingMonthKeySafe_(normalizedPayload && normalizedPayload.billingMonth);
@@ -3544,6 +3669,7 @@ function generatePreparedInvoices_(prepared, options) {
     monthCache.preparedByMonth[normalized.billingMonth] = monthCache.preparedByMonth[normalized.billingMonth]
       || reducePreparedBillingSummary_(normalized);
   }
+  preloadPreparedPayloadsForPdfGeneration_(normalized, monthCache);
   const aggregateApplied = applyAggregateInvoiceRulesFromBankFlags_(normalized, monthCache);
   const receiptEnriched = attachPreviousReceiptAmounts_(aggregateApplied, monthCache);
   if (!receiptEnriched || !receiptEnriched.billingJson) {
@@ -3626,7 +3752,7 @@ function generatePreparedInvoices_(prepared, options) {
 
 function generateInvoicesFromCache(billingMonth, options) {
   const month = normalizeBillingMonthInput(billingMonth);
-  const loaded = loadPreparedBillingWithSheetFallback_(month.key, { withValidation: true });
+  const loaded = loadPreparedBillingForPdfGeneration_(month.key, { withValidation: true });
   const validation = loaded && loaded.validation ? loaded.validation : null;
   const prepared = normalizePreparedBilling_(loaded && loaded.prepared);
   if (!prepared || !prepared.billingJson || (validation && validation.ok === false)) {
@@ -3692,7 +3818,7 @@ function generateAggregatedInvoice(billingMonth, options) {
     throw new Error('患者IDを指定してください');
   }
 
-  const loaded = loadPreparedBillingWithSheetFallback_(month.key, { withValidation: true, restoreCache: true });
+  const loaded = loadPreparedBillingForPdfGeneration_(month.key, { withValidation: true });
   const validation = loaded && loaded.validation ? loaded.validation : null;
   const prepared = normalizePreparedBilling_(loaded && loaded.prepared);
   if (!prepared || !prepared.billingJson || (validation && validation.ok === false)) {
@@ -3711,6 +3837,12 @@ function generateAggregatedInvoice(billingMonth, options) {
   const aggregateMonths = normalizeAggregateInvoiceMonths_(mergedMonths, prepared, month.key);
 
   const monthCache = createBillingMonthCache_();
+  if (monthCache.preparedByMonth) {
+    monthCache.preparedByMonth[month.key] = reducePreparedBillingSummary_(prepared);
+  }
+  loadPreparedBillingSummariesIntoCache_(monthCache);
+  loadBankWithdrawalAmountsIntoCache_(monthCache, prepared);
+  preloadPreparedPayloadsForPdfGeneration_(prepared, monthCache);
   const receiptPrepared = attachPreviousReceiptAmounts_(prepared, monthCache);
   const receiptEntry = (receiptPrepared && receiptPrepared.billingJson || [])
     .find(row => billingNormalizePatientId_(row && row.patientId) === patientId) || entry;
@@ -4098,7 +4230,7 @@ function generatePreparedInvoicesForMonth(billingMonth, options) {
     applyBillingEdits(monthKey, opts);
   }
 
-  const loaded = loadPreparedBilling_(monthKey, { withValidation: true });
+  const loaded = loadPreparedBillingForPdfGeneration_(monthKey, { withValidation: true });
   const validation = loaded && loaded.validation ? loaded.validation : null;
   const prepared = normalizePreparedBilling_(loaded && loaded.prepared);
   if (!prepared || !prepared.billingJson || (validation && validation.ok === false)) {
@@ -4111,6 +4243,7 @@ function generatePreparedInvoicesForMonth(billingMonth, options) {
   }
   loadPreparedBillingSummariesIntoCache_(monthCache);
   loadBankWithdrawalAmountsIntoCache_(monthCache, prepared);
+  preloadPreparedPayloadsForPdfGeneration_(prepared, monthCache);
 
   return generatePreparedInvoices_(prepared, Object.assign({}, opts, { monthCache }));
 }


### PR DESCRIPTION
### Motivation
- Avoid repeated chunked cache merges and noisy `loadBillingCachePayload_` logs during PDF generation by preventing runtime reads of chunked persistent cache.
- Improve PDF generation latency and reduce I/O by serving `prepared` payloads from an in-memory runtime cache populated up-front from Sheets.
- Keep persistent cache and `prepared` payload schema unchanged while making PDF entry points use sheet-backed runtime data.

### Description
- Added runtime cache helpers: `getPreparedPayloadRuntimeCache_`, `storePreparedPayloadInRuntimeCache_`, and `getPreparedPayloadForMonthCached_` to manage `preparedEntriesByMonth` on the month cache.
- Implemented `collectPreparedPayloadMonthsForPdf_` and `preloadPreparedPayloadsForPdfGeneration_` to compute and prefetch all months required for PDF generation into the runtime cache from Sheets.
- Added a sheet-only loader `loadPreparedBillingForPdfGeneration_` that reads `prepared` payloads from Sheets (with optional validation) and replaced usages of the fallback loader at PDF entry points.
- Updated `getPreparedBillingEntryForMonthCached_` to check the runtime `prepared` payload store first, and wired PDF entry points (`generatePreparedInvoices_`, `generatePreparedInvoicesForMonth`, `generateInvoicesFromCache`, and `generateAggregatedInvoice`) to call `preloadPreparedPayloadsForPdfGeneration_` and use the new sheet loader.
- Persisted a shared summary document at `docs/issue-1132-summary.md` describing the change, rationale, and impact scope.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968b852b2ec8321badb8fbb51e44c38)