### PR TITLE
Allow self-pay rows to display regardless of visitCount in billing UI

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -2387,20 +2387,17 @@ function renderBillingResult() {
   /**
    * Decide if the self-pay section should be shown for a patient row.
    *
-   * Condition: the section appears only when visitCount normalizes to 0 and
-   * there is any positive self-pay amount from entries, row selfPayItems,
-   * or manualSelfPayAmount.
-   * Data fields used: visitCount, entries (entry.items or entry.selfPayItems),
+   * Condition: the section appears when there is any positive self-pay amount
+   * from entries, row selfPayItems, or manualSelfPayAmount.
+   * Data fields used: entries (entry.items or entry.selfPayItems),
    * selfPayItems (on the row), manualSelfPayAmount.
    *
    * Examples:
-   * - visitCount = 0, entries include items with amount > 0 => shows self-pay section.
-   * - visitCount = 0, row.manualSelfPayAmount = 500 => shows self-pay section.
-   * - visitCount = 2, even with selfPayItems present => hides self-pay section.
+   * - entries include items with amount > 0 => shows self-pay section.
+   * - row.manualSelfPayAmount = 500 => shows self-pay section.
+   * - no self-pay amounts => hides self-pay section.
    */
   function hasSelfPaySection(row) {
-    const visitCount = normalizeVisitCount(row && row.visitCount);
-    if (visitCount !== 0) return false;
     const entries = Array.isArray(row && row.entries) ? row.entries : [];
     const hasEntrySelfPayAmount = entries.some(entry => {
       const items = Array.isArray(entry && entry.items)


### PR DESCRIPTION
### Motivation
- Ensure patients who have both insurance and self-pay in the same month are shown in both the insurance and self-pay sections by removing the visit-count gating from the self-pay display logic.
- Constrain the change to UI display decision logic only and avoid touching aggregation, prepared generation, PDF, Sheets, bank integrations, or data structures.

### Description
- Modified `hasSelfPaySection` in `src/main.js.html` to remove the `visitCount` check so the self-pay section is shown whenever there is any positive self-pay amount in `entries` (entry `items` or `selfPayItems`), `row.selfPayItems`, or `row.manualSelfPayAmount`.
- Updated the JSDoc/comments for `hasSelfPaySection` to reflect the new visibility criteria.
- Kept the change scope limited to `renderBillingResult` display determination and row generation logic only.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f299eb8a88321af7c73c18c3ec470)