### PR TITLE
Save prepared billing cache after applying manual billing overrides

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -3802,9 +3802,14 @@ function prepareBillingData(billingMonth, options) {
     if (existingPrepared && (!existingValidation || existingValidation.ok)) {
       const manualSync = syncManualBillingOverridesIntoPrepared_(existingPrepared, normalizedMonth.key);
       if (manualSync && manualSync.updated) {
-        savePreparedBilling_(manualSync.prepared);
         savePreparedBillingToSheet_(normalizedMonth.key, manualSync.prepared);
         billingLogger_.log('[billing] prepareBillingData refreshed manual billing overrides for ' + normalizedMonth.key);
+      }
+      if (manualSync && manualSync.prepared) {
+        savePreparedBilling_(manualSync.prepared);
+        if (!manualSync.updated) {
+          billingLogger_.log('[billing] prepareBillingData using existing prepared billing for ' + normalizedMonth.key);
+        }
         return manualSync.prepared;
       }
       billingLogger_.log('[billing] prepareBillingData using existing prepared billing for ' + normalizedMonth.key);


### PR DESCRIPTION
### Motivation
- Fix a bug where manual billing overrides were applied to the prepared payload but the in-memory cache (`savePreparedBilling_`) was not always persisted when returning early from `prepareBillingData` using existing prepared data.

### Description
- In `prepareBillingData` call path, ensure that when `syncManualBillingOverridesIntoPrepared_` returns a `prepared` payload it is persisted with `savePreparedBilling_` before returning.
- Keep `savePreparedBillingToSheet_` for the case where overrides actually changed (`manualSync.updated`), and adjust logging to avoid duplicate messages.
- This guarantees that `billingJson`, `totalsByPatient`, and `billingOverrideFlags` updates from manual overrides are saved to the prepared cache when reusing prepared billing.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e0dcdd29c8321b14e4007fa7e6af5)