### PR TITLE
Fix invoice PDF line item label resolution

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -210,9 +210,11 @@ function normalizeInvoiceMoney_(value) {
 }
 
 function resolveInvoiceItemLabel_(item) {
+  const type = item && item.type != null ? String(item.type).trim() : '';
+  if (type === 'online_fee') return 'オンライン同意サービス利用料';
   const label = item && item.label != null ? String(item.label).trim() : '';
   if (label) return label;
-  return item && item.type != null ? String(item.type).trim() : '';
+  return type;
 }
 
 function normalizeInvoiceVisitCount_(value) {


### PR DESCRIPTION
### Motivation
- Ensure invoice PDF line item display names follow the rules: prefer an explicit `label`, fall back to `type` only when `label` is absent, and always render `online_fee` as a user-facing Japanese name rather than exposing the internal key.

### Description
- Update `resolveInvoiceItemLabel_` in `src/output/billingOutput.js` to return the hardcoded string `オンライン同意サービス利用料` for `type === 'online_fee'`, then prefer `item.label` if present, and otherwise return the normalized `type`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ca7a738ec8321b21d40a1c79cbec5)