### PR TITLE
Force standard invoice display when previous receipt exists

### DIFF
--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -284,13 +284,11 @@ function resolveInvoiceDisplayMode_(entry, billingMonth, amount) {
   const prevReceiptSettled = entry ? isPreviousReceiptSettled_(entry) : false;
   const shouldShowReceipt = !!(amount && amount.showReceipt);
   const requiresPreviousReceipt = (hasPrevReceiptAmount && prevReceiptSettled) || shouldShowReceipt;
-  const needsMonthlyExplanation = requiresMonthlyExplanation_(entry);
 
   const canAggregateDisplay = !hasInsuranceTreatment
     && !hasNewSelfPayCharge
-    && isOnlyPastUnpaidSettlement
-    && !requiresPreviousReceipt
-    && !needsMonthlyExplanation;
+    && !hasPrevReceiptAmount
+    && isOnlyPastUnpaidSettlement;
   const displayMode = canAggregateDisplay ? 'aggregate' : 'standard';
 
   return {


### PR DESCRIPTION
### Motivation
- Force invoices into `standard` display when a previous receipt amount exists (`previousReceiptAmount > 0`) while keeping all amount and aggregation calculations unchanged.

### Description
- Update `resolveInvoiceDisplayMode_` in `src/output/billingOutput.js` to require `!hasPrevReceiptAmount` for `aggregate` mode and remove the prior checks that used `requiresPreviousReceipt` and `needsMonthlyExplanation`, leaving other billing/aggregation logic intact.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981c83087488321900555dbd755bad2)