### PR TITLE
Include online-fee patients and always show current self-pay items in invoice rows

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -1049,13 +1049,15 @@ function buildInvoiceTemplateData_(item) {
   ));
   const isAggregateInvoice = !!(aggregateDecision && aggregateDecision.isAggregateInvoice);
   const chargeMonthLabel = monthLabel;
-  let breakdown = calculateInvoiceChargeBreakdown_(Object.assign({}, item, { billingMonth }));
+  const baseBreakdown = calculateInvoiceChargeBreakdown_(Object.assign({}, item, { billingMonth }));
+  let breakdown = baseBreakdown;
   let visits = breakdown.visits || 0;
   let unitPrice = breakdown.treatmentUnitPrice || 0;
   let carryOverAmount = normalizeBillingCarryOver_(item);
   let transportDetail = breakdown.transportDetail || (formatBillingCurrency_(TRANSPORT_PRICE) + '円 × ' + visits + '回');
   let aggregateMonthTotals = [];
   let grandTotal = breakdown.grandTotal;
+  const baseSelfPayItems = Array.isArray(baseBreakdown.selfPayItems) ? baseBreakdown.selfPayItems : [];
 
   if (isAggregateInvoice && aggregateDecisionMonths.length > 1) {
     const aggregateData = buildAggregateInvoiceBreakdowns_(item, aggregateDecisionMonths, { monthCache });
@@ -1085,8 +1087,7 @@ function buildInvoiceTemplateData_(item) {
     { label: '施術料', detail: formatBillingCurrency_(unitPrice) + '円 × ' + visits + '回', amount: breakdown.treatmentAmount },
     { label: '交通費', detail: transportDetail, amount: breakdown.transportAmount }
   ];
-  const selfPayItems = Array.isArray(breakdown.selfPayItems) ? breakdown.selfPayItems : [];
-  selfPayItems.forEach(entry => {
+  baseSelfPayItems.forEach(entry => {
     if (!entry) return;
     rows.push({ label: entry.type || '', detail: '', amount: entry.amount });
   });


### PR DESCRIPTION
### Motivation
- Ensure patients flagged for the online-consent fee are included in prepared billing even if they have zero visits so the ¥1,000 online fee is preserved for later aggregation and receipts.
- Ensure the current-month self-pay entries (including the online-fee line) always appear as invoice rows in the PDF regardless of carry-over or aggregate decision adjustments.
- Make this change without altering prepared billing storage, totals calculation, or PDF templates.

### Description
- Add `resolveOnlineFeeFlag_` helper to detect online-fee eligibility from raw patient fields and use it in billing logic via `generateBillingJsonFromSource` so online-fee patient IDs are added to the billing set even when visit count is zero.
- When building `billingItems` and `selfPayItems` in `generateBillingJsonFromSource`, use `resolveOnlineFeeFlag_` to append the `online_fee` item (`amount: 1000`) into `selfPayItems` as before.
- In `buildInvoiceTemplateData_` capture the base/current-month breakdown via `baseBreakdown = calculateInvoiceChargeBreakdown_(...)` and use `baseSelfPayItems` when appending rows so current self-pay items are always emitted even if `breakdown` is later replaced for aggregate/carry-over logic.
- Keep existing totals, PDF template shape, and prepared-billing generation logic unchanged apart from the inclusion behavior above.

### Testing
- No automated tests were executed (`npm test` / CI not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a046393e88321982032f438638056)