### PR TITLE
Make billing PDF generation read-only and add Issue 1175 summary

### DIFF
--- a/docs/issue-1175-summary.md
+++ b/docs/issue-1175-summary.md
@@ -1,0 +1,12 @@
+# Issue 1175 共有サマリー
+
+## 変更点
+- 請求PDF生成時に `applyEdits` を送らないようにし、PDF生成が編集保存を要求しないように変更。
+- サーバー側でも `generatePreparedInvoicesForMonth` が `applyEdits` を受け取っても無視するようにし、PDF生成時に `applyBillingEdits` が実行されないように変更。
+
+## 変更理由
+- PDF生成フローがPreparedBillingや銀行引落シートに書き込みを行うと、AE/AF/AGフラグ（合算など）が意図せず解除・再計算される可能性があるため、完全に参照専用に固定する。
+
+## 影響範囲
+- 影響対象: 請求PDF生成（PreparedBillingを選択してPDF生成する導線）。
+- 影響外: 集計処理、手動保存（請求編集の保存）、請求金額算出ロジック、PDFテンプレート。

--- a/src/main.gs
+++ b/src/main.gs
@@ -4565,7 +4565,7 @@ function generatePreparedInvoicesForMonth(billingMonth, options) {
 
   const opts = options || {};
   if (opts.applyEdits === true) {
-    applyBillingEdits(monthKey, opts);
+    billingLogger_.log('[billing] generatePreparedInvoicesForMonth ignored applyEdits to keep PDF generation read-only');
   }
 
   const loaded = loadPreparedBillingForPdfGeneration_(monthKey, { withValidation: true });

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -1683,13 +1683,9 @@ function handleBillingPdfGeneration() {
   billingState.invoiceMode = invoiceMode;
   billingState.invoicePatientIdsInput = invoicePatientIdsText;
   setBillingLoading(true, 'PDF生成中…');
-  const preparedMonth = normalizeYm(billingState.prepared && billingState.prepared.billingMonth);
-  // 編集反映は「prepared月＝PDF対象月」の場合のみ。過去月編集は対象外。
-  const shouldApplyEdits = preparedMonth && preparedMonth === targetMonth;
   const payload = Object.assign({}, buildBillingSavePayload(), {
     invoiceMode,
-    invoicePatientIds,
-    applyEdits: shouldApplyEdits
+    invoicePatientIds
   });
   google.script.run
     .withSuccessHandler(onBillingPdfCompleted)


### PR DESCRIPTION
### Motivation
- Prevent PDF generation from triggering writes to PreparedBilling or bank withdrawal sheets because those writes can clear or recompute AE/AF/AG flags and cause data drift. 
- Ensure the PDF flow is strictly read-only so generating invoices does not mutate billing state or sheet data.

### Description
- Stop applying edits during PDF generation by ignoring `opts.applyEdits` inside `generatePreparedInvoicesForMonth` and log a message instead of calling `applyBillingEdits` in `src/main.gs`.
- Remove the `applyEdits` flag from the client payload in `handleBillingPdfGeneration` so the client no longer requests edit application in `src/main.js.html`.
- Add a shared summary document at `docs/issue-1175-summary.md` that describes the change, rationale, and impact scope.

### Testing
- No automated tests were run for this change.
- Manual verification was performed by reviewing the server-side guard and client payload removal to ensure the PDF path no longer attempts to apply edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c8e26371c83218e450d51cd3df7d6)