### PR TITLE
Include self30, self60 and mixed in selfPayCount calculation

### DIFF
--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -135,7 +135,9 @@ function normalizeSelfPayCount_(value) {
   if (!value || typeof value !== 'object') return 0;
   const self30 = Number(value.self30) || 0;
   const self60 = Number(value.self60) || 0;
-  return self30 + self60;
+  const mixed = Number(value.mixed) || 0;
+  const self30Only = Math.max(0, self30 - mixed);
+  return self30Only + self60 + mixed;
 }
 
 function normalizeMoneyNumber_(value) {


### PR DESCRIPTION
### Motivation
- Fix incorrect interpretation so `selfPayCount` reflects the number of visits that include any self-pay portion by counting `self30`, `self60`, and `mixed` visits while leaving visit counts, amount calculations, PDF output, and data format unchanged.

### Description
- Update `normalizeSelfPayCount_` in `src/logic/billingLogic.js` to compute `selfPayCount` as `self30Only + self60 + mixed` where `self30Only = Math.max(0, self30 - mixed)` to avoid double-counting mixed entries; no other logic was modified.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cc69cc74c8321989edb850d4070c2)