### PR TITLE
Include aggregate months in unpaid (ae) check to suppress previous receipt

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -165,7 +165,7 @@
     <? var receiptDate = receipt.date || receipt.receiptDate || ''; ?>
     <? var receiptAmount = receipt.amount != null ? receipt.amount : 0; ?>
     <? var receiptNote = receipt.note || receipt.description || ''; ?>
-    <? if (!amount.forceHideReceipt && !isAggregateDisplay && (data.showPreviousReceipt === true || (amount.previousReceiptAmount != null && amount.previousReceiptAmount > 0))) { ?>
+    <? if (!amount.forceHideReceipt && !isAggregateDisplay && amount.previousReceiptVisible !== false && (data.showPreviousReceipt === true || (amount.previousReceiptAmount != null && amount.previousReceiptAmount > 0))) { ?>
       <section class="card">
         <h3 class="section-title">前月分領収書</h3>
         <div class="info">


### PR DESCRIPTION
### Motivation
- Prevent rendering the previous-month receipt when any month involved in the invoice (receipt target months or aggregate target months) is marked unpaid for bank withdrawal (`ae`).
- The prior logic only inspected `receiptMonths`, which could allow the previous receipt to display incorrectly when an aggregate target month was `ae`.

### Description
- Compute `unpaidTargetMonths` as the union of `normalizedAggregateMonths` and `receiptMonths` and use it for unpaid checking. (`src/main.gs`)
- Evaluate `receiptMonthHasUnpaid` by scanning `unpaidTargetMonths` with `getBankWithdrawalStatusByPatient_`, and combine that result with `previousReceiptUnpaid` into `canShowPreviousReceipt`. (`src/main.gs`)
- Apply `canShowPreviousReceipt` to `previousReceipt.visible`, to the returned `previousReceiptVisible`, and to the computed `showPreviousReceipt` so display is gated without altering any monetary calculations. (`src/main.gs`)

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982aa846bf4832198122a4ad11cf7de)