### PR TITLE
Include self-pay items in invoice PDF detail rows

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -1085,6 +1085,11 @@ function buildInvoiceTemplateData_(item) {
     { label: '施術料', detail: formatBillingCurrency_(unitPrice) + '円 × ' + visits + '回', amount: breakdown.treatmentAmount },
     { label: '交通費', detail: transportDetail, amount: breakdown.transportAmount }
   ];
+  const selfPayItems = Array.isArray(breakdown.selfPayItems) ? breakdown.selfPayItems : [];
+  selfPayItems.forEach(entry => {
+    if (!entry) return;
+    rows.push({ label: entry.type || '', detail: '', amount: entry.amount });
+  });
   if (carryOverAmount !== 0) {
     rows.unshift({ label: '前月繰越', detail: '', amount: carryOverAmount });
   }


### PR DESCRIPTION
### Motivation
- Fix missing self-pay entries (e.g. "オンライン同意サービス使用料") from the invoice PDF details by ensuring `selfPayItems` are rendered in the same detail table as treatment and transport charges.

### Description
- In `src/output/billingOutput.js` the `buildInvoiceTemplateData_` function now collects `breakdown.selfPayItems` and appends each item as a row with the item `type` as the label and `amount` as the value so they appear in the invoice detail table.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969ffa10b548321843512fc5833878f)