### PR TITLE
標準請求PDFに自費明細と前月領収情報を含める修正

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -162,7 +162,7 @@
     <? var receiptDate = receipt.date || receipt.receiptDate || ''; ?>
     <? var receiptAmount = receipt.amount != null ? receipt.amount : 0; ?>
     <? var receiptNote = receipt.note || receipt.description || ''; ?>
-    <? if (!amount.forceHideReceipt && !isAggregateDisplay && data.showPreviousReceipt === true) { ?>
+    <? if (!amount.forceHideReceipt && !isAggregateDisplay && (data.showPreviousReceipt === true || (amount.previousReceiptAmount != null && amount.previousReceiptAmount > 0))) { ?>
       <section class="card">
         <h3 class="section-title">前月分領収書</h3>
         <div class="info">

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -825,6 +825,8 @@ function normalizeInvoicePdfContext_(context) {
   const source = context && typeof context === 'object' ? context : {};
   const amount = source.amount && typeof source.amount === 'object' ? source.amount : {};
   const months = Array.isArray(source.months) ? source.months : [];
+  const normalizedDisplayMode = amount.displayMode || '';
+  const normalizedPreviousReceiptAmount = Number(amount.previousReceiptAmount) || 0;
   return {
     patientId: source.patientId ? String(source.patientId) : '',
     billingMonth: source.billingMonth ? String(source.billingMonth) : '',
@@ -841,15 +843,20 @@ function normalizeInvoicePdfContext_(context) {
       receiptMonths: Array.isArray(amount.receiptMonths) ? amount.receiptMonths : [],
       receiptRemark: amount.receiptRemark || '',
       showReceipt: !!amount.showReceipt,
-      showPreviousReceipt: amount.showPreviousReceipt != null ? !!amount.showPreviousReceipt : !!amount.showReceipt,
+      showPreviousReceipt: amount.showPreviousReceipt != null
+        ? !!amount.showPreviousReceipt
+        : (!!amount.showReceipt || (normalizedDisplayMode !== 'aggregate' && normalizedPreviousReceiptAmount > 0)),
       showOnlineConsentNote: !!amount.showOnlineConsentNote,
       displayMode: amount.displayMode || '',
       previousReceipt: amount.previousReceipt || null,
+      previousReceiptAmount: amount.previousReceiptAmount,
+      previousReceiptMonth: amount.previousReceiptMonth || '',
       forceHideReceipt: !!amount.forceHideReceipt,
       watermark: amount.watermark || null,
       aggregateStatus: amount.aggregateStatus || '',
       aggregateConfirmed: !!amount.aggregateConfirmed,
-      carryOverAmount: amount.carryOverAmount
+      carryOverAmount: amount.carryOverAmount,
+      selfPayItems: Array.isArray(amount.selfPayItems) ? amount.selfPayItems : []
     }, amount),
     name: source.name || source.nameKanji || '',
     isAggregateInvoice: !!source.isAggregateInvoice,


### PR DESCRIPTION
### Motivation
- 標準表示（displayMode === 'standard'）において、オンライン同意などの自費（selfPayItems）や前月領収（previousReceiptAmount／previousReceiptMonth）をPDFコンテキストに確実に含め、1枚の請求書PDFに全て表示されるようにするための修正です。 
- 合算（aggregate）向けに行っている「明細削減／領収非表示」の処理が標準表示に誤って適用されないように防止する意図があります。

### Description
- `src/main.gs` の `buildStandardInvoiceAmountDataForPdf_` に `selfPayItems` を返すよう追加し、標準請求の明細コンテキストへ自費項目を含めるようにしました。 
- `src/main.gs` の `buildInsuranceInvoiceEntryForPdf_` で保険エントリに紐づく `selfPayItems` を構築して渡すように変更しました。 
- `src/main.gs` の `finalizeInvoiceAmountDataForPdf_` で算出した `previousReceiptMonth` を PDF の amount に含めるようにしました。 
- `src/output/billingOutput.js` の `normalizeInvoicePdfContext_` で `previousReceiptAmount`／`previousReceiptMonth`／`selfPayItems` を通し、`showPreviousReceipt` の既定判定を `displayMode !== 'aggregate'` かつ `previousReceiptAmount > 0` の場合に領収表示を維持するよう補正しました。 
- `src/invoice_template.html` のテンプレート条件を拡張し、標準表示かつ `previousReceiptAmount > 0` の場合に前月領収書ブロックが必ず描画されるようにしました。

### Testing
- 自動化されたテストは実行していません（未実行）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981cdbd33008321909c166d657176f9)