### PR TITLE
Copy selfPayUnitPrice into billing patient records

### DIFF
--- a/src/get/billingGet.js
+++ b/src/get/billingGet.js
@@ -1340,14 +1340,16 @@ function getBillingPatientRecords() {
       ? ''
       : normalizeMoneyValue_(transportRaw);
 
+    const raw = buildPatientRawObject_(headers, row);
     return {
       patientId: pid,
-      raw: buildPatientRawObject_(headers, row),
+      raw,
       nameKanji: colName ? String(row[colName - 1] || '').trim() : '',
       nameKana: colKana ? String(row[colKana - 1] || '').trim() : '',
       insuranceType,
       burdenRate: normalizedBurden,
       unitPrice: colUnitPrice ? normalizeMoneyValue_(unitPriceRaw) : 0,
+      selfPayUnitPrice: raw.selfPayUnitPrice,
       manualUnitPrice,
       manualTransportAmount,
       address: colAddress ? String(row[colAddress - 1] || '').trim() : '',


### PR DESCRIPTION
### Motivation
- 患者情報シートにある `selfPayUnitPrice` を請求計算ロジックが参照できるよう、`getBillingPatientRecords()` で生成する patient オブジェクトへ渡す必要があるため。 

### Description
- `src/get/billingGet.js` の `getBillingPatientRecords()` で `buildPatientRawObject_` の戻り値を `raw` として再利用し、`patient.selfPayUnitPrice` を `raw.selfPayUnitPrice` からトップレベルにコピーする変更を加えた（`billingLogic.js` は変更していない）。

### Testing
- 自動テストは実行しておらず、変更はファイル編集とコミットのみ行った。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698016bc392483219cfc30127d8a7cb1)