### PR TITLE
Add JSON trace logging for aggregate previous-receipt visibility

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -4894,6 +4894,34 @@ function finalizeInvoiceAmountDataForPdf_(entry, billingMonth, aggregateMonths, 
     carryOverAmount
   });
   const showPreviousReceipt = !!(displayFlags && displayFlags.showPreviousReceipt) && canShowPreviousReceipt;
+  if (displayFlags && displayFlags.displayMode === 'aggregate'
+      && resolvedPreviousReceiptAmount != null
+      && typeof DEBUG_RECEIPT_TRACE !== 'undefined'
+      && DEBUG_RECEIPT_TRACE === true) {
+    const aeByMonth = unpaidTargetMonths.reduce((result, month) => {
+      const flags = getBankWithdrawalStatusByPatient_(month, entry && entry.patientId, cache);
+      result[month] = !!(flags && flags.ae);
+      return result;
+    }, {});
+    const tracePayload = {
+      patientId: entry && entry.patientId,
+      billingMonth,
+      displayMode: displayFlags.displayMode,
+      shouldShowReceipt,
+      forceHideReceipt: amount.forceHideReceipt,
+      canShowPreviousReceipt,
+      previousReceiptAmount: resolvedPreviousReceiptAmount,
+      receiptMonths,
+      normalizedAggregateMonths,
+      unpaidTargetMonths,
+      aeByMonth
+    };
+    if (typeof billingLogger_ !== 'undefined' && billingLogger_ && typeof billingLogger_.log === 'function') {
+      billingLogger_.log(JSON.stringify(tracePayload));
+    } else if (typeof console !== 'undefined' && typeof console.log === 'function') {
+      console.log(JSON.stringify(tracePayload));
+    }
+  }
   logReceiptDebug_(entry && entry.patientId, {
     step: 'finalizeInvoiceAmountDataForPdf_',
     billingMonth,


### PR DESCRIPTION
### Motivation
- Make the decision path for showing a previous-month receipt observable in a single JSON line per patient without changing any existing behavior.
- Restrict additional logs to aggregate display scenarios where a previous receipt amount exists and a debug flag is explicitly enabled so normal log volume is unchanged.

### Description
- Added a gated logging block inside `finalizeInvoiceAmountDataForPdf_` that runs when `displayFlags.displayMode === 'aggregate'`, `resolvedPreviousReceiptAmount != null`, and `DEBUG_RECEIPT_TRACE === true`.
- The logger emits a single JSON object (one patient per line) containing `patientId`, `billingMonth`, `displayMode`, `shouldShowReceipt`, `forceHideReceipt`, `canShowPreviousReceipt`, `previousReceiptAmount`, `receiptMonths`, `normalizedAggregateMonths`, `unpaidTargetMonths`, and `aeByMonth` (per-month `ae` flags).
- The log is written via `billingLogger_.log` when available or falls back to `console.log`, and does not modify any existing conditionals, `return` points, or visible behavior.

### Testing
- No automated tests were executed for this logging-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982b1804a148321a91531547232e2da)