### PR TITLE
Use bank withdrawal sheet 'オンライン' (AG) flag to determine online fee

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -1147,6 +1147,8 @@ function collectBankWithdrawalStatusByPatient_(billingMonth) {
   const headers = sheet.getRange(1, 1, 1, lastCol).getDisplayValues()[0];
   const unpaidCol = resolveBillingColumn_(headers, [BANK_WITHDRAWAL_UNPAID_HEADER], BANK_WITHDRAWAL_UNPAID_HEADER, {});
   const aggregateCol = resolveBillingColumn_(headers, [BANK_WITHDRAWAL_AGGREGATE_HEADER], BANK_WITHDRAWAL_AGGREGATE_HEADER, {});
+  const onlineCol = resolveBillingColumn_(headers, [BANK_WITHDRAWAL_ONLINE_HEADER], BANK_WITHDRAWAL_ONLINE_HEADER, {});
+  const onlineCol = resolveBillingColumn_(headers, [BANK_WITHDRAWAL_ONLINE_HEADER], BANK_WITHDRAWAL_ONLINE_HEADER, {});
   const amountCol = resolveBillingColumn_(
     headers,
     ['金額', '請求金額', '引落額', '引落金額'],
@@ -3101,6 +3103,7 @@ function getBankFlagsByPatient_(billingMonth, prepared) {
   const headers = sheet.getRange(1, 1, 1, lastCol).getDisplayValues()[0];
   const unpaidCol = resolveBillingColumn_(headers, [BANK_WITHDRAWAL_UNPAID_HEADER], BANK_WITHDRAWAL_UNPAID_HEADER, {});
   const aggregateCol = resolveBillingColumn_(headers, [BANK_WITHDRAWAL_AGGREGATE_HEADER], BANK_WITHDRAWAL_AGGREGATE_HEADER, {});
+  const onlineCol = resolveBillingColumn_(headers, [BANK_WITHDRAWAL_ONLINE_HEADER], BANK_WITHDRAWAL_ONLINE_HEADER, {});
   const nameCol = resolveBillingColumn_(headers, BILLING_LABELS.name, '名前', { required: true, fallbackLetter: 'A' });
   const kanaCol = resolveBillingColumn_(headers, BILLING_LABELS.furigana, 'フリガナ', {});
   const pidCol = resolveBillingColumn_(headers, BILLING_LABELS.recNo.concat(['患者ID', '患者番号']), '患者ID', {});
@@ -3119,10 +3122,15 @@ function getBankFlagsByPatient_(billingMonth, prepared) {
       : '');
     if (!pid) return;
 
-    const current = flagsByPatient[pid] || { ae: false, af: false };
+    const current = flagsByPatient[pid] || { ae: false, af: false, online: false };
     const ae = unpaidCol ? normalizeBankFlagValue_(row[unpaidCol - 1]) : false;
     const af = aggregateCol ? normalizeBankFlagValue_(row[aggregateCol - 1]) : false;
-    flagsByPatient[pid] = { ae: current.ae || ae, af: current.af || af };
+    const online = onlineCol ? normalizeBankFlagValue_(row[onlineCol - 1]) : false;
+    flagsByPatient[pid] = {
+      ae: current.ae || ae,
+      af: current.af || af,
+      online: current.online || online
+    };
   });
 
   return flagsByPatient;


### PR DESCRIPTION
### Motivation
- Centralize online consent (AG) source to the bank withdrawal sheet so the online fee is decided from the bank sheet's checkbox rather than patient master or other sheets.
- Ensure billing generation adds the `online_fee` (¥1,000) only when the bank withdrawal row indicates online consent, without changing amount logic, PDFs, or AE/AF behavior.

### Description
- Pass `bankFlagsByPatient` through billing source normalization by adding it to `normalizeBillingSource_` and the billing source payload (`src/logic/billingLogic.js`).
- Replace the previous patient-field AG detection with a new `resolveOnlineFeeFlag_(patientId, bankFlagsByPatient)` which checks `flags.online` or `flags.ag` from the bank flags map (`src/logic/billingLogic.js`).
- Include patients flagged for online fee into the billing candidate set and add `online_fee` into `billingItems`/`selfPayItems` when the bank flag indicates consent (`src/logic/billingLogic.js`).
- Capture the `オンライン` checkbox from the bank withdrawal sheet into the per-patient bank flags map by reading the `onlineCol` and storing `online` alongside existing `ae`/`af` flags in `getBankFlagsByPatient_` and related bank-sheet parsing (`src/main.gs`).

### Testing
- No automated tests were executed as part of this change.
- Manual verification steps were not recorded in automated form and therefore no pass/fail results are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b3751cb0c8321be1f8c67e111dee9)