### PR TITLE
Preserve visit breakdown when applying adjustedVisitCount in getBillingSourceData

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -1571,7 +1571,20 @@ function getBillingSourceData(billingMonth) {
       billingOverrideFlags[pid] = flags;
     }
     if (override.adjustedVisitCount !== undefined) {
-      treatmentVisitCounts[pid] = override.adjustedVisitCount;
+      const adjustedVisitCount = override.adjustedVisitCount;
+      const currentVisitCount = treatmentVisitCounts[pid];
+      if (currentVisitCount && typeof currentVisitCount === 'object') {
+        treatmentVisitCounts[pid] = Object.assign({}, currentVisitCount, {
+          visitCount: adjustedVisitCount
+        });
+      } else {
+        treatmentVisitCounts[pid] = {
+          visitCount: adjustedVisitCount,
+          self30: 0,
+          self60: 0,
+          mixed: 0
+        };
+      }
     }
   });
   const staffDirectory = loadBillingStaffDirectory_();


### PR DESCRIPTION
### Motivation
- The previous logic in `getBillingSourceData` replaced `treatmentVisitCounts[pid]` with a raw number when `adjustedVisitCount` was present, which destroyed the `self30`/`self60`/`mixed` breakdown and caused `selfPayCount` to become 0.
- The intent is for `adjustedVisitCount` to only override the total insurance visit count while preserving the per-category breakdown that feeds `selfPayCount`.

### Description
- Update `src/get/billingGet.js` so that when `override.adjustedVisitCount` is present, if `treatmentVisitCounts[pid]` is an object it is copied with only the `visitCount` field overridden via `Object.assign`.</p>
- If `treatmentVisitCounts[pid]` is a number or missing, convert it into an object with `visitCount` set to the adjusted value and `self30`, `self60`, and `mixed` initialized to `0` to preserve shape for downstream logic.</p>
- Do not modify visit count normalization, billing amount calculations, or PDF/output logic outside this targeted change.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cccacb0d88321914cc392905de4a0)