### PR TITLE
Add self-pay count column to billing result table

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -2023,6 +2023,7 @@ function renderBillingResult() {
     { key: 'payerType', label: '保険者', sortable: false },
     { key: 'burdenRate', label: '負担', sortable: true },
     { key: 'visitCount', label: '回数', sortable: true },
+    { key: 'selfPayCount', label: '自費回数', sortable: false },
     { key: 'unitPrice', label: '単価', sortable: true },
     { key: 'treatmentAmount', label: '施術料', sortable: true },
     { key: 'transportAmount', label: '交通費', sortable: true },
@@ -2134,6 +2135,10 @@ function renderBillingResult() {
     try {
       const safeItem = item && typeof item === 'object' ? item : {};
       const nameWithBadge = `${safeItem.nameKanji || ''}${renderStatusBadges(safeItem)}`;
+      const selfPayCount = safeItem.selfPayCount;
+      const selfPayDisplay = (selfPayCount === 0 || selfPayCount === '0' || selfPayCount)
+        ? selfPayCount
+        : '—';
       bodyRows.push(`
       <tr>
         <td>${safeItem.patientId || ''}</td>
@@ -2144,6 +2149,7 @@ function renderBillingResult() {
         <td>${renderEditableCell(safeItem, 'payerType')}</td>
         <td>${renderEditableCell(safeItem, 'burdenRate')}</td>
         <td>${wrapWithOverrideBadge(safeItem.visitCount || 0, safeItem.patientId, 'visitCount')}</td>
+        <td>${selfPayDisplay}</td>
         <td class="right">${renderEditableCell(safeItem, 'unitPrice', true)}</td>
         <td class="right">${formatCurrency(safeItem.treatmentAmount)}</td>
         <td class="right">${renderEditableCell(safeItem, 'transportAmount', true)}</td>


### PR DESCRIPTION
### Motivation
- Display per-patient self-pay counts (「自費回数」) in the generated billing result table using the existing `selfPayCount` supplied in `billingJson`, while keeping aggregation and PDF/prepared-saving logic unchanged.

### Description
- Add a new header column `{ key: 'selfPayCount', label: '自費回数' }` in `src/main.js.html` for the billing result table. 
- Compute a `selfPayDisplay` from `safeItem.selfPayCount` and render it as a dedicated cell next to `visitCount`, explicitly showing `0` or a fallback `'—'` when absent. 
- This is a UI-only change and does not modify aggregation, totals, PDF generation, or `PreparedBilling` persistence.

### Testing
- No automated tests were executed because this is a UI-only change and was validated via code inspection only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cbf96391c83219cbbdc6684d9fdb0)