### PR TITLE
Separate aggregate calculation from display; add invoice display-mode and online consent note

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -57,15 +57,16 @@
   <? } ?>
   <div class="wrapper">
     <header class="header">
-      <? var isAggregateInvoice = data.isAggregateInvoice; ?>
+      <? var displayMode = data.displayMode || (data.isAggregateInvoice ? 'aggregate' : 'standard'); ?>
+      <? var isAggregateDisplay = displayMode === 'aggregate'; ?>
       <? var chargeMonthLabel = (amount && amount.chargeMonthLabel) || normalizeBillingMonthLabel_(data.billingMonth); ?>
       <? var chargePeriodLabel = buildInvoiceChargePeriodLabel_(data); ?>
       <div>
         <div class="brand">べるつりー訪問鍼灸マッサージ</div>
-        <div class="note"><?= isAggregateInvoice ? '合算／未回収考慮モード' : '月次請求書' ?></div>
+        <div class="note"><?= isAggregateDisplay ? '合算／未回収考慮モード' : '月次請求書' ?></div>
       </div>
       <div class="meta">
-        <div><?= isAggregateInvoice ? '請求対象: ' : '請求月: ' ?><?= chargeMonthLabel ?></div>
+        <div><?= isAggregateDisplay ? '請求対象: ' : '請求月: ' ?><?= chargeMonthLabel ?></div>
         <div>発行日: <?= Utilities.formatDate(new Date(), Session.getScriptTimeZone() || 'Asia/Tokyo', 'yyyy年MM月dd日') ?></div>
       </div>
     </header>
@@ -83,12 +84,12 @@
   </section>
 
   <section class="card">
-    <h3 class="section-title">ご請求内容（<?= isAggregateInvoice ? '未回収合算' : '当月' ?>）</h3>
+    <h3 class="section-title">ご請求内容（<?= isAggregateDisplay ? '未回収合算' : '当月' ?>）</h3>
       <? var aggregateMonthTotals = Array.isArray(amount.aggregateMonthTotals)
         ? amount.aggregateMonthTotals
         : [];
       ?>
-      <? if (isAggregateInvoice) { ?>
+      <? if (isAggregateDisplay) { ?>
         <div class="subsection-title">月別内訳</div>
         <table class="subtable">
           <thead>
@@ -115,12 +116,16 @@
           </tfoot>
         </table>
       <? } else { ?>
+        <? var displayRows = Array.isArray(amount.displayRows) && amount.displayRows.length
+          ? amount.displayRows
+          : amount.rows;
+        ?>
         <table>
           <thead>
             <tr><th>項目</th><th>詳細</th><th class="amount">金額</th></tr>
           </thead>
           <tbody>
-            <? amount.rows.forEach(function(row) { ?>
+            <? displayRows.forEach(function(row) { ?>
               <tr>
                 <td><?= row.label ?></td>
                 <td><?= row.detail || '' ?></td>
@@ -141,7 +146,10 @@
           </tfoot>
         </table>
       <? } ?>
-      <div class="note"><?= isAggregateInvoice ? '未回収期間を含めた合計金額です。（前月未回収分を含む）' : '前月繰越を含む合計金額です。' ?>口座振替日：毎月20日（祝日の場合は翌営業日）</div>
+      <div class="note"><?= isAggregateDisplay ? '未回収期間を含めた合計金額です。（前月未回収分を含む）' : '前月繰越を含む合計金額です。' ?>口座振替日：毎月20日（祝日の場合は翌営業日）</div>
+      <? if (isAggregateDisplay && data.showOnlineConsentNote) { ?>
+        <div class="note"><strong>注記:</strong> オンライン同意費用（1,000円）を含む</div>
+      <? } ?>
       <? if (amount.aggregateRemark) { ?>
         <div class="note"><strong>備考:</strong> <?= amount.aggregateRemark ?></div>
       <? } ?>
@@ -154,7 +162,7 @@
     <? var receiptDate = receipt.date || receipt.receiptDate || ''; ?>
     <? var receiptAmount = receipt.amount != null ? receipt.amount : 0; ?>
     <? var receiptNote = receipt.note || receipt.description || ''; ?>
-    <? if (!amount.forceHideReceipt && amount.showReceipt === true) { ?>
+    <? if (!amount.forceHideReceipt && !isAggregateDisplay && data.showPreviousReceipt === true) { ?>
       <section class="card">
         <h3 class="section-title">前月分領収書</h3>
         <div class="info">

--- a/src/main.gs
+++ b/src/main.gs
@@ -4738,7 +4738,7 @@ function buildStandardInvoiceAmountDataForPdf_(entry, billingMonth) {
     : [];
   selfPayItems.forEach(item => {
     if (!item) return;
-    rows.push({ label: item.type || '', detail: '', amount: item.amount });
+    rows.push({ label: resolveInvoiceItemLabel_(item), detail: '', amount: item.amount });
   });
 
   return {
@@ -4768,6 +4768,7 @@ function finalizeInvoiceAmountDataForPdf_(entry, billingMonth, aggregateMonths, 
   const baseAmount = isAggregateInvoice
     ? buildAggregateInvoiceAmountDataForPdf_(normalizedAggregateMonths, billingMonth, entry && entry.patientId, cache)
     : buildStandardInvoiceAmountDataForPdf_(entry, billingMonth);
+  const displayAmount = buildStandardInvoiceAmountDataForPdf_(entry, billingMonth);
   const aggregateMonthTotals = Array.isArray(baseAmount.aggregateMonthTotals)
     ? baseAmount.aggregateMonthTotals
     : [];
@@ -4834,6 +4835,12 @@ function finalizeInvoiceAmountDataForPdf_(entry, billingMonth, aggregateMonths, 
     previousReceipt.visible = shouldShowReceipt;
   }
   const carryOverAmount = normalizeBillingCarryOver_(entry);
+  const displayFlags = resolveInvoiceDisplayMode_(entry, billingMonth, {
+    showReceipt: shouldShowReceipt,
+    previousReceipt,
+    previousReceiptAmount: resolvedPreviousReceiptAmount,
+    carryOverAmount
+  });
   logReceiptDebug_(entry && entry.patientId, {
     step: 'finalizeInvoiceAmountDataForPdf_',
     billingMonth,
@@ -4864,6 +4871,11 @@ function finalizeInvoiceAmountDataForPdf_(entry, billingMonth, aggregateMonths, 
     previousReceiptAmount: resolvedPreviousReceiptAmount,
     showReceipt: shouldShowReceipt,
     previousReceipt,
+    displayMode: displayFlags.displayMode,
+    showOnlineConsentNote: displayFlags.showOnlineConsentNote,
+    showPreviousReceipt: displayFlags.showPreviousReceipt,
+    displayRows: Array.isArray(displayAmount && displayAmount.rows) ? displayAmount.rows : [],
+    carryOverAmount,
     watermark
   });
 }


### PR DESCRIPTION
### Motivation
- 表示ロジックを合算計算から切り離し、表示モード（通常表示／合算専用表示）を仕様どおりに判定してテンプレートに反映するための変更です。 
- 金額算出・合算計算は絶対に変えず、表示のみ条件分岐することが目的です。 

### Description
- 表示モード判定ロジックを追加し、オンライン同意（online_fee）を検出するユーティリティ `isOnlineConsentItem_` と `resolveInvoiceDisplayMode_` を導入しました（ファイル: `src/output/billingOutput.js`）。
- PDFコンテキストに `displayMode` / `showOnlineConsentNote` / `showPreviousReceipt` / `displayRows` / `carryOverAmount` 等の表示フラグを確実に渡すように `normalizeInvoicePdfContext_` と `buildInvoiceTemplateContext_` を更新しました（ファイル: `src/output/billingOutput.js`）。
- `finalizeInvoiceAmountDataForPdf_` で表示判定を呼び出し、出力コンテキストに表示フラグと表示用明細行（`displayRows`：既存金額計算はそのまま）を付与するようにしました（ファイル: `src/main.gs`）。
- テンプレート `src/invoice_template.html` を表示モードに基づいて切り替え、通常表示では明細行・前月領収書を出力し、合算専用表示では合算表を表示してオンライン同意がある場合は注記を出すように変更しました。
- 既存の金額計算・合算ロジック（`calculateInvoiceChargeBreakdown_` や合算集計関数群）は変更していません。

変更した主なファイル:
- `src/output/billingOutput.js`（表示判定ユーティリティ、PDFコンテキスト拡張）
- `src/main.gs`（`finalizeInvoiceAmountDataForPdf_` の表示フラグセット）
- `src/invoice_template.html`（テンプレート表示切替、オンライン同意注記、前月領収書表示条件）

### Testing
- 自動化されたテストは実行していません（`not run`）。
- コードは差分レビューで表示フラグの追加とテンプレート分岐が正しく渡されることを確認していますが、PDF生成の実行テストは未実施です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981aab574f88321b64a67b76ee7c2a4)