### PR TITLE
Count mixed (保険＋自費) treatments toward insurance visitCount

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -927,17 +927,19 @@ function buildVisitCountMap_(billingMonth) {
     debug.counted += 1;
     filteredCount += 1;
     const current = counts[pid] || { visitCount: 0, self30: 0, self60: 0, mixed: 0 };
-    current.visitCount += 1;
     const categoryKey = log && log.treatmentCategoryKey ? String(log.treatmentCategoryKey).trim() : '';
-    if (categoryKey) {
-      const group = BILLING_TREATMENT_CATEGORY_ATTENDANCE_GROUP[categoryKey];
-      if (group === 'self') {
-        if (categoryKey === 'self60') current.self60 += 1;
-        else current.self30 += 1;
-      } else if (group === 'mixed') {
-        current.mixed += 1;
-        current.self30 += 1;
-      }
+    const attendanceGroup = categoryKey ? BILLING_TREATMENT_CATEGORY_ATTENDANCE_GROUP[categoryKey] : '';
+    const shouldCountInsurance = !categoryKey || attendanceGroup === 'insurance' || attendanceGroup === 'mixed';
+    if (shouldCountInsurance) {
+      current.visitCount += 1;
+    }
+    if (attendanceGroup === 'self') {
+      if (categoryKey === 'self60') current.self60 += 1;
+      else current.self30 += 1;
+    }
+    if (attendanceGroup === 'mixed') {
+      current.mixed += 1;
+      current.self30 += 1;
     }
     counts[pid] = current;
 


### PR DESCRIPTION
### Motivation
- Recalculate insurance visit counts based on the treatment category (H列) so that records marked as `mixed` ("60分施術（保険＋自費）") increment the insurance `visitCount` while keeping self-pay counting independent and unchanged.

### Description
- Updated `buildVisitCountMap_` in `src/get/billingGet.js` to derive `attendanceGroup` from `treatmentCategoryKey` and only increment `current.visitCount` when the category is absent or `attendanceGroup` is `insurance` or `mixed`, while preserving existing `self30`, `self60`, and `mixed` counters and their behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69703b49187083219bdce22452730515)