### PR TITLE
Restrict previous receipt display to data.showPreviousReceipt

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -165,7 +165,7 @@
     <? var receiptDate = receipt.date || receipt.receiptDate || ''; ?>
     <? var receiptAmount = receipt.amount != null ? receipt.amount : 0; ?>
     <? var receiptNote = receipt.note || receipt.description || ''; ?>
-    <? if (!amount.forceHideReceipt && !isAggregateDisplay && amount.previousReceiptVisible !== false && (data.showPreviousReceipt === true || (amount.previousReceiptAmount != null && amount.previousReceiptAmount > 0))) { ?>
+    <? if (data.showPreviousReceipt === true) { ?>
       <section class="card">
         <h3 class="section-title">前月分領収書</h3>
         <div class="info">


### PR DESCRIPTION
### Motivation
- Fix a bug where the template showed the previous-month receipt whenever `amount.previousReceiptAmount` existed even if `data.showPreviousReceipt` was set to `false`, and ensure the visibility decision is driven only by `data.showPreviousReceipt` so `main.gs` unpaid (`ae`) logic is respected.

### Description
- Updated `src/invoice_template.html` to replace the complex conditional with a single check `<? if (data.showPreviousReceipt === true) { ?>`, removing `amount.forceHideReceipt`, `isAggregateDisplay`, `amount.previousReceiptVisible`, and `amount.previousReceiptAmount` from the template-side logic.

### Testing
- No automated tests were executed for this template-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982d895995483218adaa5c21bcb413c)