### PR TITLE
Short-circuit invoice display mode and gate billing debug logs

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -2260,10 +2260,12 @@ function validatePreparedBillingPayload_(payload, expectedMonthKey) {
   try {
     validatePreparedBillingPhase4A_(payload);
   } catch (err) {
-    try {
-      billingLogger_.log('[billing] Phase4-A validation failed to run: ' + err);
-    } catch (logErr) {
-      // ignore logging errors in non-GAS environments
+    if (isBillingDebugEnabled_()) {
+      try {
+        billingLogger_.log('[billing] Phase4-A validation failed to run: ' + err);
+      } catch (logErr) {
+        // ignore logging errors in non-GAS environments
+      }
     }
   }
 
@@ -2271,6 +2273,7 @@ function validatePreparedBillingPayload_(payload, expectedMonthKey) {
 }
 
 function logPreparedBillingPhase4AMismatch_(patientId, billingMonth, field, expected, actual) {
+  if (!isBillingDebugEnabled_()) return;
   try {
     billingLogger_.log('[billing] Phase4-A mismatch ' + JSON.stringify({
       patientId: patientId || '',

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -285,6 +285,15 @@ function resolveInvoiceDisplayMode_(entry, billingMonth, amount) {
   const shouldShowReceipt = !!(amount && amount.showReceipt);
   const requiresPreviousReceipt = (hasPrevReceiptAmount && prevReceiptSettled) || shouldShowReceipt;
 
+  if (hasInsuranceTreatment || hasNewSelfPayCharge || hasPrevReceiptAmount) {
+    return {
+      displayMode: 'standard',
+      showOnlineConsentNote: false,
+      showPreviousReceipt: requiresPreviousReceipt,
+      hasOnlineConsentFee
+    };
+  }
+
   const canAggregateDisplay = !hasInsuranceTreatment
     && !hasNewSelfPayCharge
     && !hasPrevReceiptAmount
@@ -657,6 +666,12 @@ function resolveAggregateInvoiceDecision_(item, receipt, billingMonth, options) 
 }
 
 function logAggregateDecisionTrace_(label, payload) {
+  const isDebug = typeof isBillingDebugEnabled_ === 'function'
+    ? isBillingDebugEnabled_()
+    : (typeof getConfig === 'function'
+      ? String(getConfig('BILLING_DEBUG') || getConfig('billing_debug') || getConfig('BILLING_DEBUG_LOG') || '').trim() === '1'
+      : false);
+  if (!isDebug) return;
   const logger = typeof billingLogger_ !== 'undefined' && billingLogger_ && typeof billingLogger_.log === 'function'
     ? billingLogger_
     : null;


### PR DESCRIPTION
### Motivation
- 請求書生成の高速化と通常実行時のログ出力削減のため、表示モード判定を早期確定して余分な集約判定を避けると同時に、確認用ログを明示的なデバッグフラグ有効時のみ出力するようにする。
- 金額・合算計算ロジックは一切変更せず、最終的な表示結果は現行仕様を維持することを意図している。 

### Description
- `resolveInvoiceDisplayMode_` に早期リターンを追加し、当月の保険施術（`hasInsuranceTreatment`）、当月の新規自費（`hasNewSelfPayCharge`）、または前月領収金額（`hasPrevReceiptAmount`）のいずれかを検出した時点で `displayMode: 'standard'` を確定するようにした（`src/output/billingOutput.js`）。
- 早期確定時は `showOnlineConsentNote` を `false` に設定し、`showPreviousReceipt` は既存の `requiresPreviousReceipt` を尊重するようにしている（集約判定ロジックはスキップ）。
- 集約判定トレース用の `logAggregateDecisionTrace_` を明示的なデバッグ判定（`isBillingDebugEnabled_()` または `BILLING_DEBUG` 相当の設定）でガードし、通常実行時はログ出力を抑制するようにした（`src/output/billingOutput.js`）。
- Phase4-A 検証失敗ログと不一致ログを `isBillingDebugEnabled_()` が有効な場合のみ出力するように変更した（`src/main.gs` の Phase4-A 関連ログをガード）。
- 金額計算や合算ロジックには手を入れていないため、金額結果は変更されない。 

### Testing
- 自動テストは実行していない（今回の変更はロジック短絡とログ出力ガードの追加のため、既存テスト実行は要求されていない）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981d62976148321b32d428df9f34e7f)