### PR TITLE
Fix insurance billing totals to avoid self-pay overrides

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -2377,7 +2377,10 @@ function renderBillingResult() {
     if (insuranceVisitCount === null || insuranceVisitCount === undefined) {
       return safeItem.treatmentAmount;
     }
-    const totals = calculateBillingRowTotalsLocal(Object.assign({}, safeItem, { visitCount: insuranceVisitCount }));
+    const totals = calculateBillingRowTotalsLocal(Object.assign({}, safeItem, {
+      entryType: 'insurance',
+      visitCount: insuranceVisitCount,
+    }));
     return totals.treatmentAmount;
   }
 


### PR DESCRIPTION
### Motivation
- Prevent self_pay manual overrides from affecting insurance treatment amount by ensuring billing totals are computed with an explicit insurance context.

### Description
- Pass `entryType: 'insurance'` and the insurance `visitCount` into `calculateBillingRowTotalsLocal` when called from `resolveInsuranceTreatmentAmount` (update in `src/main.js.html`).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970e5d6d44c8321ae74325f45484810)