### PR TITLE
Fix self-pay and online consent section visibility

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -1230,7 +1230,9 @@ function filterEntriesByType(entries, entryType) {
 
 function hasVisitBasedSelfPayEntry(entry) {
   if (!entry || typeof entry !== 'object') return false;
-  return Object.prototype.hasOwnProperty.call(entry, 'visitCount');
+  return Object.prototype.hasOwnProperty.call(entry, 'visitCount')
+    && entry.visitCount !== null
+    && entry.visitCount !== undefined;
 }
 
 function resolveSelfPayVisitEntry(entries) {
@@ -2631,15 +2633,16 @@ function renderBillingResult() {
   /**
    * Decide if the online consent section should be shown for a patient row.
    *
-   * Condition: the section appears when the online consent flag is set.
-   * Data fields used: onlineConsent flag.
+   * Condition: the section appears when an online_fee item exists in self-pay entries.
+   * Data fields used: entries[].entryType === 'self_pay' items[].type === 'online_fee'.
    *
    * Examples:
-   * - onlineConsent = 1 => shows online consent section.
-   * - onlineConsent = 0 => hides online consent section.
+   * - online_fee item exists => shows online consent section.
+   * - no online_fee item => hides online consent section.
    */
-  function hasOnlineConsentSection(row) {
-    return normalizeOnlineConsentFlag(row && row.onlineConsent) === 1;
+  function hasOnlineConsentSection(entries) {
+    const items = collectSelfPayItems(entries);
+    return items.some(item => item && item.type === 'online_fee');
   }
 
   /**
@@ -2694,7 +2697,7 @@ function renderBillingResult() {
         }
       }
 
-      if (hasOnlineConsentSection(safeItem)) {
+      if (hasOnlineConsentSection(entries)) {
         if (!onlineConsentRowsByPatient.has(patientKey)) {
           onlineConsentRowsByPatient.set(patientKey, renderOnlineConsentRow(safeItem));
         }


### PR DESCRIPTION
### Motivation
- The UI hid both self-pay and online-consent sections after splitting `self_pay` entries into visit-based and item-only variants because visibility was based on truthy checks of `visitCount` and conflated entry existence with item presence. 
- The intent is to show the self-pay table when a visit-based `self_pay` entry exists (even when `visitCount` is `0`) and to show the online-consent table only when an `online_fee` item is present in `self_pay` entries.

### Description
- Tighten `hasVisitBasedSelfPayEntry` to return true only when `visitCount` is explicitly present and not `null`/`undefined` by changing the check to `Object.prototype.hasOwnProperty.call(entry, 'visitCount') && entry.visitCount !== null && entry.visitCount !== undefined`.
- Replace the old online-consent visibility (which used `onlineConsent` row flag) with `hasOnlineConsentSection(entries)` that collects items from `self_pay` entries via `collectSelfPayItems(entries)` and returns true when any item has `type === 'online_fee'`.
- Update the call site to pass `entries` into `hasOnlineConsentSection` so row rendering shows the online-consent section only for rows with an `online_fee` item, and update the doc comments to reflect the new rules.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e925eb2148321b7191fb96b6b40a3)