### PR TITLE
Fix insurance visit count for mixed (保険＋自費) treatment labels

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -936,7 +936,9 @@ function buildVisitCountMap_(billingMonth) {
     if (current.selfPayVisitCount == null) current.selfPayVisitCount = 0;
     const categoryKey = log && log.treatmentCategoryKey ? String(log.treatmentCategoryKey).trim() : '';
     const attendanceGroup = categoryKey ? BILLING_TREATMENT_CATEGORY_ATTENDANCE_GROUP[categoryKey] : '';
-    const shouldCountInsurance = !categoryKey || attendanceGroup === 'insurance' || attendanceGroup === 'mixed';
+    const categoryLabel = log && log.treatmentCategoryLabel ? String(log.treatmentCategoryLabel) : '';
+    const hasMixedLabel = categoryLabel.includes('保険') && categoryLabel.includes('自費');
+    const shouldCountInsurance = hasMixedLabel || !categoryKey || attendanceGroup === 'insurance' || attendanceGroup === 'mixed';
     if (shouldCountInsurance) {
       current.visitCount += 1;
     }


### PR DESCRIPTION
### Motivation
- Mixed treatments whose label contains both `保険` and `自費` were not always incrementing the insurance `visitCount` because the logic relied on a normalized `treatmentCategoryKey` → `attendanceGroup`, causing insurance totals to be incorrect while self-pay counting still worked.

### Description
- In `src/get/billingGet.js` inside `buildVisitCountMap_`, added a `categoryLabel` and `hasMixedLabel` check for labels containing both `保険` and `自費`, and included `hasMixedLabel` in the `shouldCountInsurance` condition so mixed-label records increment insurance `visitCount` even when `treatmentCategoryKey` is missing or unnormalized, while keeping existing mappings and self-pay logic unchanged.

### Testing
- No automated tests were run for this change (static edit only, per instructions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f312f9854832193676ddbdae0cbd0)