### PR TITLE
Update online fee label to 'オンライン同意サービス使用料'

### DIFF
--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -283,7 +283,7 @@ function generateBillingJsonFromSource(sourceData) {
       : null;
     const hasOnlineFee = normalizeZeroOneFlag_(rawOnlineValue) === 1;
     const billingItems = hasOnlineFee
-      ? [{ type: 'online_fee', label: 'オンライン対応加算', amount: 1000 }]
+      ? [{ type: 'online_fee', label: 'オンライン同意サービス使用料', amount: 1000 }]
       : [];
     const selfPayItems = Array.isArray(patient.selfPayItems) ? patient.selfPayItems.slice() : [];
     if (billingItems.length) {


### PR DESCRIPTION
### Motivation
- Ensure patients with the AG（オンライン） flag have the online consent fee rendered on invoices as a self-pay line with the required label.

### Description
- Change the `billingItems` online-fee entry label in `src/logic/billingLogic.js` from `オンライン対応加算` to `オンライン同意サービス使用料` so the item `{ type: 'online_fee', label: 'オンライン同意サービス使用料', amount: 1000 }` is added when applicable.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969df78b7308321abef0d014a6a238c)