### PR TITLE
Render billing UI rows by entry (grouped: 保険請求 / 自費請求)

### DIFF
--- a/src/billing.html
+++ b/src/billing.html
@@ -87,6 +87,7 @@
   .cell-badge{ display:inline-flex; align-items:center; gap:6px; }
   .cell-badge.right{ justify-content:flex-end; width:100%; }
   .override-badge{ background:#fef3c7; color:#92400e; padding:2px 6px; border-radius:8px; font-size:0.75rem; font-weight:700; white-space:nowrap; }
+  .billing-section td{ background:#f9fafb; font-weight:700; color:#374151; text-align:left; }
   .action-footer{ margin-top:12px; padding:12px 14px; border:1px dashed var(--border); border-radius:12px; display:flex; flex-wrap:wrap; gap:10px; align-items:center; justify-content:space-between; background:#f8fafc; }
   .action-buttons{ display:flex; gap:8px; flex-wrap:wrap; }
   .bank-flow-grid{ display:grid; grid-template-columns:1.2fr 1fr; gap:18px; align-items:flex-start; }

--- a/src/main.js.html
+++ b/src/main.js.html
@@ -1068,6 +1068,42 @@ function getDisplayBillingRows() {
   return sortBillingRows(merged);
 }
 
+function normalizeBillingEntryType(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  const normalized = raw.toLowerCase().replace(/\s+/g, '');
+  if (normalized === 'insurance') return 'insurance';
+  if (normalized === 'selfpay' || normalized === 'self_pay' || normalized === 'self-pay') return 'self_pay';
+  return '';
+}
+
+function buildBillingEntryDisplayRow(baseRow, entry) {
+  const safeBase = baseRow && typeof baseRow === 'object' ? baseRow : {};
+  const safeEntry = entry && typeof entry === 'object' ? entry : {};
+  const entryType = normalizeBillingEntryType(safeEntry.type || safeEntry.entryType);
+  const manualOverrideAmount = safeEntry.manualOverride
+    && Object.prototype.hasOwnProperty.call(safeEntry.manualOverride, 'amount')
+    ? safeEntry.manualOverride.amount
+    : '';
+  const selfPayItems = Array.isArray(safeEntry.selfPayItems)
+    ? safeEntry.selfPayItems
+    : (Array.isArray(safeEntry.items) ? safeEntry.items : []);
+
+  return Object.assign({}, safeBase, {
+    unitPrice: safeEntry.unitPrice,
+    visitCount: safeEntry.visitCount,
+    treatmentAmount: safeEntry.treatmentAmount,
+    transportAmount: safeEntry.transportAmount,
+    carryOverAmount: safeEntry.carryOverAmount,
+    grandTotal: safeEntry.total,
+    billingAmount: safeEntry.billingAmount,
+    selfPayItems,
+    manualBillingAmount: entryType === 'insurance' ? manualOverrideAmount : '',
+    manualSelfPayAmount: entryType === 'self_pay' ? manualOverrideAmount : '',
+    entryType
+  });
+}
+
 function buildBillingDerivedViews(entry) {
   const source = entry && typeof entry === 'object' ? entry : {};
   const rawSelfPayItems = Array.isArray(source.selfPayItems) ? source.selfPayItems : [];
@@ -2244,15 +2280,18 @@ function renderBillingResult() {
   }
 
   const bodyRows = [];
-  rows.forEach(item => {
-    try {
-      const safeItem = item && typeof item === 'object' ? item : {};
-      const nameWithBadge = `${safeItem.nameKanji || ''}${renderStatusBadges(safeItem)}`;
-      const selfPayCount = safeItem.selfPayCount;
-      const selfPayDisplay = (selfPayCount === 0 || selfPayCount === '0' || selfPayCount)
-        ? selfPayCount
-        : '—';
-      bodyRows.push(`
+
+  function renderEntryRow(item) {
+    const safeItem = item && typeof item === 'object' ? item : {};
+    const nameWithBadge = `${safeItem.nameKanji || ''}${renderStatusBadges(safeItem)}`;
+    const selfPayCount = safeItem.selfPayCount;
+    const selfPayDisplay = (selfPayCount === 0 || selfPayCount === '0' || selfPayCount)
+      ? selfPayCount
+      : '—';
+    const visitDisplay = (safeItem.visitCount === 0 || safeItem.visitCount === '0' || safeItem.visitCount)
+      ? safeItem.visitCount
+      : '—';
+    return `
       <tr>
         <td>${safeItem.patientId || ''}</td>
         <td>${nameWithBadge}</td>
@@ -2261,7 +2300,7 @@ function renderBillingResult() {
         <td>${renderEditableCell(safeItem, 'onlineConsent')}</td>
         <td>${renderEditableCell(safeItem, 'payerType')}</td>
         <td>${renderEditableCell(safeItem, 'burdenRate')}</td>
-        <td>${wrapWithOverrideBadge(safeItem.visitCount || 0, safeItem.patientId, 'visitCount')}</td>
+        <td>${wrapWithOverrideBadge(visitDisplay, safeItem.patientId, 'visitCount')}</td>
         <td>${selfPayDisplay}</td>
         <td class="right">${renderEditableCell(safeItem, 'unitPrice', true)}</td>
         <td class="right">${formatCurrency(safeItem.treatmentAmount)}</td>
@@ -2271,7 +2310,41 @@ function renderBillingResult() {
         <td>${formatPaidStatus(safeItem) || '—'}</td>
         <td>${formatBankInfo(safeItem) || '—'}</td>
         <td>${formatNewFlag(safeItem) || ''}</td>
-      </tr>`);
+      </tr>`;
+  }
+
+  function renderSectionRow(label) {
+    return `<tr class="billing-section"><td colspan="${columnCount}">${label}</td></tr>`;
+  }
+
+  rows.forEach(item => {
+    try {
+      const safeItem = item && typeof item === 'object' ? item : {};
+      const entries = Array.isArray(safeItem.entries) ? safeItem.entries : [];
+      const insuranceEntries = [];
+      const selfPayEntries = [];
+      entries.forEach(entry => {
+        const entryType = normalizeBillingEntryType(entry && (entry.type || entry.entryType));
+        if (entryType === 'insurance') {
+          insuranceEntries.push(entry);
+        } else if (entryType === 'self_pay') {
+          selfPayEntries.push(entry);
+        }
+      });
+
+      if (insuranceEntries.length) {
+        bodyRows.push(renderSectionRow('【保険請求】'));
+        insuranceEntries.forEach(entry => {
+          bodyRows.push(renderEntryRow(buildBillingEntryDisplayRow(safeItem, entry)));
+        });
+      }
+
+      if (selfPayEntries.length) {
+        bodyRows.push(renderSectionRow('【自費請求】'));
+        selfPayEntries.forEach(entry => {
+          bodyRows.push(renderEntryRow(buildBillingEntryDisplayRow(safeItem, entry)));
+        });
+      }
     } catch (err) {
       console.error('Failed to render billing row', err, item);
       const pid = item && item.patientId ? `患者ID: ${item.patientId}` : '患者行の表示でエラーが発生しました';


### PR DESCRIPTION
### Motivation
- Change the billing list rendering to use each `billingJson` row's `entries[]` as the source of displayed rows and to present logical separation between insurance and self-pay items on the UI.
- Keep existing column layout and avoid introducing any derived values, totals, or changes to PDF/Sheets/prepared/save logic; this change is strictly for visual separation.

### Description
- Added `normalizeBillingEntryType` to canonicalize entry `type`/`entryType` values and `buildBillingEntryDisplayRow` to map an entry's fields into the existing table column shape while preserving base row metadata.
- Reworked `renderBillingResult` table body generation to iterate each merged row's `entries[]`, group them into `insurance` and `self_pay`, and emit section header rows `【保険請求】` / `【自費請求】` followed by per-entry display rows using entry-level values only.
- Preserved all existing editable cells, badges, controls and column definitions so editing/saving/PDF flows remain unchanged.
- Added CSS `.billing-section td` to visually distinguish section header rows in the table.

### Testing
- Launched a local static server with `python -m http.server` and rendered `src/billing.html` in an automated Playwright script, capturing `artifacts/billing-section.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e2b46592483218846c0be728e5a8f)