### PR TITLE
Emit JSON trace for previous receipt when `DEBUG_RECEIPT_TRACE` is enabled

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -4903,8 +4903,7 @@ function finalizeInvoiceAmountDataForPdf_(entry, billingMonth, aggregateMonths, 
     }
   }
   const showPreviousReceipt = !!(displayFlags && displayFlags.showPreviousReceipt) && canShowPreviousReceipt;
-  if (displayFlags && displayFlags.displayMode === 'aggregate'
-      && resolvedPreviousReceiptAmount != null
+  if (resolvedPreviousReceiptAmount != null
       && typeof DEBUG_RECEIPT_TRACE !== 'undefined'
       && DEBUG_RECEIPT_TRACE === true) {
     const aeByMonth = unpaidTargetMonths.reduce((result, month) => {


### PR DESCRIPTION
### Motivation
- To help diagnose why previous-month receipts are shown incorrectly, emit an investigation-only JSON trace of the previous-receipt decision whenever a previous receipt amount exists and `DEBUG_RECEIPT_TRACE` is enabled, independent of the display mode.

### Description
- Relaxed the logging condition in `finalizeInvoiceAmountDataForPdf_` so the trace runs when `resolvedPreviousReceiptAmount != null && DEBUG_RECEIPT_TRACE === true`; the emitted JSON payload contains `patientId`, `billingMonth`, `displayMode`, `shouldShowReceipt`, `forceHideReceipt`, `canShowPreviousReceipt`, `previousReceiptAmount`, `receiptMonths`, `normalizedAggregateMonths`, `unpaidTargetMonths`, and `aeByMonth`, and it logs via `billingLogger_.log` if available or falls back to `console.log`.

### Testing
- No automated tests were run for this logging-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982c54136808321b0d4e55191594685)