### PR TITLE
Classify billing rows by `entries[].type` and fold `online_consent` into insurance section

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -2323,7 +2323,6 @@ function renderBillingResult() {
   }
 
   const insuranceRows = [];
-  const onlineConsentRows = [];
   const selfPayRows = [];
 
   rows.forEach(item => {
@@ -2332,18 +2331,8 @@ function renderBillingResult() {
       const entries = Array.isArray(safeItem.entries) ? safeItem.entries : [];
       entries.forEach(entry => {
         const entryType = normalizeBillingEntryType(entry && (entry.type || entry.entryType));
-        if (entryType === 'insurance') {
+        if (entryType === 'insurance' || entryType === 'online_consent') {
           insuranceRows.push(renderEntryRow(buildBillingEntryDisplayRow(safeItem, entry)));
-        } else if (entryType === 'online_consent') {
-          const amount = normalizeMoneyNumber(entry && (entry.total != null ? entry.total : entry.amount));
-          onlineConsentRows.push(`
-            <tr>
-              <td>${safeItem.patientId || ''}</td>
-              <td>${safeItem.nameKanji || ''}</td>
-              <td>${getResponsibleDisplay(safeItem) || '—'}</td>
-              <td class="right">${formatCurrency(amount)}</td>
-            </tr>
-          `);
         } else if (entryType === 'self_pay') {
           selfPayRows.push(renderSelfPayRow(buildBillingEntryDisplayRow(safeItem, entry)));
         }
@@ -2352,28 +2341,18 @@ function renderBillingResult() {
       console.error('Failed to render billing row', err, item);
       const pid = item && item.patientId ? `患者ID: ${item.patientId}` : '患者行の表示でエラーが発生しました';
       insuranceRows.push(`<tr class="error-row"><td colspan="${columnCount}">${pid}</td></tr>`);
-      onlineConsentRows.push(`<tr class="error-row"><td colspan="4">${pid}</td></tr>`);
       selfPayRows.push(`<tr class="error-row"><td colspan="8">${pid}</td></tr>`);
     }
   });
 
-  const insuranceTableHtml = [
+  const insuranceTableHtml = insuranceRows.length ? [
     '<h3>【保険請求】</h3>',
     '<table><thead><tr>',
     header.map(renderSortHeaderCell).join(''),
     '</tr></thead><tbody>',
-    insuranceRows.length ? insuranceRows.join('') : '<tr><td colspan="' + columnCount + '" class="muted">該当なし</td></tr>',
+    insuranceRows.join(''),
     '</tbody></table>'
-  ].join('');
-
-  const onlineConsentTableHtml = [
-    '<h3>【オンライン同意請求】</h3>',
-    '<table><thead><tr>',
-    '<th>患者ID</th><th>氏名</th><th>担当者</th><th class="right">オンライン同意金額</th>',
-    '</tr></thead><tbody>',
-    onlineConsentRows.length ? onlineConsentRows.join('') : '<tr><td colspan="4" class="muted">該当なし</td></tr>',
-    '</tbody></table>'
-  ].join('');
+  ].join('') : '';
 
   const selfPayHeader = [
     { key: 'patientId', label: '患者ID' },
@@ -2386,19 +2365,18 @@ function renderBillingResult() {
     { key: 'grandTotal', label: '合計' }
   ];
 
-  const selfPayTableHtml = [
+  const selfPayTableHtml = selfPayRows.length ? [
     '<h3>【自費請求】</h3>',
     '<table><thead><tr>',
     selfPayHeader.map(h => `<th>${h.label}</th>`).join(''),
     '</tr></thead><tbody>',
-    selfPayRows.length ? selfPayRows.join('') : '<tr><td colspan="8" class="muted">該当なし</td></tr>',
+    selfPayRows.join(''),
     '</tbody></table>'
-  ].join('');
+  ].join('') : '';
 
+  const sections = [insuranceTableHtml, selfPayTableHtml].filter(Boolean);
   const tableHtml = [
-    insuranceTableHtml,
-    onlineConsentTableHtml,
-    selfPayTableHtml,
+    sections.join(''),
     renderBillingActionFooter(rows && rows.length > 0)
   ].join('');
 


### PR DESCRIPTION
### Motivation
- Ensure UI classification is based only on `entries[].type` and that `online_consent` entries are treated as insurance so rows appear in the correct section and online-consent-only patients do not appear under self-pay.
- Remove empty-section placeholders so only sections with matching `entries[]` are rendered.

### Description
- Updated `src/main.js.html` to stop collecting a separate `onlineConsentRows` array and instead route `entry.type === 'online_consent'` into the insurance rows so those entries render in the `【保険請求】` table. 
- Enforced per-entry classification by using `normalizeBillingEntryType(entry && (entry.type || entry.entryType))` and pushing built rows via `buildBillingEntryDisplayRow` into either `insuranceRows` or `selfPayRows` only. 
- Changed section rendering so `insuranceTableHtml` and `selfPayTableHtml` are produced only when their respective row arrays are non-empty, and removed the previous "該当なし" placeholder rows. 
- Left all prepared/save/PDF/Sheets/banking logic untouched and preserved the billing action footer behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ef3faf6d08321a336db10da29ea18)