### PR TITLE
Always show aggregate unpaid notice for multi-month aggregate invoices

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -4963,8 +4963,9 @@ function buildInvoicePdfContextForEntry_(entry, prepared, cache, receiptSummaryM
   const aggregateMonths = receiptSummary.aggregateMonths || [];
   const isAggregateInvoice = !!receiptSummary.isAggregateInvoice;
   const amount = finalizeInvoiceAmountDataForPdf_(receiptEntry, billingMonth, aggregateMonths, isAggregateInvoice, cache, prepared);
+  const normalizedAggregateMonths = normalizePastBillingMonths_(aggregateMonths, billingMonth);
   amount.showAggregateUnpaidNotice = amount.displayMode === 'aggregate'
-    && hasAggregateUnpaidFlagForMonths_(patientId, aggregateMonths, cache);
+    && normalizedAggregateMonths.length >= 2;
 
   return {
     patientId,
@@ -4986,7 +4987,7 @@ function buildAggregateInvoicePdfContext_(entry, aggregateMonths, prepared, cach
   const normalizedMonths = normalizePastBillingMonths_(aggregateMonths, billingMonth);
   const amount = finalizeInvoiceAmountDataForPdf_(entry, billingMonth, normalizedMonths, true, cache, prepared);
   amount.showAggregateUnpaidNotice = amount.displayMode === 'aggregate'
-    && hasAggregateUnpaidFlagForMonths_(patientId, normalizedMonths, cache);
+    && normalizedMonths.length >= 2;
 
   return {
     patientId,


### PR DESCRIPTION
### Motivation
- Ensure the unpaid-notice is shown for aggregate PDFs when the invoice is an aggregate display covering multiple months, regardless of bank unpaid flags (`ae`).

### Description
- In `src/main.gs` update `buildInvoicePdfContextForEntry_` and `buildAggregateInvoicePdfContext_` to set `amount.showAggregateUnpaidNotice` when `amount.displayMode === 'aggregate'` and the normalized aggregate months length is >= 2, replacing the previous `hasAggregateUnpaidFlagForMonths_` dependency; other amount calculations and `standard`/`aggregate` detection are left unchanged.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982ad25be688321a5ea19624b751ef0)