### PR TITLE
Prefer item.label for invoice PDF line item labels (fallback to type)

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -209,6 +209,12 @@ function normalizeInvoiceMoney_(value) {
   return Number.isFinite(num) ? num : 0;
 }
 
+function resolveInvoiceItemLabel_(item) {
+  const label = item && item.label != null ? String(item.label).trim() : '';
+  if (label) return label;
+  return item && item.type != null ? String(item.type).trim() : '';
+}
+
 function normalizeInvoiceVisitCount_(value) {
   const source = value && value.visitCount != null ? value.visitCount : value;
   if (typeof source === 'number') {
@@ -1092,7 +1098,7 @@ function buildInvoiceTemplateData_(item) {
   }
   baseSelfPayItems.forEach(entry => {
     if (!entry) return;
-    rows.push({ label: entry.type || '', detail: '', amount: entry.amount });
+    rows.push({ label: resolveInvoiceItemLabel_(entry), detail: '', amount: entry.amount });
   });
 
   return Object.assign({}, item, {


### PR DESCRIPTION
### Motivation
- Fix invoice PDF detail row labeling so that `item.label` is used when present and `item.type` is used only as a fallback to avoid internal keys like `online_fee` being displayed.

### Description
- Add `resolveInvoiceItemLabel_` helper and use it when building invoice `rows` in `src/output/billingOutput.js` so PDF detail lines prefer `label` and fall back to `type` if needed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b6f3611b88321b38eb6f8c41abf51)