### PR TITLE
Hide self-pay rows with zero visits

### DIFF
--- a/src/main.js.html
+++ b/src/main.js.html
@@ -1230,9 +1230,11 @@ function filterEntriesByType(entries, entryType) {
 
 function hasVisitBasedSelfPayEntry(entry) {
   if (!entry || typeof entry !== 'object') return false;
-  return Object.prototype.hasOwnProperty.call(entry, 'visitCount')
-    && entry.visitCount !== null
-    && entry.visitCount !== undefined;
+  const entryType = normalizeBillingEntryType(entry && (entry.type || entry.entryType));
+  const visitCount = Number(entry.visitCount);
+  return entryType === 'self_pay'
+    && Number.isFinite(visitCount)
+    && visitCount > 0;
 }
 
 function resolveSelfPayVisitEntry(entries) {


### PR DESCRIPTION
### Motivation
- The server now always emits a `self_pay` entry (including `visitCount: 0`) and the UI showed rows whenever a self-pay entry existed, causing patients with no self-pay visits to appear in the self-pay table.

### Description
- Tighten the visit-based self-pay check by updating `hasVisitBasedSelfPayEntry` in `src/main.js.html` to require the entry normalize to `self_pay` and `visitCount > 0` (casts `visitCount` to `Number` and uses `Number.isFinite`), so item-only self-pay entries (e.g. `online_fee`) do not trigger row visibility.

### Testing
- No automated tests were run for this UI-only change (per instructions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f2ad603008321a89147fce3ffad70)