### PR TITLE
Normalize billing entry types for aggregation and preserve legacy selfPay entryType

### DIFF
--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -402,7 +402,7 @@ function generateBillingJsonFromSource(sourceData) {
     ];
     if (amountCalc.selfPayItems.length || hasManualSelfPayAmount || selfPayEntryTotal) {
       entries.push(Object.assign({}, {
-        type: 'selfPay',
+        type: 'self_pay',
         entryType: 'selfPay',
         items: amountCalc.selfPayItems,
         selfPayItems: amountCalc.selfPayItems,


### PR DESCRIPTION
### Motivation
- Use `entries[type]` (normalized values) for Phase 3 billing aggregation while keeping existing consumers functioning. 
- Ensure manual override inputs (`manualBillingAmount` / `manualSelfPayAmount`) are applied to the matching normalized entry types during resolution. 
- Preserve downstream compatibility by retaining the legacy `entryType: 'selfPay'` on generated self-pay rows while setting `type: 'self_pay'` for aggregation.

### Description
- Add `normalizeBillingEntryTypeValue_` to canonicalize incoming `type`/`entryType` strings into `insurance` or `self_pay` for robust matching. 
- Update `resolveBillingEntries_` to accept `entry.entries` arrays, filter items by the normalized type, and inject `manualOverride.amount` when `manualBillingAmount` or `manualSelfPayAmount` is present. 
- Change generated/fallback entries to set `type: 'self_pay'` while preserving `entryType: 'selfPay'` for self-pay rows in `generateBillingJsonFromSource` and fallback construction in `resolveBillingEntries_`. 
- Change `resolveBillingEntryByType_` to compare normalized types and update `buildSelfPayAmountByPatientId_` to look up `self_pay` via the normalization function, leaving insurance handling intact.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e128ba3888321b6a50a5740f7a779)