### PR TITLE
Use insurance entry burdenRate when building billing display rows

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -1082,6 +1082,9 @@ function buildBillingEntryDisplayRow(baseRow, entry) {
   const safeBase = baseRow && typeof baseRow === 'object' ? baseRow : {};
   const safeEntry = entry && typeof entry === 'object' ? entry : {};
   const entryType = normalizeBillingEntryType(safeEntry.type || safeEntry.entryType);
+  const entryBurdenRate = Object.prototype.hasOwnProperty.call(safeEntry, 'burdenRate')
+    ? safeEntry.burdenRate
+    : safeBase.burdenRate;
   const manualOverrideAmount = safeEntry.manualOverride
     && Object.prototype.hasOwnProperty.call(safeEntry.manualOverride, 'amount')
     ? safeEntry.manualOverride.amount
@@ -1098,6 +1101,7 @@ function buildBillingEntryDisplayRow(baseRow, entry) {
     carryOverAmount: safeEntry.carryOverAmount,
     grandTotal: safeEntry.total,
     billingAmount: safeEntry.billingAmount,
+    burdenRate: entryBurdenRate,
     selfPayItems,
     manualBillingAmount: entryType === 'insurance' ? manualOverrideAmount : '',
     manualSelfPayAmount: entryType === 'self_pay' ? manualOverrideAmount : '',


### PR DESCRIPTION
### Motivation
- Fix a UI inconsistency where treatment fees became 0 while transport fees remained due to the visit count being taken from insurance entries but `burdenRate` remaining sourced from the base row, causing `calculateBillingRowTotalsLocal()` to compute zero treatment amounts.

### Description
- When constructing the display row in `buildBillingEntryDisplayRow` (`src/main.js.html`), prefer `safeEntry.burdenRate` if present (falling back to the base row) and include this `burdenRate` on the returned display object so recalculations use the same source as insurance visit counts.

### Testing
- No automated tests were run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970d8a128fc832190bc4fba98eaf2d8)