### PR TITLE
Base self-pay visit counts on treatment labels and prevent duplicate manual overrides

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -254,22 +254,10 @@ const BILLING_TREATMENT_CATEGORY_ATTENDANCE_GROUP = typeof TREATMENT_CATEGORY_AT
     new: 'new'
   };
 
-const BILLING_SELF_PAY_VISIT_UNITS_BY_CATEGORY = {
-  self30: 1,
-  self60: 2,
-  mixed: 1
-};
-
 function resolveSelfPayVisitUnits_(categoryKey, categoryLabel) {
-  if (categoryKey && Object.prototype.hasOwnProperty.call(BILLING_SELF_PAY_VISIT_UNITS_BY_CATEGORY, categoryKey)) {
-    return BILLING_SELF_PAY_VISIT_UNITS_BY_CATEGORY[categoryKey];
-  }
   const normalized = String(categoryLabel || '').normalize('NFKC').replace(/\s+/g, '');
   if (!normalized || normalized.indexOf('自費') === -1) return 0;
-  const hasInsurance = normalized.indexOf('保険') !== -1;
-  if (normalized.indexOf('30分') !== -1) return 1;
-  if (normalized.indexOf('60分') !== -1) return hasInsurance ? 1 : 2;
-  return 0;
+  return 1;
 }
 
 function normalizeTreatmentCategoryKey_(value) {

--- a/src/logic/billingLogic.js
+++ b/src/logic/billingLogic.js
@@ -470,21 +470,19 @@ function generateBillingJsonFromSource(sourceData) {
     ];
     const hasVisitBasedSelfPay = selfPayVisitCount > 0;
     const hasItemOnlySelfPay = itemOnlySelfPayItems.length > 0;
-    const visitBasedEntryTotal = hasManualSelfPayAmount ? manualSelfPayAmount : selfPayChargeAmount;
+    const visitBasedEntryTotal = resolvedSelfPayUnitPrice * selfPayVisitCount;
     const itemOnlyEntryTotal = hasManualSelfPayAmount
       ? (hasVisitBasedSelfPay ? 0 : manualSelfPayAmount)
       : itemOnlySelfPayTotal;
-    if (hasVisitBasedSelfPay) {
-      entries.push(Object.assign({}, {
-        type: 'self_pay',
-        entryType: 'self_pay',
-        visitCount: selfPayVisitCount,
-        unitPrice: resolvedSelfPayUnitPrice,
-        items: visitBasedSelfPayItems,
-        selfPayItems: visitBasedSelfPayItems,
-        total: visitBasedEntryTotal
-      }, hasManualSelfPayAmount ? { manualOverride: { amount: manualSelfPayAmount } } : {}));
-    }
+    entries.push(Object.assign({}, {
+      type: 'self_pay',
+      entryType: 'self_pay',
+      visitCount: selfPayVisitCount,
+      unitPrice: resolvedSelfPayUnitPrice,
+      items: visitBasedSelfPayItems,
+      selfPayItems: visitBasedSelfPayItems,
+      total: visitBasedEntryTotal
+    }, (hasManualSelfPayAmount && hasVisitBasedSelfPay) ? { manualOverride: { amount: manualSelfPayAmount } } : {}));
     if (hasItemOnlySelfPay || (!hasVisitBasedSelfPay && (hasManualSelfPayAmount || selfPayEntryTotal))) {
       entries.push(Object.assign({}, {
         type: 'self_pay',


### PR DESCRIPTION
### Motivation
- Ensure self-pay visit counts are derived strictly from treatment record labels (施術時間区分) containing `自費` so counts reflect recorded treatments rather than inferred category keys.
- Prevent double-counting when a manual self-pay amount is supplied by avoiding applying that manual override to visit-based entries when `visitCount` is zero.

### Description
- Simplified `resolveSelfPayVisitUnits_` in `src/get/billingGet.js` to ignore category-key mappings and return `1` when the normalized `categoryLabel` contains `自費`, otherwise `0`.
- Removed the per-category `BILLING_SELF_PAY_VISIT_UNITS_BY_CATEGORY` logic and the special-case that treated `60分施術（完全自費）` as two visits.
- Changed visit-based self-pay calculation in `src/logic/billingLogic.js` to compute `visitBasedEntryTotal` as `resolvedSelfPayUnitPrice * selfPayVisitCount` and always emit a visit-based `self_pay` entry, while attaching `manualOverride` only when `hasManualSelfPayAmount && hasVisitBasedSelfPay`.
- Preserved item-only self-pay entry behavior and the existing insurance entry logic while preventing manual override duplication when there are no visit-based self-pay counts.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ea3655020832180282a3f90601c3f)