### PR TITLE
Count mixed (保険＋自費) as self30 for self-pay aggregation

### DIFF
--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -131,6 +131,13 @@ function normalizeVisitCount_(value) {
   return Number.isFinite(num) && num > 0 ? num : 0;
 }
 
+function normalizeSelfPayCount_(value) {
+  if (!value || typeof value !== 'object') return 0;
+  const self30 = Number(value.self30) || 0;
+  const self60 = Number(value.self60) || 0;
+  return self30 + self60;
+}
+
 function normalizeMoneyNumber_(value) {
   if (typeof value === 'number') {
     return Number.isFinite(value) ? value : 0;
@@ -324,6 +331,7 @@ function generateBillingJsonFromSource(sourceData) {
     }
     const rawVisitCount = treatmentVisitCounts[pid];
     const visitCount = normalizeVisitCount_(rawVisitCount);
+    const selfPayCount = normalizeSelfPayCount_(rawVisitCount);
     if (!visitCount && zeroVisitDebug.length < 20) {
       zeroVisitDebug.push({
         patientId: pid,
@@ -376,6 +384,7 @@ function generateBillingJsonFromSource(sourceData) {
       burdenRate: normalizedBurdenRate,
       medicalAssistance: normalizedMedicalAssistance,
       visitCount: amountCalc.visits,
+      selfPayCount,
       manualUnitPrice,
       unitPrice: amountCalc.unitPrice,
       treatmentAmount: amountCalc.treatmentAmount,


### PR DESCRIPTION
### Motivation
- Fix a billing aggregation bug where mixed treatments (`saveKind="mixed"` / `group === "mixed"`) contained a 30min self-pay portion that was not reflected in self-pay totals while keeping `visitCount` semantics unchanged.

### Description
- Add treatment category normalization and helpers in `src/get/billingGet.js` (`BILLING_TREATMENT_CATEGORY_*`, `normalizeTreatmentCategoryKey_`).
- Read a treatment category column when loading treatment logs and attach `treatmentCategoryKey`/`treatmentCategoryLabel` to each log in `loadTreatmentLogs_` in `src/get/billingGet.js`.
- Change `buildVisitCountMap_` (in `src/get/billingGet.js`) to track `self30`, `self60` and `mixed` per patient and to increment `self30` when a `mixed` entry is encountered (so mixed contributes to self-pay 30 counts) while leaving `visitCount` logic unchanged.
- Add `normalizeSelfPayCount_` to `src/logic/billingLogic.js` and expose `selfPayCount` in generated billing JSON returned by `generateBillingJsonFromSource` so self-pay counts (including mixed→self30) are available to billing consumers.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cb7a6952883219a997abb17e0f93c)