### PR TITLE
Fix billing override isolation in insurance/self-pay views

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -1118,7 +1118,7 @@ function buildBillingEntryDisplayRow(baseRow, entry) {
     unitPrice: safeEntry.unitPrice,
     visitCount: safeEntry.visitCount,
     treatmentAmount: safeEntry.treatmentAmount,
-    transportAmount: safeEntry.transportAmount,
+    transportAmount: entryType === 'insurance' ? safeEntry.transportAmount : 0,
     carryOverAmount: safeEntry.carryOverAmount,
     grandTotal: safeEntry.total,
     billingAmount: safeEntry.billingAmount,
@@ -1142,7 +1142,7 @@ function buildBillingEntryDisplayRow(baseRow, entry) {
 function buildBillingDerivedViews(entry) {
   const source = entry && typeof entry === 'object' ? entry : {};
   const entries = Array.isArray(source.entries) ? source.entries : [];
-  const resolveEntryTotal = item => {
+  const resolveSelfPayTotal = item => {
     if (!item) return null;
     const manualOverride = item.manualOverride && Object.prototype.hasOwnProperty.call(item.manualOverride, 'amount')
       ? item.manualOverride.amount
@@ -1154,8 +1154,8 @@ function buildBillingDerivedViews(entry) {
   };
   const insuranceEntry = entries.find(item => normalizeBillingEntryType(item && (item.type || item.entryType)) === 'insurance');
   const selfPayEntry = entries.find(item => normalizeBillingEntryType(item && (item.type || item.entryType)) === 'self_pay');
-  const insuranceTotal = insuranceEntry ? resolveEntryTotal(insuranceEntry) : 0;
-  const selfPayTotal = selfPayEntry ? resolveEntryTotal(selfPayEntry) : 0;
+  const insuranceTotal = insuranceEntry ? normalizeMoneyNumber(insuranceEntry.total) : 0;
+  const selfPayTotal = selfPayEntry ? resolveSelfPayTotal(selfPayEntry) : 0;
   const mixedTotal = normalizeMoneyNumber(source.grandTotal);
   const selfPayItemsSource = selfPayEntry
     ? (Array.isArray(selfPayEntry.selfPayItems) ? selfPayEntry.selfPayItems : selfPayEntry.items)
@@ -2403,11 +2403,11 @@ function renderBillingResult() {
 
   function resolveInsuranceTreatmentAmount(item, insuranceVisitCount) {
     const safeItem = item && typeof item === 'object' ? item : {};
-    if (insuranceVisitCount === null || insuranceVisitCount === undefined) {
-      return safeItem.treatmentAmount;
-    }
+    const resolvedVisitCount = (insuranceVisitCount === 0 || insuranceVisitCount)
+      ? insuranceVisitCount
+      : safeItem.visitCount;
     const totals = calculateBillingRowTotalsLocal(Object.assign({}, safeItem, {
-      visitCount: insuranceVisitCount,
+      visitCount: resolvedVisitCount,
       entryType: 'insurance'
     }));
     return totals.treatmentAmount;


### PR DESCRIPTION
### Motivation
- The UI showed insurance totals calculated incorrectly because self-pay/manual overrides leaked into insurance calculations and transport was always attached to insurance entries.
- Root causes identified: `calculateBillingRowTotalsLocal` was invoked without a definite `entryType`, totals were reverse-calculated (`insuranceTotal = grandTotal - selfPayTotal`), and `transportAmount` was not gated by entry type.

### Description
- Ensure transport is only applied on insurance display rows by setting `transportAmount: entryType === 'insurance' ? safeEntry.transportAmount : 0` in `buildBillingEntryDisplayRow` so non-insurance entries report `0` transport.
- Stop reverse-calculation of insurance totals by using the insurance entry total directly and compute self-pay totals from the self-pay entry (added `resolveSelfPayTotal`), so `insuranceTotal = insuranceEntry.total` and `selfPayTotal` honors self-pay manual overrides only in `buildBillingDerivedViews`.
- When recalculating insurance treatment, always call `calculateBillingRowTotalsLocal` with `entryType: 'insurance'` and a resolved visit count so insurance visit counts are used consistently in `resolveInsuranceTreatmentAmount`.
- Changes are minimal and avoid schema, PDF, or bank-logic modifications as required.

### Testing
- No automated tests were run for this change (none requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697310ec11508321ac38e2f332655ec4)