### PR TITLE
Add online fee to prepared billing entries when AG (オンライン) flag is set

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -959,6 +959,7 @@ function pickPreparedBillingEntrySummary_(entry) {
     unitPrice: row.unitPrice,
     medicalAssistance: row.medicalAssistance,
     selfPayItems: row.selfPayItems,
+    billingItems: row.billingItems,
     manualSelfPayAmount: row.manualSelfPayAmount
   };
 }


### PR DESCRIPTION
### Motivation
- Add a 1,000円 "オンライン対応加算" line to prepared monthly billing for patients with the AG/オンライン flag, applied only during PreparedBilling creation and without altering PDF I/O or carry-over logic.
- Keep existing total calculation logic unchanged by folding the new fee into existing self-pay item processing.

### Description
- Detect the AG/オンライン mark from patient raw fields in `generateBillingJsonFromSource` and treat it as a boolean via `normalizeZeroOneFlag_` to decide eligibility for the online fee. 
- When eligible, append `{ type: 'online_fee', label: 'オンライン対応加算', amount: 1000 }` and merge it into `selfPayItems` so existing billing amount calculations include the fee (implemented in `src/logic/billingLogic.js`).
- Surface `billingItems` on prepared entry summaries by returning `billingItems` from `pickPreparedBillingEntrySummary_` so prepared payloads contain the new item (implemented in `src/main.gs`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969dc69aebc8321b0b237607f955545)