### PR TITLE
Fix previous receipt visibility in invoice PDF

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -589,6 +589,13 @@ function isPreviousReceiptSettled_(item) {
   return String(status || '').toUpperCase() === 'SETTLED';
 }
 
+function hasPreviousReceiptAmount_(item) {
+  const previousAmount = Number(item && item.previousReceiptAmount);
+  if (Number.isFinite(previousAmount) && previousAmount > 0) return true;
+  const breakdown = Array.isArray(item && item.receiptMonthBreakdown) ? item.receiptMonthBreakdown : [];
+  return breakdown.some(row => Number(row && row.amount) > 0);
+}
+
 function buildInvoicePreviousReceipt_(item, display, aggregateMonths) {
   const receiptDisplay = display || resolveInvoiceReceiptDisplay_(item);
   const addressee = item && item.nameKanji ? String(item.nameKanji).trim() : '';
@@ -621,7 +628,7 @@ function buildInvoicePreviousReceipt_(item, display, aggregateMonths) {
   const receiptMonthBreakdown = isAggregateInvoice ? aggregateBreakdown : null;
 
   return {
-    visible: !!(receiptDisplay && receiptDisplay.visible),
+    visible: hasPreviousReceiptAmount_(item),
     addressee,
     date,
     amount: Number.isFinite(resolvedAmount) ? resolvedAmount : 0,
@@ -972,7 +979,7 @@ function buildAggregateInvoiceTemplateData_(item, aggregateMonths) {
   }
 
   if (previousReceipt) {
-    previousReceipt.visible = !!(receipt && receipt.visible);
+    previousReceipt.visible = hasPreviousReceiptAmount_(item);
   }
 
   const aggregateDecision = resolveAggregateInvoiceDecision_(item, receipt, billingMonth, { monthCache });
@@ -1038,7 +1045,7 @@ function buildInvoiceTemplateData_(item) {
   }
 
   if (previousReceipt) {
-    previousReceipt.visible = !!(receipt && receipt.visible);
+    previousReceipt.visible = hasPreviousReceiptAmount_(item);
   }
 
   const aggregateDecisionTrace = Object.assign(


### PR DESCRIPTION
### Motivation
- 請求書PDFで前月分領収書ブロックが表示されない不具合を修正するため、前月請求金額の実在ベースで表示判定を行う必要がある。
- 表示判定は `previousReceiptAmount > 0` または `receiptMonthBreakdown` の内訳に金額がある場合とし、`carryOver` フラグや既存の表示フラグに依存させない要件に従うため。 

### Description
- `src/output/billingOutput.js` に `hasPreviousReceiptAmount_` ヘルパー関数を追加し、`previousReceiptAmount` が正数か、`receiptMonthBreakdown` のいずれかの `amount` が正数であるかを判定するようにした。 
- `buildInvoicePreviousReceipt_` 内の `visible` 判定を `receiptDisplay.visible` から `hasPreviousReceiptAmount_(item)` に変更した。 
- 集計請求テンプレート／通常請求テンプレートで `previousReceipt.visible` を設定している箇所も同様に `hasPreviousReceiptAmount_(item)` を使うように置換した。 

### Testing
- 自動テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b73e6d688832192ab119e26ac44bc)