### PR TITLE
Refine unpaid aggregate notice flag lookup

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -147,6 +147,9 @@
         </table>
       <? } ?>
       <div class="note"><?= isAggregateDisplay ? '未回収期間を含めた合計金額です。（前月未回収分を含む）' : '前月繰越を含む合計金額です。' ?>口座振替日：毎月20日（祝日の場合は翌営業日）</div>
+      <? if (isAggregateDisplay && amount.showAggregateUnpaidNotice) { ?>
+        <div class="note"><strong>注意:</strong> 手続き不備または残高不足等により前月分の引き落としが確認できなかったため、当月分と合算してご請求させていただいております。</div>
+      <? } ?>
       <? if (isAggregateDisplay && data.showOnlineConsentNote) { ?>
         <div class="note"><strong>注記:</strong> オンライン同意費用（1,000円）を含みます</div>
       <? } ?>


### PR DESCRIPTION
### Motivation
- Make the PDF aggregate-unpaid notice decision more accurate by deriving unpaid status from per-month bank-withdrawal status instead of relying on prepared payload shape. 

### Description
- Replace per-`prepared` bank-flag lookup with `getBankWithdrawalStatusByPatient_` in `hasAggregateUnpaidFlagForMonths_` so the check uses the canonical per-month bank-withdrawal status. 
- Ensure invoice PDF contexts set `amount.showAggregateUnpaidNotice` when `displayMode === 'aggregate'` and any aggregate month has an unpaid bank-flag, and keep the template display condition intact. 
- 変更差分（どこをどう変えたか）: `src/main.gs` updated to call `getBankWithdrawalStatusByPatient_` in `hasAggregateUnpaidFlagForMonths_` and to set `amount.showAggregateUnpaidNotice` in `buildInvoicePdfContextForEntry_` and `buildAggregateInvoicePdfContext_`; `src/invoice_template.html` contains the added fixed Japanese notice block for aggregate display. 
- 受け入れ条件に対する確認観点（表示パターンの文章化）: `displayMode === 'aggregate'` かつ合算対象月のいずれかに銀行引落未回収フラグ (`ae`) が立っている場合に注意書きを表示すること; `displayMode === 'standard'` では表示しないこと; `displayMode === 'aggregate'` でも該当月に `ae` がない場合は表示しないこと. 
- 既存挙動を壊さないための注意点（該当箇所のみ）: この変更は表示フラグの算出とテンプレート表示に限定しており、金額計算/領収書ロジック（例: `finalizeInvoiceAmountDataForPdf_`, `applyAggregateInvoiceRulesFromBankFlags_`）には手を入れていないため、金額関連の挙動には影響を与えない点を確認してください. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69829bb22690832195148f5019447ec2)