### PR TITLE
Refine dashboard invoice logging to isolate link-drop points

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -131,6 +131,12 @@ const dashboardState = {
   marking: new Set()
 };
 
+function logDashboardUi_(label, details) {
+  if (typeof console === 'undefined') return;
+  const payload = details === undefined ? '' : details;
+  console.info(`[dashboard-ui] ${label}`, payload);
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const refreshBtn = document.getElementById('refreshBtn');
   refreshBtn.addEventListener('click', fetchDashboardData);
@@ -140,15 +146,26 @@ document.addEventListener('DOMContentLoaded', () => {
 function fetchDashboardData() {
   setLoading(true);
   dashboardState.error = '';
+  logDashboardUi_('fetchDashboardData:start', { mock: resolveDashboardMockParam_() || null });
 
   const onSuccess = (payload) => {
     dashboardState.data = payload || {};
     setLoading(false);
+    const summary = {
+      tasks: Array.isArray(payload && payload.tasks) ? payload.tasks.length : 0,
+      visits: Array.isArray(payload && payload.todayVisits) ? payload.todayVisits.length : 0,
+      patients: Array.isArray(payload && payload.patients) ? payload.patients.length : 0,
+      unpaidAlerts: Array.isArray(payload && payload.unpaidAlerts) ? payload.unpaidAlerts.length : 0,
+      warnings: Array.isArray(payload && payload.warnings) ? payload.warnings.length : 0,
+      metaError: payload && payload.meta && payload.meta.error ? payload.meta.error : ''
+    };
+    logDashboardUi_('fetchDashboardData:success', summary);
     renderAll();
   };
   const onFailure = (err) => {
     dashboardState.error = err && err.message ? err.message : String(err || '不明なエラー');
     setLoading(false);
+    logDashboardUi_('fetchDashboardData:failure', dashboardState.error);
     renderAll();
   };
 
@@ -156,6 +173,7 @@ function fetchDashboardData() {
   if (runner && typeof runner.getDashboardData === 'function') {
     const mockFlag = resolveDashboardMockParam_();
     const args = mockFlag ? { mock: mockFlag } : {};
+    logDashboardUi_('fetchDashboardData:appsScript', { mock: mockFlag || null });
     runner.withSuccessHandler(onSuccess).withFailureHandler(onFailure).getDashboardData(args);
     return;
   }
@@ -163,6 +181,7 @@ function fetchDashboardData() {
   const mock = resolveDashboardMockParam_();
   const mockQuery = mock ? `&mock=${encodeURIComponent(mock)}` : '';
   const url = (typeof baseUrl !== 'undefined' ? baseUrl : '') + `?action=getDashboardData${mockQuery}`;
+  logDashboardUi_('fetchDashboardData:fetch', { url });
   fetch(url)
     .then(res => res.json())
     .then(onSuccess)

--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -74,6 +74,7 @@ function getDashboardData(options) {
       responsible,
       treatmentLogs
     });
+    logContext('getDashboardData:buildPatients', `patients=${patients.length}`);
 
     const warningState = collectDashboardWarnings_([
       patientInfo,

--- a/src/dashboard/data/loadInvoices.js
+++ b/src/dashboard/data/loadInvoices.js
@@ -23,6 +23,14 @@ function loadInvoicesUncached_(options) {
   const setupIncomplete = !!(patientInfo && patientInfo.setupIncomplete);
   const invoices = {};
   const latestMeta = {};
+  const logContext = (label, details) => {
+    if (typeof dashboardLogContext_ === 'function') {
+      dashboardLogContext_(label, details);
+    } else if (typeof dashboardWarn_ === 'function') {
+      const payload = details ? ` ${details}` : '';
+      dashboardWarn_(`[${label}]${payload}`);
+    }
+  };
 
   Object.keys(patients).forEach(pid => {
     const normalized = dashboardNormalizePatientId_(pid);
@@ -35,6 +43,7 @@ function loadInvoicesUncached_(options) {
   if (!root || typeof root.getFolders !== 'function') {
     warnings.push('請求書フォルダが取得できませんでした');
     dashboardWarn_('[loadInvoices] invoice root folder not found');
+    logContext('loadInvoices:done', `patients=${Object.keys(invoices).length} linked=0 warnings=${warnings.length} setupIncomplete=true`);
     return { invoices, warnings, setupIncomplete: true };
   }
 
@@ -75,6 +84,8 @@ function loadInvoicesUncached_(options) {
     }
   }
 
+  const linkedCount = Object.keys(invoices).reduce((count, pid) => (invoices[pid] ? count + 1 : count), 0);
+  logContext('loadInvoices:done', `patients=${Object.keys(invoices).length} linked=${linkedCount} warnings=${warnings.length} setupIncomplete=${setupIncomplete}`);
   return { invoices, warnings, setupIncomplete };
 }
 


### PR DESCRIPTION
### Motivation
- 現行ログで `invoices=<件数>` とだけ出力すると、患者キーを初期化しているだけのケースと実際に請求書リンクが存在するケースが区別できず、どこでリンクが失われているか追跡しづらかったため、より判別しやすいログにする目的で変更しました。
- 変更は低リスクなログ出力の改善に限定し、動作ロジックは維持して原因追跡を容易にすることを狙いとしています。

### Description
- `src/dashboard/data/loadInvoices.js` のログ出力を更新し、フォルダ取得失敗時のログを `patients=<初期化した患者キー数> linked=0` へ置換し、通常完了時には `linked` を算出して `patients=<総キー数> linked=<URL保持数> warnings=<数> setupIncomplete=<true|false>` を出力するようにしました。
- 受け入れ条件（表示パターン）としては次を想定します: 正常時は `patients>0 && linked>0`、請求書欠落のみは `patients>0 && linked=0`、セットアップ不備は `setupIncomplete=true` を伴うログ、そしてサーバーログが妥当でもクライアント側でゼロ表示になる場合はクライアント受信/描画経路を確認する、という判定パターンを出力で確認できること。
- 挙動を壊さないための注意点は、`invoices` オブジェクトの生成・更新・返却 (`return { invoices, warnings, setupIncomplete }`) はそのまま残しており、今回の変更はログ集計と出力文言の修正のみであることです。

### Testing
- 自動化されたテストは実行していません（ログ出力のみの変更のため）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982f5b9ead883219c5b992e4a7cec3a)