### PR TITLE
Add persistent オンライン同意 (AT) flag, sync to bank sheet, and bill online fee via AG

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -182,6 +182,7 @@ const BILLING_LABELS = typeof LABELS !== 'undefined' ? LABELS : {
   consent: ['同意年月日', '同意日', '同意開始日', '同意開始'],
   consentHandout: ['配布', '配布欄', '配布状況', '配布日', '配布（同意書）'],
   consentContent: ['同意症状', '同意内容', '施術対象疾患', '対象疾患', '対象症状', '同意書内容', '同意記載内容'],
+  onlineConsent: ['オンライン同意', 'オンライン同意フラグ', 'オンライン同意（AT）', 'オンライン同意(AT)'],
   share: ['負担割合', '負担', '自己負担', '負担率', '負担割', '負担%', '負担％'],
   phone: ['電話', '電話番号', 'TEL', 'Tel']
 };
@@ -244,6 +245,7 @@ const BILLING_PATIENT_COLS_FIXED = typeof PATIENT_COLS_FIXED !== 'undefined' ? P
   consent: 28,
   consentHandout: 54,
   consentContent: 25,
+  onlineConsent: 46,
   phone: 32,
   share: 47
 };
@@ -1169,6 +1171,12 @@ function getBillingPatientRecords() {
     '交通費',
     {}
   );
+  const colOnlineConsent = resolveBillingColumn_(
+    headers,
+    BILLING_LABELS.onlineConsent || ['オンライン同意'],
+    'オンライン同意',
+    { fallbackLetter: 'AT' }
+  );
 
   return values.map(row => {
     const pid = billingNormalizePatientId_(row[colPid - 1]);
@@ -1204,7 +1212,8 @@ function getBillingPatientRecords() {
       accountNumber: colAccount ? String(row[colAccount - 1] || '').trim() : '',
       isNew: colIsNew ? normalizeZeroOneFlag_(row[colIsNew - 1]) : 0,
       carryOverAmount: colCarryOver ? normalizeMoneyValue_(row[colCarryOver - 1]) : 0,
-      medicalSubsidy: colMedicalSubsidy ? normalizeZeroOneFlag_(row[colMedicalSubsidy - 1]) : 0
+      medicalSubsidy: colMedicalSubsidy ? normalizeZeroOneFlag_(row[colMedicalSubsidy - 1]) : 0,
+      onlineConsent: colOnlineConsent ? normalizeZeroOneFlag_(row[colOnlineConsent - 1]) : 0
     };
   }).filter(Boolean);
 }

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -55,7 +55,7 @@ const BILLING_TRANSPORT_UNIT_PRICE_FALLBACK = 33;
 const BILLING_TRANSPORT_UNIT_PRICE = (typeof globalThis !== 'undefined' && typeof globalThis.BILLING_TRANSPORT_UNIT_PRICE === 'number')
   ? globalThis.BILLING_TRANSPORT_UNIT_PRICE
   : BILLING_TRANSPORT_UNIT_PRICE_FALLBACK;
-const BILLING_PATIENT_INFO_FIELDS = ['medicalAssistance', 'burdenRate', 'payerType', 'responsible', 'bankInfo', 'isNew'];
+const BILLING_PATIENT_INFO_FIELDS = ['medicalAssistance', 'onlineConsent', 'burdenRate', 'payerType', 'responsible', 'bankInfo', 'isNew'];
 const BILLING_BILLING_OVERRIDES_FIELDS = ['unitPrice', 'transportAmount', 'carryOverAmount', 'visitCount', 'selfPayAmount'];
 const BILLING_OVERRIDE_BADGE_FIELDS = ['unitPrice', 'transportAmount', 'carryOverAmount', 'visitCount', 'selfPayAmount', 'burdenRate'];
 
@@ -838,6 +838,11 @@ function normalizeMedicalAssistanceFlag(value) {
   return 0;
 }
 
+function normalizeOnlineConsentFlag(value) {
+  if (value === 1 || value === '1' || value === true) return 1;
+  return 0;
+}
+
 function getBillingBaseUrl() {
   return (window.APP_CONFIG && window.APP_CONFIG.baseUrl) || '';
 }
@@ -1280,6 +1285,7 @@ function normalizeBillingResultPayload(raw) {
     insuranceType: '',
     burdenRate: 0,
     medicalAssistance: 0,
+    onlineConsent: 0,
     manualUnitPrice: '',
     manualTransportAmount: '',
     manualSelfPayAmount: '',
@@ -1362,6 +1368,7 @@ function normalizeBillingResultPayload(raw) {
         insuranceType: patient.insuranceType,
         burdenRate: patient.burdenRate,
         medicalAssistance: patient.medicalAssistance,
+        onlineConsent: patient.onlineConsent,
         manualUnitPrice: patient.manualUnitPrice != null ? patient.manualUnitPrice : patient.unitPrice,
         manualTransportAmount: patient.manualTransportAmount,
         manualSelfPayAmount: patient.manualSelfPayAmount,
@@ -1391,6 +1398,11 @@ function normalizeBillingResultPayload(raw) {
         ? row.medicalAssistance
         : patient.medicalAssistance;
       merged.medicalAssistance = normalizeMedicalAssistanceFlag(assistanceSource);
+
+      const consentSource = row && row.hasOwnProperty('onlineConsent')
+        ? row.onlineConsent
+        : patient.onlineConsent;
+      merged.onlineConsent = normalizeOnlineConsentFlag(consentSource);
 
       const manualPriceSource = row && row.hasOwnProperty('manualUnitPrice')
         ? row.manualUnitPrice
@@ -2011,6 +2023,7 @@ function renderBillingResult() {
     { key: 'nameKanji', label: '氏名', sortable: true },
     { key: 'responsible', label: '担当者', sortable: true },
     { key: 'medicalAssistance', label: '医療助成', sortable: false },
+    { key: 'onlineConsent', label: 'オンライン同意', sortable: false },
     { key: 'payerType', label: '保険者', sortable: false },
     { key: 'burdenRate', label: '負担', sortable: true },
     { key: 'visitCount', label: '回数', sortable: true },
@@ -2070,6 +2083,11 @@ function renderBillingResult() {
         const editor = `<label class="${editClass}" style="display:flex;align-items:center;gap:6px;"><input type="checkbox" ${baseAttrs} ${checked} />医療助成</label>`;
         return wrapWithOverrideBadge(editor, item.patientId, field, alignRight);
       }
+      if (field === 'onlineConsent') {
+        const checked = normalizeOnlineConsentFlag(item.onlineConsent) ? 'checked' : '';
+        const editor = `<label class="${editClass}" style="display:flex;align-items:center;gap:6px;"><input type="checkbox" ${baseAttrs} ${checked} />オンライン同意</label>`;
+        return wrapWithOverrideBadge(editor, item.patientId, field, alignRight);
+      }
       if (field === 'unitPrice' || field === 'carryOverAmount') {
         const val = normalizeEditNumber(item[field]);
         const editor = `<input class="${editClass}" ${baseAttrs} type="number" step="10" value="${val}" />`;
@@ -2089,6 +2107,8 @@ function renderBillingResult() {
       switch (field) {
         case 'medicalAssistance':
           return normalizeMedicalAssistanceFlag(item.medicalAssistance) ? '有' : 'なし';
+        case 'onlineConsent':
+          return normalizeOnlineConsentFlag(item.onlineConsent) ? '有' : 'なし';
         case 'burdenRate':
           if (String(item.burdenRate) === '自費') {
             const selfPayAmount = item.manualSelfPayAmount || 0;
@@ -2124,6 +2144,7 @@ function renderBillingResult() {
         <td>${nameWithBadge}</td>
         <td>${getResponsibleDisplay(safeItem) || '—'}</td>
         <td>${renderEditableCell(safeItem, 'medicalAssistance')}</td>
+        <td>${renderEditableCell(safeItem, 'onlineConsent')}</td>
         <td>${renderEditableCell(safeItem, 'payerType')}</td>
         <td>${renderEditableCell(safeItem, 'burdenRate')}</td>
         <td>${wrapWithOverrideBadge(safeItem.visitCount || 0, safeItem.patientId, 'visitCount')}</td>
@@ -2208,7 +2229,9 @@ function attachBillingEditHandlers() {
       const field = this.getAttribute('data-edit-field');
       let value = this.value;
       if (this.type === 'checkbox') {
-        value = normalizeMedicalAssistanceFlag(this.checked);
+        value = field === 'onlineConsent'
+          ? normalizeOnlineConsentFlag(this.checked)
+          : normalizeMedicalAssistanceFlag(this.checked);
       }
       if (field === 'burdenRate') {
         value = value === '自費' ? '自費' : normalizeBurdenRateInt(value);


### PR DESCRIPTION
### Motivation
- Capture a persistent "オンライン同意" (AT) flag on the patient master and ensure bank withdrawal sheet AG checkbox is set for consenting patients so billing can reliably decide online-fee application.
- Make billing generation rely solely on the AG flag for online fee inclusion and preserve existing AG=true values.
- Ensure medical-assistance patients are excluded except when AG=true, in which case a 1,000円 online-fee-only bill is produced.

### Description
- Add a new `onlineConsent`/"オンライン同意" patient field (with header candidates and fallback column `AT`) and persist it in patient edits/updates (`src/get/billingGet.js`, `src/main.gs`).
- Add UI support to view/edit the online consent checkbox in the billing patient table and wire editing/normalization (`src/main.js.html`).
- Sync patient `onlineConsent` into the bank withdrawal sheet online column (sets the online/AG checkbox to true for patients with AT=true during prepare/sync), implemented in `syncBankWithdrawalOnlineConsentFlags_` and invoked during payload build; this does not overwrite existing true values (`src/main.gs`).
- Expose AG in bank flags and change online-fee detection to check AG only (`resolveOnlineFeeFlag_`), and generate a `selfPayItem` of type `online_fee` with label `オンライン同意サービス使用料` amount `1000` when AG is present (`src/logic/billingLogic.js`).
- Adjust billing logic so medical-assistance patients are excluded only when AG is false, and if `medicalAssistance=true` and `AG=true` produce a bill containing only the 1000円 online fee while preserving carry/transport/manual fields appropriately (`src/logic/billingLogic.js`).
- Do not change PDF templates or core amount calculation routines beyond the minimal adjustments to support the online-fee behavior.

### Testing
- No automated tests were run as part of this change. All edits are limited to billing source, bank sync, and UI wiring; recommend running billing prepare/sync workflows in a staging spreadsheet to validate bank-sheet checkbox synchronization and generated billing JSON before production rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b76b0f9408321a2b43145f07cda55)