### PR TITLE
Sync bank withdrawal online flag to patient `onlineConsent` (prevent stale +1000 fee)

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -3322,10 +3322,10 @@ function syncBankWithdrawalOnlineConsentFlags_(billingMonth, prepared) {
     const consentFlag = typeof normalizeZeroOneFlag_ === 'function'
       ? normalizeZeroOneFlag_(patient.onlineConsent)
       : (patient.onlineConsent === true || patient.onlineConsent === 1 || patient.onlineConsent === '1' ? 1 : 0);
-    if (!consentFlag) continue;
+    const shouldBeOnline = !!consentFlag;
     const currentValue = updatedValues[idx][0];
-    if (normalizeBankFlagValue_(currentValue)) continue;
-    updatedValues[idx][0] = true;
+    if (normalizeBankFlagValue_(currentValue) === shouldBeOnline) continue;
+    updatedValues[idx][0] = shouldBeOnline;
     updated += 1;
   }
 


### PR DESCRIPTION
### Motivation
- Fix case where the +1000 "オンライン同意" fee was still applied because the bank withdrawal sheet `online` checkbox (`bankFlagsByPatient.ag`) could remain set when the patient `onlineConsent` flag was later cleared.

### Description
- Update `syncBankWithdrawalOnlineConsentFlags_` in `src/main.gs` to explicitly set the bank withdrawal `online` column to match the patient's `onlineConsent` value (using `normalizeZeroOneFlag_` and `normalizeBankFlagValue_`) instead of only setting it when consent was true, thereby clearing stale flags.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970e25eb19c8321be5f71f9adbf511e)