### PR TITLE
Route manual billing overrides to insurance or self-pay bank columns

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -3241,6 +3241,21 @@ function buildBillingAmountByPatientId_(billingJson) {
   (billingJson || []).forEach(entry => {
     const pid = billingNormalizePatientId_(entry && entry.patientId);
     if (!pid) return;
+    const manualBillingInput = entry && Object.prototype.hasOwnProperty.call(entry, 'manualBillingAmount')
+      ? entry.manualBillingAmount
+      : undefined;
+    const hasManualBillingAmount = manualBillingInput !== '' && manualBillingInput !== null && manualBillingInput !== undefined;
+    if (hasManualBillingAmount) {
+      const insuranceType = String(entry && entry.insuranceType != null ? entry.insuranceType : '').trim();
+      const burdenRaw = entry && entry.burdenRate != null ? entry.burdenRate : '';
+      const normalizedBurden = typeof normalizeBurdenRateInt_ === 'function'
+        ? normalizeBurdenRateInt_(burdenRaw)
+        : burdenRaw;
+      const isSelfPay = insuranceType === '自費' || String(burdenRaw || '').trim() === '自費' || normalizedBurden === '自費';
+      if (isSelfPay) {
+        return;
+      }
+    }
     const amountCandidate = entry && entry.grandTotal != null
       ? entry.grandTotal
       : (entry && entry.total != null ? entry.total : entry && entry.billingAmount);
@@ -3257,6 +3272,25 @@ function buildSelfPayAmountByPatientId_(billingJson) {
   (billingJson || []).forEach(entry => {
     const pid = billingNormalizePatientId_(entry && entry.patientId);
     if (!pid) return;
+    const manualBillingInput = entry && Object.prototype.hasOwnProperty.call(entry, 'manualBillingAmount')
+      ? entry.manualBillingAmount
+      : undefined;
+    const hasManualBillingAmount = manualBillingInput !== '' && manualBillingInput !== null && manualBillingInput !== undefined;
+    if (hasManualBillingAmount) {
+      const insuranceType = String(entry && entry.insuranceType != null ? entry.insuranceType : '').trim();
+      const burdenRaw = entry && entry.burdenRate != null ? entry.burdenRate : '';
+      const normalizedBurden = typeof normalizeBurdenRateInt_ === 'function'
+        ? normalizeBurdenRateInt_(burdenRaw)
+        : burdenRaw;
+      const isSelfPay = insuranceType === '自費' || String(burdenRaw || '').trim() === '自費' || normalizedBurden === '自費';
+      if (isSelfPay) {
+        const amount = typeof normalizeMoneyNumber_ === 'function'
+          ? normalizeMoneyNumber_(manualBillingInput)
+          : Number(manualBillingInput) || 0;
+        amounts[pid] = amount;
+        return;
+      }
+    }
     if (!entry || !Object.prototype.hasOwnProperty.call(entry, 'manualSelfPayAmount')) return;
     amounts[pid] = entry.manualSelfPayAmount;
   });


### PR DESCRIPTION
### Motivation
- When a manual billing amount override is saved it must be applied to the correct bank-withdrawal column depending on whether the patient is insured or self-pay so the bank sheet S/T columns reflect the intended target.
- The same classification must be applied during bank-sheet generation and sync so generated sheets and cached amount maps stay consistent.

### Description
- Updated `buildBillingAmountByPatientId_` in `src/main.gs` to ignore `manualBillingAmount` entries for patients detected as self-pay so those manual overrides are not routed into the insurance (S) amount map used for the bank sheet.
- Updated `buildSelfPayAmountByPatientId_` in `src/main.gs` to route `manualBillingAmount` into the self-pay amount map when the entry is classified as self-pay, while preserving existing `manualSelfPayAmount` handling.
- Classification uses `insuranceType` and `burdenRate` (via `normalizeBurdenRateInt_`) to decide `isSelfPay`, matching existing billing logic and keeping amount normalization via `normalizeMoneyNumber_`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dd2a813dc8321aedcff1a382a13b7)