### PR TITLE
Self-pay UI: show visit count × editable unit price with auto-calculated billing amount

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -2323,18 +2323,35 @@ function renderBillingResult() {
       </tr>`;
   }
 
+  function getSelfPayVisitCount(item) {
+    return Number(item && item.selfPayVisitCount != null ? item.selfPayVisitCount : item && item.selfPayCount) || 0;
+  }
+
+  function getSelfPayUnitPrice(item) {
+    const safeItem = item && typeof item === 'object' ? item : {};
+    const hasManualUnitPrice = Object.prototype.hasOwnProperty.call(safeItem, 'manualUnitPrice')
+      && safeItem.manualUnitPrice !== ''
+      && safeItem.manualUnitPrice !== null
+      && safeItem.manualUnitPrice !== undefined;
+    const source = hasManualUnitPrice ? safeItem.manualUnitPrice : safeItem.unitPrice;
+    return normalizeMoneyNumber(source);
+  }
+
   function renderSelfPayRow(item) {
     const safeItem = item && typeof item === 'object' ? item : {};
+    const selfPayVisitCount = getSelfPayVisitCount(safeItem);
+    const visitDisplay = (selfPayVisitCount === 0 || selfPayVisitCount) ? selfPayVisitCount : '—';
+    const unitPrice = getSelfPayUnitPrice(safeItem);
+    const totalAmount = Number.isFinite(unitPrice) ? unitPrice * selfPayVisitCount : null;
+    const displayItem = Object.assign({}, safeItem, { unitPrice });
     return `
       <tr>
-        <td>${renderPatientIdCell(safeItem)}</td>
-        <td>${renderPatientNameCell(safeItem)}</td>
-        <td>${getResponsibleDisplay(safeItem) || '—'}</td>
-        <td class="right">${renderMoneyValue(safeItem.unitPrice)}</td>
-        <td class="right">${renderMoneyValue(safeItem.treatmentAmount)}</td>
-        <td class="right">${renderMoneyValue(safeItem.transportAmount)}</td>
-        <td class="right">${renderMoneyValue(safeItem.carryOverAmount)}</td>
-        <td class="right">${renderMoneyValue(safeItem.grandTotal)}</td>
+        <td>${renderPatientIdCell(displayItem)}</td>
+        <td>${renderPatientNameCell(displayItem)}</td>
+        <td>${getResponsibleDisplay(displayItem) || '—'}</td>
+        <td class="right">${visitDisplay}</td>
+        <td class="right">${renderEditableCell(displayItem, 'unitPrice', true)}</td>
+        <td class="right">${renderMoneyValue(totalAmount)}</td>
       </tr>`;
   }
 
@@ -2411,6 +2428,7 @@ function renderBillingResult() {
   const insuranceRowsByPatient = new Map();
   const onlineConsentRowsByPatient = new Map();
   const selfPayRowsByPatient = new Map();
+  const selfPayColumnCount = 6;
 
   function getPatientKey(item) {
     const safeItem = item && typeof item === 'object' ? item : {};
@@ -2433,7 +2451,6 @@ function renderBillingResult() {
       const safeItem = item && typeof item === 'object' ? item : {};
       const entries = Array.isArray(safeItem.entries) ? safeItem.entries : [];
       const insuranceEntry = entries.find(entry => normalizeEntryType(entry) === 'insurance');
-      const selfPayEntry = entries.find(entry => normalizeEntryType(entry) === 'self_pay');
       const patientKey = registerPatient(safeItem);
 
       if (hasInsuranceSection(safeItem)) {
@@ -2450,9 +2467,8 @@ function renderBillingResult() {
       }
 
       if (hasSelfPaySection(safeItem)) {
-        const displayRow = selfPayEntry ? buildBillingEntryDisplayRow(safeItem, selfPayEntry) : safeItem;
         if (!selfPayRowsByPatient.has(patientKey)) {
-          selfPayRowsByPatient.set(patientKey, renderSelfPayRow(displayRow));
+          selfPayRowsByPatient.set(patientKey, renderSelfPayRow(safeItem));
         }
       }
     } catch (err) {
@@ -2466,7 +2482,7 @@ function renderBillingResult() {
         onlineConsentRowsByPatient.set(patientKey, `<tr class="error-row"><td colspan="4">${pid}</td></tr>`);
       }
       if (!selfPayRowsByPatient.has(patientKey)) {
-        selfPayRowsByPatient.set(patientKey, `<tr class="error-row"><td colspan="8">${pid}</td></tr>`);
+        selfPayRowsByPatient.set(patientKey, `<tr class="error-row"><td colspan="${selfPayColumnCount}">${pid}</td></tr>`);
       }
     }
   });
@@ -2504,11 +2520,9 @@ function renderBillingResult() {
     { key: 'patientId', label: '患者ID' },
     { key: 'nameKanji', label: '氏名' },
     { key: 'responsible', label: '担当者' },
+    { key: 'selfPayVisitCount', label: '自費回数' },
     { key: 'unitPrice', label: '単価' },
-    { key: 'treatmentAmount', label: '施術料' },
-    { key: 'transportAmount', label: '交通費' },
-    { key: 'carryOverAmount', label: '繰越' },
-    { key: 'grandTotal', label: '合計' }
+    { key: 'billingAmount', label: '請求金額' }
   ];
 
   const selfPayTableHtml = [


### PR DESCRIPTION
### Motivation
- The self-pay section should present charges as “回数 × 単価” rather than showing itemized amounts, and only expose three fields: 自費回数, 単価 (editable), and 請求金額 (computed). 
- The change must be UI-only and must not alter aggregation logic, billing JSON shape, PDF/Sheets, or save behavior.

### Description
- Reworked the self-pay row rendering by adding `getSelfPayVisitCount` and `getSelfPayUnitPrice` helpers and replacing `renderSelfPayRow` to show `selfPayVisitCount`, an editable `unitPrice` (uses `manualUnitPrice` when present, falls back to `unitPrice`), and a computed billing amount (`visitCount * unitPrice`).
- Removed transport and carry-over columns from the self-pay table and adjusted the header/colspan handling (`selfPayHeader` and `selfPayColumnCount`) to match the new three-column UI.
- Stopped relying on `selfPayItems` / entry `total` / `manualSelfPayAmount` for the displayed self-pay amount so the UI reflects `selfPayVisitCount × unitPrice` only, while leaving server-side aggregation and data structures untouched.

### Testing
- Launched a local HTTP server and used a Playwright script to load `src/billing.html` and capture a screenshot of the updated self-pay UI, which completed successfully and produced `artifacts/billing-self-pay.png`.
- No automated unit tests were executed against the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69700d7152648321bb74392aef20b952)