### PR TITLE
請求書PDFの施術料表示を「単価×回数×負担割合」に統一し可読性を改善

### DIFF
--- a/src/invoice_template.html
+++ b/src/invoice_template.html
@@ -22,12 +22,12 @@
     th, td { border: 1px solid #e2e8f0; padding: 8px 10px; text-align: left; }
     th { background: #e5f0ff; font-weight: 700; }
     td.amount { text-align: right; }
-    tfoot td { font-weight: 700; background: #edf2f7; }
+    tfoot td { font-weight: 700; background: #edf2f7; font-size: 18px; }
     .subtable { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 12px; }
     .subtable th, .subtable td { border: 1px solid #e2e8f0; padding: 6px 8px; text-align: left; }
     .subtable th.amount, .subtable td.amount { text-align: right; }
     .subsection-title { margin: 10px 0 4px; font-weight: 700; font-size: 13px; }
-    .note { color: #475569; font-size: 12px; margin-top: 6px; }
+    .note { color: #475569; font-size: 14px; line-height: 1.6; margin-top: 6px; }
     .divider { border: 0; border-top: 1px dashed #cbd5e1; margin: 4px 0 2px; }
     .watermark {
       position: fixed;

--- a/src/main.gs
+++ b/src/main.gs
@@ -4744,9 +4744,14 @@ function buildStandardInvoiceAmountDataForPdf_(entry, billingMonth) {
   const carryOverAmount = normalizeBillingCarryOver_(entry);
   const unitPrice = breakdown.treatmentUnitPrice || 0;
   const transportDetail = breakdown.transportDetail || (formatBillingCurrency_(TRANSPORT_PRICE) + '円 × ' + visits + '回');
+  const burdenRateInt = normalizeInvoiceBurdenRateInt_(entry && entry.burdenRate);
+  const treatmentDetail = [
+    formatBillingCurrency_(unitPrice) + '円 × ' + visits + '回',
+    (burdenRateInt === 1 || burdenRateInt === 2 || burdenRateInt === 3) ? burdenRateInt + '割' : ''
+  ].filter(Boolean).join(' × ');
   const rows = [
     { label: '前月繰越', detail: '', amount: carryOverAmount },
-    { label: '施術料', detail: formatBillingCurrency_(unitPrice) + '円 × ' + visits + '回', amount: breakdown.treatmentAmount || 0 },
+    { label: '施術料', detail: treatmentDetail, amount: breakdown.treatmentAmount || 0 },
     { label: '交通費', detail: transportDetail, amount: breakdown.transportAmount || 0 }
   ];
   const selfPayItems = Array.isArray(entry && entry.selfPayItems)

--- a/src/output/billingOutput.js
+++ b/src/output/billingOutput.js
@@ -1267,6 +1267,7 @@ function buildInvoiceTemplateData_(item) {
   let unitPrice = breakdown.treatmentUnitPrice || 0;
   let carryOverAmount = normalizeBillingCarryOver_(item);
   let transportDetail = breakdown.transportDetail || (formatBillingCurrency_(TRANSPORT_PRICE) + '円 × ' + visits + '回');
+  const burdenRateInt = normalizeInvoiceBurdenRateInt_(item && item.burdenRate);
   let aggregateMonthTotals = [];
   let grandTotal = breakdown.grandTotal;
   const baseSelfPayItems = Array.isArray(baseBreakdown.selfPayItems) ? baseBreakdown.selfPayItems : [];
@@ -1295,8 +1296,13 @@ function buildInvoiceTemplateData_(item) {
     grandTotal = breakdown.grandTotal;
   }
 
+  const treatmentDetail = [
+    formatBillingCurrency_(unitPrice) + '円 × ' + visits + '回',
+    (burdenRateInt === 1 || burdenRateInt === 2 || burdenRateInt === 3) ? burdenRateInt + '割' : ''
+  ].filter(Boolean).join(' × ');
+
   const rows = [
-    { label: '施術料', detail: formatBillingCurrency_(unitPrice) + '円 × ' + visits + '回', amount: breakdown.treatmentAmount },
+    { label: '施術料', detail: treatmentDetail, amount: breakdown.treatmentAmount },
     { label: '交通費', detail: transportDetail, amount: breakdown.transportAmount }
   ];
   if (carryOverAmount !== 0) {


### PR DESCRIPTION
### Motivation
- 請求書PDFの施術料表示を高齢者にも直感的に分かる形式にして可読性を上げるため、表示文字列のみをGAS側で組み立ててテンプレートでは表示だけを行う責務分離を徹底しました。 

### Description
- `src/output/billingOutput.js` の `buildInvoiceTemplateData_` で施術料の `row.detail` を `4,170円 × {回数}回 × {負担割合}割` の形式で組み立てるよう変更し、`row.amount`（自己負担額）は従来どおり `breakdown.treatmentAmount` を保持しています。 
- `src/main.gs` の `buildStandardInvoiceAmountDataForPdf_` 側にも同様の表示文字列生成を追加してPDF生成経路で表示仕様を統一しました。 
- `src/invoice_template.html` のスタイルを調整して `tfoot td` を `font-size: 18px` に、`.note` を `font-size: 14px` と `line-height: 1.6` に変更し合計欄と注記の可読性を向上させました。 

### Testing
- `git diff --check` を実行して差分に問題がないことを確認しました（成功）。
- `rg` / grep による差分確認（施術料表示箇所とスタイル変更の検出）を実行し、期待どおり変更ファイルが見つかることを確認しました（成功）。
- HTMLレンダリング確認用に Playwright でローカルファイルを開く試行を行いましたが `ERR_FILE_NOT_FOUND` によりスクリーンショット取得は失敗しました（失敗）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984812d85f88321a14f46fab5874aa1)