### PR TITLE
Include `type` and `selfPayItems` on generated billingJson entries

### DIFF
--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -390,6 +390,7 @@ function generateBillingJsonFromSource(sourceData) {
     const selfPayEntryTotal = hasManualSelfPayAmount ? manualSelfPayAmount : selfPayItemsTotal;
     const entries = [
       Object.assign({}, {
+        type: 'insurance',
         entryType: 'insurance',
         unitPrice: amountCalc.unitPrice,
         visitCount: amountCalc.visits,
@@ -401,8 +402,10 @@ function generateBillingJsonFromSource(sourceData) {
     ];
     if (amountCalc.selfPayItems.length || hasManualSelfPayAmount || selfPayEntryTotal) {
       entries.push(Object.assign({}, {
+        type: 'selfPay',
         entryType: 'selfPay',
         items: amountCalc.selfPayItems,
+        selfPayItems: amountCalc.selfPayItems,
         total: selfPayEntryTotal
       }, hasManualSelfPayAmount ? { manualOverride: { amount: manualSelfPayAmount } } : {}));
     }


### PR DESCRIPTION
### Motivation
- Provide an explicit, typed `entries[]` shape in generated `billingJson` so insurance and self-pay rows are logically distinguishable while keeping backward compatibility.
- Avoid changing or removing any existing top-level `billingJson` fields or consumer behavior and preserve existing `grandTotal` calculation.

### Description
- Add `type: 'insurance'` to generated insurance entry objects in `generateBillingJsonFromSource` in `src/logic/billingLogic.js`.
- Add `type: 'selfPay'` and also expose `selfPayItems` alongside the existing `items` on self-pay entry objects for compatibility.
- Keep existing `entryType` properties and existing numeric fields and grand-total computation unchanged.
- Changes are localized to billing JSON generation only and do not modify downstream references or payload shape elsewhere.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e1137de2c832180e9dcc5b5d1276a)