### PR TITLE
Fix insurance/self-pay visit count display in billing UI

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -2297,10 +2297,30 @@ function renderBillingResult() {
     return formatCurrency(normalized);
   }
 
+  function normalizeOptionalVisitCount(value) {
+    if (value === '' || value === null || value === undefined) return null;
+    const normalized = String(value || '')
+      .normalize('NFKC')
+      .replace(/[，,]/g, '')
+      .trim();
+    if (!normalized) return null;
+    const num = Number(normalized);
+    return Number.isFinite(num) ? num : null;
+  }
+
+  function getInsuranceVisitCount(item) {
+    const safeItem = item && typeof item === 'object' ? item : {};
+    const insuranceCount = normalizeOptionalVisitCount(safeItem.insuranceCount);
+    const mixedCount = normalizeOptionalVisitCount(safeItem.mixedCount);
+    if (insuranceCount === null && mixedCount === null) return null;
+    return (insuranceCount || 0) + (mixedCount || 0);
+  }
+
   function renderEntryRow(item) {
     const safeItem = item && typeof item === 'object' ? item : {};
-    const visitDisplay = (safeItem.visitCount === 0 || safeItem.visitCount === '0' || safeItem.visitCount)
-      ? safeItem.visitCount
+    const insuranceVisitCount = getInsuranceVisitCount(safeItem);
+    const visitDisplay = (insuranceVisitCount === 0 || insuranceVisitCount)
+      ? insuranceVisitCount
       : '—';
     return `
       <tr>
@@ -2324,7 +2344,8 @@ function renderBillingResult() {
   }
 
   function getSelfPayVisitCount(item) {
-    return Number(item && item.selfPayVisitCount != null ? item.selfPayVisitCount : item && item.selfPayCount) || 0;
+    const safeItem = item && typeof item === 'object' ? item : {};
+    return normalizeOptionalVisitCount(safeItem.selfPayVisitCount);
   }
 
   function getSelfPayUnitPrice(item) {
@@ -2342,7 +2363,9 @@ function renderBillingResult() {
     const selfPayVisitCount = getSelfPayVisitCount(safeItem);
     const visitDisplay = (selfPayVisitCount === 0 || selfPayVisitCount) ? selfPayVisitCount : '—';
     const unitPrice = getSelfPayUnitPrice(safeItem);
-    const totalAmount = Number.isFinite(unitPrice) ? unitPrice * selfPayVisitCount : null;
+    const totalAmount = (Number.isFinite(unitPrice) && selfPayVisitCount != null)
+      ? unitPrice * selfPayVisitCount
+      : null;
     const displayItem = Object.assign({}, safeItem, { unitPrice });
     return `
       <tr>
@@ -2382,16 +2405,16 @@ function renderBillingResult() {
   /**
    * Decide if the insurance section should be shown for a patient row.
    *
-   * Condition: the section appears when the normalized visitCount is greater than 0.
-   * Data fields used: visitCount (from the row).
+   * Condition: the section appears when insuranceCount + mixedCount is greater than 0.
+   * Data fields used: insuranceCount, mixedCount (from the row).
    *
    * Examples:
-   * - visitCount = 3 => shows insurance section.
-   * - visitCount = 0 or undefined => hides insurance section.
+   * - insuranceCount = 2, mixedCount = 1 => shows insurance section.
+   * - insuranceCount = 0, mixedCount = 0 or undefined => hides insurance section.
    */
   function hasInsuranceSection(row) {
-    const visitCount = normalizeVisitCount(row && row.visitCount);
-    return visitCount > 0;
+    const insuranceVisitCount = getInsuranceVisitCount(row);
+    return Number(insuranceVisitCount) > 0;
   }
 
   /**
@@ -2412,15 +2435,15 @@ function renderBillingResult() {
    * Decide if the self-pay section should be shown for a patient row.
    *
    * Condition: the section appears when selfPayVisitCount is 1 or more.
-   * Data fields used: selfPayVisitCount (or fallback selfPayCount).
+   * Data fields used: selfPayVisitCount.
    *
    * Examples:
    * - selfPayVisitCount = 1 => shows self-pay section.
-   * - selfPayVisitCount = 0 => hides self-pay section.
+   * - selfPayVisitCount = 0 or undefined => hides self-pay section.
    */
   function hasSelfPaySection(row) {
-    const selfPayVisitCount = Number(row && row.selfPayVisitCount != null ? row.selfPayVisitCount : row.selfPayCount) || 0;
-    return selfPayVisitCount >= 1;
+    const selfPayVisitCount = getSelfPayVisitCount(row);
+    return Number(selfPayVisitCount) >= 1;
   }
 
   const patientOrder = [];


### PR DESCRIPTION
### Motivation
- The billing UI used `visitCount` directly for showing insurance counts, causing mixed (保険＋自費) records to leak self-pay visits into the insurance display. 
- The UI should show insurance-related visits as `insuranceCount + mixedCount`, while self-pay UI should rely only on `selfPayVisitCount` without changing aggregation or payment logic.

### Description
- Add `normalizeOptionalVisitCount` to parse optional visit-count-like fields robustly and return `null` for absent values. 
- Add `getInsuranceVisitCount` which returns `(insuranceCount || 0) + (mixedCount || 0)` or `null` when both are absent. 
- Update `renderEntryRow` to display insurance visits using `getInsuranceVisitCount` instead of `visitCount`. 
- Change `getSelfPayVisitCount` to use `normalizeOptionalVisitCount` and update `renderSelfPayRow` total calculation to handle absent self-pay counts. 
- Update `hasInsuranceSection` and `hasSelfPaySection` logic and inline docs to base visibility on the new helpers (`insuranceCount + mixedCount` and `selfPayVisitCount`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69706d05d67c8321a3c55ec31a897ff8)