### PR TITLE
Normalize online consent UI: only show when online-fee items exist

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -2393,50 +2393,39 @@ function renderBillingResult() {
     return String(rawType).indexOf('オンライン同意') >= 0;
   }
 
-  function getEntryAmount(entry) {
-    if (!entry || typeof entry !== 'object') return 0;
-    const rawAmount = entry.amount !== null && entry.amount !== undefined
-      ? entry.amount
-      : entry.total;
-    return normalizeMoneyNumber(rawAmount);
-  }
-
-  function hasEntryItemsAmount(entry) {
-    if (!entry || typeof entry !== 'object') return false;
-    const items = Array.isArray(entry.items)
-      ? entry.items
-      : (Array.isArray(entry.selfPayItems) ? entry.selfPayItems : []);
-    return hasSelfPayItemsAmount(items);
-  }
-
-  function collectOnlineConsentEntryAmounts(row) {
-    const entries = Array.isArray(row && row.entries) ? row.entries : [];
-    return entries
-      .map(getEntryAmount)
+  function collectOnlineConsentItemAmounts(items) {
+    return (items || [])
+      .filter(item => isOnlineConsentItem(item))
+      .map(item => normalizeMoneyNumber(item && item.amount))
       .filter(amount => amount > 0);
+  }
+
+  function collectOnlineConsentAmounts(row) {
+    const entries = Array.isArray(row && row.entries) ? row.entries : [];
+    const entryAmounts = entries.flatMap(entry => {
+      const items = Array.isArray(entry && entry.items) ? entry.items : [];
+      return collectOnlineConsentItemAmounts(items);
+    });
+    const billingItems = collectOnlineConsentItemAmounts(row && row.billingItems);
+    const selfPayItems = collectOnlineConsentItemAmounts(row && row.selfPayItems);
+    return entryAmounts.concat(billingItems, selfPayItems);
   }
 
   /**
    * Decide if the online consent section should be shown for a patient row.
    *
    * Condition: the section appears when any online consent amount is positive.
-   * Data fields used: entries (entry.items amount and entry.total/amount),
-   * row selfPayItems, row manualSelfPayAmount.
+   * Data fields used: entries.items (online fee items only),
+   * row billingItems (online fee items), row selfPayItems (online fee items).
    *
    * Examples:
-   * - entries = [{ items: [{ amount: 1000 }], total: 1000 }] => shows online consent section.
-   * - row.selfPayItems = [{ amount: 1000 }] => shows online consent section.
-   * - row.manualSelfPayAmount = 1000 => shows online consent section.
+   * - entries = [{ items: [{ type: 'online_fee', amount: 1000 }] }] => shows online consent section.
+   * - row.selfPayItems = [{ type: 'online_fee', amount: 1000 }] => shows online consent section.
+   * - row.billingItems = [{ type: 'online_fee', amount: 1000 }] => shows online consent section.
    * - no online consent amounts => hides online consent section.
    */
   function hasOnlineConsentSection(row) {
-    const entries = Array.isArray(row && row.entries) ? row.entries : [];
-    const hasEntryItemAmount = entries.some(hasEntryItemsAmount);
-    const hasEntryTotalAmount = entries.some(entry => getEntryAmount(entry) > 0);
-    const rowSelfPayItems = Array.isArray(row && row.selfPayItems) ? row.selfPayItems : [];
-    const hasRowSelfPayAmount = hasSelfPayItemsAmount(rowSelfPayItems);
-    const hasManualSelfPayAmount = normalizeMoneyNumber(row && row.manualSelfPayAmount) > 0;
-    return hasEntryItemAmount || hasEntryTotalAmount || hasRowSelfPayAmount || hasManualSelfPayAmount;
+    return collectOnlineConsentAmounts(row).length > 0;
   }
 
   /**
@@ -2504,7 +2493,7 @@ function renderBillingResult() {
       }
 
       if (hasOnlineConsentSection(safeItem)) {
-        const onlineConsentTotal = collectOnlineConsentEntryAmounts(safeItem)
+        const onlineConsentTotal = collectOnlineConsentAmounts(safeItem)
           .reduce((sum, amount) => sum + normalizeMoneyNumber(amount), 0);
         if (!onlineConsentRowsByPatient.has(patientKey)) {
           onlineConsentRowsByPatient.set(patientKey, renderOnlineConsentRow(safeItem, onlineConsentTotal));


### PR DESCRIPTION
### Motivation
- Ensure the online consent section in the billing UI only appears for patients who actually have online-consent/online-fee item amounts, preventing insurance patients from appearing in the online-consent list and preventing online-consent patients from being mixed into the self-pay list.

### Description
- Replace the previous detection logic for online consent with `collectOnlineConsentItemAmounts` and `collectOnlineConsentAmounts` that only consider items matching online-fee types (from `entries[].items`, `billingItems`, and `selfPayItems`) and positive `amount` values.
- Stop relying on entry-level `total`/`amount`, `manualSelfPayAmount`, or entry-type heuristics for deciding whether to show the online consent section, and make `hasOnlineConsentSection` return `true` only when `collectOnlineConsentAmounts(row).length > 0`.
- Update the online-consent total calculation to sum only the online-fee item amounts via `collectOnlineConsentAmounts` before rendering the online consent row.
- Change made in `src/main.js.html` and comments/docs adjusted to reflect online-fee-only detection and sources.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f5aa257f88321a462f6656a8090ff)