### PR TITLE
Use entry amount for online consent row display

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -2322,15 +2322,19 @@ function renderBillingResult() {
       </tr>`;
   }
 
-  function renderOnlineConsentRow(item) {
+  function renderOnlineConsentRow(item, entry) {
     const safeItem = item && typeof item === 'object' ? item : {};
+    const hasEntryAmount = entry && entry.amount !== null && entry.amount !== undefined;
+    const hasEntryTotal = entry && entry.total !== null && entry.total !== undefined;
+    const entryAmount = hasEntryAmount ? entry.amount : (hasEntryTotal ? entry.total : 0);
+    const displayAmount = normalizeMoneyNumber(entryAmount);
     const nameWithBadge = `${safeItem.nameKanji || ''}${renderStatusBadges(safeItem)}`;
     return `
       <tr>
         <td>${safeItem.patientId || ''}</td>
         <td>${nameWithBadge}</td>
         <td>${getResponsibleDisplay(safeItem) || '—'}</td>
-        <td class="right">${formatCurrency(safeItem.grandTotal)}</td>
+        <td class="right">${formatCurrency(displayAmount)}</td>
       </tr>`;
   }
 
@@ -2397,7 +2401,7 @@ function renderBillingResult() {
           const rawType = entry && (entry.type || entry.entryType);
           const normalizedRawType = String(rawType || '').trim().toLowerCase().replace(/\s+/g, '');
           if (normalizedRawType === 'online_consent' || normalizedRawType === 'online_fee') {
-            onlineConsentRows.push(renderOnlineConsentRow(buildBillingEntryDisplayRow(safeItem, entry)));
+            onlineConsentRows.push(renderOnlineConsentRow(buildBillingEntryDisplayRow(safeItem, entry), entry));
           }
         });
       }


### PR DESCRIPTION
### Motivation
- Ensure online consent billing rows display the correct amount derived from the individual entry instead of using the parent row's `grandTotal`, with priority `entry.amount` then `entry.total` then `0`.

### Description
- Modify `renderOnlineConsentRow` to accept an `entry` argument and compute `displayAmount` from `entry.amount`, falling back to `entry.total` and then `0`, then render that amount instead of `safeItem.grandTotal`, and update the caller in `renderBillingResult` to pass the `entry` context; no other PDF, data preparation, sheets, or bank logic was changed.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f020a9ca88321bb5d787b3c8599d8)