### PR TITLE
Separate aggregate presentation from calculation and fix invoice PDF displayMode selection

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -57,7 +57,7 @@
   <? } ?>
   <div class="wrapper">
     <header class="header">
-      <? var displayMode = data.displayMode || (data.isAggregateInvoice ? 'aggregate' : 'standard'); ?>
+      <? var displayMode = data && data.displayMode ? data.displayMode : 'standard'; ?>
       <? var isAggregateDisplay = displayMode === 'aggregate'; ?>
       <? var chargeMonthLabel = (amount && amount.chargeMonthLabel) || normalizeBillingMonthLabel_(data.billingMonth); ?>
       <? var chargePeriodLabel = buildInvoiceChargePeriodLabel_(data); ?>
@@ -148,7 +148,7 @@
       <? } ?>
       <div class="note"><?= isAggregateDisplay ? '未回収期間を含めた合計金額です。（前月未回収分を含む）' : '前月繰越を含む合計金額です。' ?>口座振替日：毎月20日（祝日の場合は翌営業日）</div>
       <? if (isAggregateDisplay && data.showOnlineConsentNote) { ?>
-        <div class="note"><strong>注記:</strong> オンライン同意費用（1,000円）を含む</div>
+        <div class="note"><strong>注記:</strong> オンライン同意費用（1,000円）を含みます</div>
       <? } ?>
       <? if (amount.aggregateRemark) { ?>
         <div class="note"><strong>備考:</strong> <?= amount.aggregateRemark ?></div>


### PR DESCRIPTION
### Motivation
- The invoice PDF was choosing aggregate presentation too aggressively, hiding insurance/self-pay line items and previous-month receipts even when calculations were correct.
- The change isolates presentation (`displayMode`) from existing aggregate calculation logic so totals remain unchanged.
- Online consent (1,000円) must continue to be included in totals but be shown as a line item only in `standard` mode and as a short note in `aggregate` mode.

### Description
- Introduced a presentation heuristic function `requiresMonthlyExplanation_` to detect family/guardian/office/recipient contexts and force `standard` display when needed. 
- Reworked `resolveInvoiceDisplayMode_` to implement the specified rules: `standard` when insurance visits exist, when new self-pay charges exist, when a previous-receipt transition requires showing a receipt, or when monthly explanation is required; `aggregate` only when none of those apply and only past unpaid balances are being settled. This affects only rendering decisions and not any calculation paths. (`src/output/billingOutput.js`)
- Adjusted self-pay detection to consider all `selfPayItems` totals when deciding display mode while keeping all amount calculations unchanged. (`src/output/billingOutput.js`)
- Template rendering now relies on an explicit `displayMode` in the PDF context and defaults to `standard` unless `displayMode` is set to `aggregate`, and the aggregate online-consent note text was adjusted to the requested wording. (`src/invoice_template.html`)
- Ensured `buildInvoiceTemplateContext_` defaults `displayMode` to `'standard'` when not provided so aggregate presentation must be opt-in. (`src/output/billingOutput.js`)

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981bbc7ddc08321b269b52e0e217b0d)