### PR TITLE
請求書PDF: selfPayItemsを明細行に追加し、PreparedBilling.grandTotalを合計に使用

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -3734,6 +3734,13 @@ function buildStandardInvoiceAmountDataForPdf_(entry, billingMonth) {
     { label: '施術料', detail: formatBillingCurrency_(unitPrice) + '円 × ' + visits + '回', amount: breakdown.treatmentAmount || 0 },
     { label: '交通費', detail: transportDetail, amount: breakdown.transportAmount || 0 }
   ];
+  const selfPayItems = Array.isArray(entry && entry.selfPayItems)
+    ? entry.selfPayItems
+    : [];
+  selfPayItems.forEach(item => {
+    if (!item) return;
+    rows.push({ label: item.type || '', detail: '', amount: item.amount });
+  });
 
   return {
     rows,
@@ -3786,6 +3793,9 @@ function finalizeInvoiceAmountDataForPdf_(entry, billingMonth, aggregateMonths, 
   });
   if (hasBreakdownTotal) {
     amount.grandTotal = breakdownTotal;
+  }
+  if (entry && entry.grandTotal != null && entry.grandTotal !== '') {
+    amount.grandTotal = normalizeMoneyNumber_(entry.grandTotal);
   }
 
   const receiptDisplay = resolveInvoiceReceiptDisplay_(entry, { aggregateMonths: normalizedAggregateMonths });


### PR DESCRIPTION
### Motivation

- PreparedBilling に含まれる `selfPayItems`（online_fee）を請求書PDFの明細行に必ず表示し、明細からの再計算を行わずに元データをそのまま反映する必要がある。 
- 請求書PDFの合計金額は `billingAmount/total` ではなく PreparedBilling の `grandTotal` を優先して使うべきで、テンプレートや PreparedBilling 生成ロジックは変更しない制約がある。

### Description

- `buildStandardInvoiceAmountDataForPdf_` にて `entry.selfPayItems` を検出して `rows` に追加する処理を実装し、オンライン手数料などの自費項目を明細行に含めるようにした（`src/main.gs`）。
- `finalizeInvoiceAmountDataForPdf_` にて、既存の内訳合計が存在しない場合でも `entry.grandTotal` が存在すれば `amount.grandTotal` を `normalizeMoneyNumber_` 経由で優先して設定するようにした（`src/main.gs`）。

### Testing

- 自動化されたテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b4637b58483219cf213418200e1d8)