### PR TITLE
Separate aggregate calculation from invoice presentation

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -57,7 +57,9 @@
   <? } ?>
   <div class="wrapper">
     <header class="header">
-      <? var isAggregateInvoice = data.isAggregateInvoice; ?>
+      <? var aggregateCalculation = data.aggregateCalculation != null ? data.aggregateCalculation : data.isAggregateInvoice; ?>
+      <? var aggregatePresentation = data.aggregatePresentation || (aggregateCalculation ? 'aggregate' : 'standard'); ?>
+      <? var isAggregateInvoice = aggregatePresentation === 'aggregate'; ?>
       <? var chargeMonthLabel = (amount && amount.chargeMonthLabel) || normalizeBillingMonthLabel_(data.billingMonth); ?>
       <? var chargePeriodLabel = buildInvoiceChargePeriodLabel_(data); ?>
       <div>
@@ -154,7 +156,8 @@
     <? var receiptDate = receipt.date || receipt.receiptDate || ''; ?>
     <? var receiptAmount = receipt.amount != null ? receipt.amount : 0; ?>
     <? var receiptNote = receipt.note || receipt.description || ''; ?>
-    <? if (!amount.forceHideReceipt && amount.showReceipt === true) { ?>
+    <? var shouldShowReceipt = !amount.forceHideReceipt && (amount.showReceipt === true || (aggregateCalculation && aggregatePresentation === 'standard')); ?>
+    <? if (shouldShowReceipt) { ?>
       <section class="card">
         <h3 class="section-title">前月分領収書</h3>
         <div class="info">


### PR DESCRIPTION
### Motivation
- Decouple the decision to compute aggregated amounts from the decision to render invoices in aggregated UI so `aggregate=true` can still render the standard invoice presentation.
- Preserve existing aggregate calculation logic while enabling the billing output layer to select presentation independently.

### Description
- Change `resolveInvoiceGenerationMode` to return `{ aggregateCalculation: <bool>, aggregateMonths: [...] }` instead of a `mode` string, and update callers to use `aggregateCalculation` (modified `src/main.gs`).
- Ensure aggregated amount generation still exposes the standard invoice `rows` when the presentation is requested as standard by computing `standardAmount` and using its `rows` if aggregate rows are missing (updated `finalizeInvoiceAmountDataForPdf_` in `src/main.gs`).
- Add `resolveAggregatePresentationMode_`, propagate `aggregateCalculation` and `aggregatePresentation` through invoice PDF context normalization and template context in `src/output/billingOutput.js`, and switch PDF generation to choose the aggregate template based on `aggregatePresentation` instead of only `isAggregateInvoice`.
- Update `invoice_template.html` to compute `aggregateCalculation`/`aggregatePresentation`, use `aggregatePresentation` to determine whether to show the aggregate UI, and allow the previous-receipt section to be displayed when calculation is aggregated but presentation is `standard`.
- Files changed: `src/main.gs`, `src/output/billingOutput.js`, `src/invoice_template.html`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69818b1de2548321b514b6b6083d307a)