### PR TITLE
Add UI toggles to include/exclude insurance and self-pay invoice PDFs

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -175,6 +175,17 @@
         <div id="billingError" class="alert danger" style="display:none"></div>
       </div>
       <div class="generation-options">
+        <p class="muted" style="margin:0">PDF生成対象</p>
+        <div class="mode-options" role="group" aria-label="請求書PDFの出力対象">
+          <label class="pill-input">
+            <input type="checkbox" id="includeInsurancePdf" checked onchange="handleInvoicePdfOptionChange(event)" />
+            <span>保険請求PDF</span>
+          </label>
+          <label class="pill-input">
+            <input type="checkbox" id="includeSelfPayPdf" onchange="handleInvoicePdfOptionChange(event)" />
+            <span>自費請求PDF</span>
+          </label>
+        </div>
         <p class="muted" style="margin:0">PDF生成モード</p>
           <div class="mode-options" role="group" aria-label="請求書PDFの生成モード">
             <label class="pill-input">

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -20,7 +20,9 @@ const billingState = {
   preparedMonths: [],
   selectedPreparedMonth: '',
   reaggregationRequiredMonths: {},
-  sort: { field: null, direction: 'asc' }
+  sort: { field: null, direction: 'asc' },
+  includeInsurancePdf: true,
+  includeSelfPayPdf: false
 };
 
 const bankFlowState = {
@@ -206,6 +208,7 @@ function updateBillingControls() {
   }
   updatePreparedMonthSelectors();
   updateInvoiceModeControls();
+  updateInvoicePdfOptionControls();
   renderReceiptControls();
   renderPreparedMonthInfo();
 }
@@ -247,6 +250,22 @@ function updateInvoiceModeControls() {
 
   if (note) {
     note.className = isPartial ? 'field-note warn' : 'field-note';
+  }
+}
+
+function updateInvoicePdfOptionControls() {
+  const loading = billingState.loading;
+  const includeInsurance = qs('includeInsurancePdf');
+  const includeSelfPay = qs('includeSelfPayPdf');
+
+  if (includeInsurance) {
+    includeInsurance.disabled = loading;
+    includeInsurance.checked = billingState.includeInsurancePdf !== false;
+  }
+
+  if (includeSelfPay) {
+    includeSelfPay.disabled = loading;
+    includeSelfPay.checked = !!billingState.includeSelfPayPdf;
   }
 }
 
@@ -401,6 +420,18 @@ function getInvoiceMode() {
   return 'bulk';
 }
 
+function getIncludeInsurancePdf() {
+  const checkbox = qs('includeInsurancePdf');
+  if (checkbox) return !!checkbox.checked;
+  return billingState.includeInsurancePdf !== false;
+}
+
+function getIncludeSelfPayPdf() {
+  const checkbox = qs('includeSelfPayPdf');
+  if (checkbox) return !!checkbox.checked;
+  return !!billingState.includeSelfPayPdf;
+}
+
 function getInvoicePatientIdsInput() {
   const textarea = qs('invoicePatientIds');
   return textarea && textarea.value ? textarea.value : '';
@@ -416,6 +447,17 @@ function handleInvoiceModeToggle(event) {
 function handleInvoicePatientInput(event) {
   const value = event && event.target ? event.target.value : getInvoicePatientIdsInput();
   billingState.invoicePatientIdsInput = value;
+}
+
+function handleInvoicePdfOptionChange(event) {
+  if (!event || !event.target) return;
+  if (event.target.id === 'includeInsurancePdf') {
+    billingState.includeInsurancePdf = !!event.target.checked;
+  }
+  if (event.target.id === 'includeSelfPayPdf') {
+    billingState.includeSelfPayPdf = !!event.target.checked;
+  }
+  updateInvoicePdfOptionControls();
 }
 
 function handleReceiptStatusChange(event) {
@@ -1685,7 +1727,9 @@ function handleBillingPdfGeneration() {
   setBillingLoading(true, 'PDF生成中…');
   const payload = Object.assign({}, buildBillingSavePayload(), {
     invoiceMode,
-    invoicePatientIds
+    invoicePatientIds,
+    includeInsurancePdf: getIncludeInsurancePdf(),
+    includeSelfPayPdf: getIncludeSelfPayPdf()
   });
   google.script.run
     .withSuccessHandler(onBillingPdfCompleted)


### PR DESCRIPTION
### Motivation
- Provide UI controls to let operators choose whether to generate insurance PDFs and/or self-pay PDFs so self-pay related processing can be completely skipped when not needed.
- Preserve existing insurance PDF flow, templates and billing calculations while making self-pay generation opt-in.

### Description
- Added two checkboxes to the billing UI: `includeInsurancePdf` (default `true`) and `includeSelfPayPdf` (default `false`) in `src/billing.html` and wired handlers in `src/main.js.html` to maintain state and expose `getIncludeInsurancePdf()`/`getIncludeSelfPayPdf()`.
- Extended client payload for PDF generation to include `includeInsurancePdf` and `includeSelfPayPdf` when calling `generatePreparedInvoicesForMonth`.
- Updated server-side `generatePreparedInvoices_` in `src/main.gs` to read the flags and gate behavior so that insurance PDF context creation / receipt summary work runs only when `includeInsurancePdf` is enabled, and self-pay target selection and PDF generation run only when `includeSelfPayPdf` is enabled.
- Kept existing filename behavior and self-pay suffixing via `appendSelfPaySuffixToFileName_`, and ensured generated files list is composed accordingly.

### Testing
- Attempted an automated visual check using Playwright to capture `src/billing.html`, but the Playwright run failed with a `TargetClosedError` / SIGSEGV from the headless browser process.
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc3ead84c832183a8ae431e503355)