### PR TITLE
Ensure self-pay section includes all self-pay patients

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -2387,20 +2387,17 @@ function renderBillingResult() {
   /**
    * Decide if the self-pay section should be shown for a patient row.
    *
-   * Condition: the section appears only when visitCount normalizes to 0 and
-   * there is any positive self-pay amount from entries, row selfPayItems,
-   * or manualSelfPayAmount.
-   * Data fields used: visitCount, entries (entry.items or entry.selfPayItems),
+   * Condition: the section appears when there is any positive self-pay amount
+   * from entries, row selfPayItems, or manualSelfPayAmount.
+   * Data fields used: entries (entry.items or entry.selfPayItems),
    * selfPayItems (on the row), manualSelfPayAmount.
    *
    * Examples:
-   * - visitCount = 0, entries include items with amount > 0 => shows self-pay section.
-   * - visitCount = 0, row.manualSelfPayAmount = 500 => shows self-pay section.
-   * - visitCount = 2, even with selfPayItems present => hides self-pay section.
+   * - entries include items with amount > 0 => shows self-pay section.
+   * - row.manualSelfPayAmount = 500 => shows self-pay section.
+   * - no self-pay amounts anywhere => hides self-pay section.
    */
   function hasSelfPaySection(row) {
-    const visitCount = normalizeVisitCount(row && row.visitCount);
-    if (visitCount !== 0) return false;
     const entries = Array.isArray(row && row.entries) ? row.entries : [];
     const hasEntrySelfPayAmount = entries.some(entry => {
       const items = Array.isArray(entry && entry.items)


### PR DESCRIPTION
### Motivation
- Ensure patients with any positive self-pay amount are always shown in the 【自費請求】 section by basing the display decision on UI aggregation (self-pay amounts) rather than `visitCount`.

### Description
- Remove the `visitCount` gating from `hasSelfPaySection` in `src/main.js.html` so the function returns true when there is any positive self-pay amount detected in `entries`, `selfPayItems`, or `manualSelfPayAmount`, and update the inline documentation to reflect this change.
- No other rendering, saving, PDF, or Sheets logic is modified; `selfPayRows` generation and rendering remain unchanged.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f2602d8288321b340ac8e369ac62e)