### PR TITLE
Save invoice PDFs in staff/month folders with sequencing and optional cleanup

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -3772,6 +3772,7 @@ function generatePreparedInvoices_(prepared, options) {
       && row.bankFlags
       && row.bankFlags.af === true
   );
+  const aggregateFileOptions = Object.assign({}, opts, { billingMonth: normalized.billingMonth });
   const aggregateFiles = aggregateTargets.map(entry => {
     const pid = billingNormalizePatientId_(entry && entry.patientId);
     if (!pid) return null;
@@ -3799,7 +3800,7 @@ function generatePreparedInvoices_(prepared, options) {
       aggregateTargetMonths: uniqueAggregateMonths
     });
     const aggregateContext = buildAggregateInvoicePdfContext_(aggregateEntry, uniqueAggregateMonths, receiptEnriched, monthCache);
-    const meta = generateAggregateInvoicePdf(aggregateContext, { billingMonth: normalized.billingMonth });
+    const meta = generateAggregateInvoicePdf(aggregateContext, aggregateFileOptions);
     return Object.assign({}, meta, { patientId: aggregateEntry.patientId, nameKanji: aggregateEntry.nameKanji });
   }).filter(Boolean);
   const matchedIds = new Set(


### PR DESCRIPTION
### Motivation
- Organize generated invoice PDFs into staff + year/month folders so files are automatically placed per担当者 and billing month (no change to PDF content or amounts). 
- Provide predictable file names (`01_患者名.pdf`, `02_…`) and an option to clear the same-month folder on re-generation to support fresh exports.

### Description
- Added staff/month folder hierarchy under the invoice root: `請求書/スタッフ別/{staffName}/{YYYY}年/{MM}月分` and ensure folders are created only when missing by introducing `resolveInvoiceStaffFolderName_`, `resolveInvoiceMonthFolderLabels_`, and `ensureInvoiceStaffRootFolder_` in `src/output/billingOutput.js`.
- Implemented per-folder cleanup and sequencing state with `clearInvoiceFolderIfNeeded_`, `countInvoicePdfFiles_`, `consumeInvoiceSequenceIndex_`, and `formatInvoiceSequenceFileName_`, and use these in `saveInvoicePdf` so saved PDFs are named `NN_患者名.pdf` and numbering continues consistently within a month folder.
- Made `saveInvoicePdf` accept `options.folder`, `options.sequenceIndex`, and `options.clearMonthFolder`, and preserved existing overwrite behavior while setting the PDF blob name before save.
- Propagated invoice file options into aggregate invoice generation by forwarding `opts` to `generateAggregateInvoicePdf` in `src/main.gs` so aggregate files follow the same foldering/sequence rules.
- Modified `generateInvoicePdfs` to carry through the merged `options` (preserving `overwriteExisting` semantics for partial vs bulk generation).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969e3f5f0a8832187f69a3b3cc3f25d)