### PR TITLE
Count mixed treatments as self30 in visit attendance aggregation

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -11381,7 +11381,10 @@ function syncVisitAttendance(options){
         else if (categoryKey === 'self60') pendingEntry.counts.self60 += 1;
         else pendingEntry.counts.self30 += 1;
       }
-      if (group === 'mixed') pendingEntry.counts.mixed += 1;
+      if (group === 'mixed') {
+        pendingEntry.counts.mixed += 1;
+        pendingEntry.counts.self30 += 1;
+      }
       if (group === 'new') pendingEntry.counts.new += 1;
     }
     pendingEntry.rowNumbers.push(rowNumber);


### PR DESCRIPTION
### Motivation
- Mixed 60-minute treatments (`saveKind="mixed"`) should be treated as a single insurance visit for `visitCount` while also contributing to self-pay 30-minute totals so self-pay aggregations reflect the split billing.

### Description
- When building visit attendance in `syncVisitAttendance` (`src/Code.js`), increment `pendingEntry.counts.self30` alongside `pendingEntry.counts.mixed` when `group === 'mixed'`, preserving the existing `mixed` count.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cb49272808321b858b9fd740d95ba)