### PR TITLE
Deterministically set invoice PDF displayMode to 'aggregate' when 2+ months

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -5001,6 +5001,8 @@ function buildInvoicePdfContextForEntry_(entry, prepared, cache, receiptSummaryM
   const isAggregateInvoice = !!receiptSummary.isAggregateInvoice;
   const amount = finalizeInvoiceAmountDataForPdf_(receiptEntry, billingMonth, aggregateMonths, isAggregateInvoice, cache, prepared);
   const normalizedAggregateMonths = normalizePastBillingMonths_(aggregateMonths, billingMonth);
+  const isAggregate = Array.isArray(normalizedAggregateMonths) && normalizedAggregateMonths.length >= 2;
+  amount.displayMode = isAggregate ? 'aggregate' : 'standard';
   amount.showAggregateUnpaidNotice = amount.displayMode === 'aggregate'
     && normalizedAggregateMonths.length >= 2;
 
@@ -5023,6 +5025,8 @@ function buildAggregateInvoicePdfContext_(entry, aggregateMonths, prepared, cach
 
   const normalizedMonths = normalizePastBillingMonths_(aggregateMonths, billingMonth);
   const amount = finalizeInvoiceAmountDataForPdf_(entry, billingMonth, normalizedMonths, true, cache, prepared);
+  const isAggregate = Array.isArray(normalizedMonths) && normalizedMonths.length >= 2;
+  amount.displayMode = isAggregate ? 'aggregate' : 'standard';
   amount.showAggregateUnpaidNotice = amount.displayMode === 'aggregate'
     && normalizedMonths.length >= 2;
 


### PR DESCRIPTION
### Motivation
- Ensure the invoice PDF `displayMode` always reflects actual aggregate state so aggregate billing is never rendered as `standard` when multiple months are combined.
- Centralize the display mode decision based on normalized aggregate months to make notice/receipt visibility consistent with the real aggregate state.

### Description
- In `buildInvoicePdfContextForEntry_` compute `normalizedAggregateMonths` and set `amount.displayMode = isAggregate ? 'aggregate' : 'standard'` where `isAggregate` means `normalizedAggregateMonths.length >= 2`.
- In `buildAggregateInvoicePdfContext_` compute `normalizedMonths` and set `amount.displayMode = isAggregate ? 'aggregate' : 'standard'` where `isAggregate` means `normalizedMonths.length >= 2`.
- Kept all amount calculation code and unpaid/`ae` logic unchanged and did not modify any HTML templates.
- Left `showAggregateUnpaidNotice` logic intact and still derived from `amount.displayMode` and the normalized months length.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982c7aefb68832184d92838de22cd9f)