### PR TITLE
Add top overview blocks to practitioner dashboard (invoices, consent, visits)

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -67,6 +67,15 @@
   .alert-metrics{ display:flex; gap:8px; flex-wrap:wrap; align-items:center; }
   .alert-amount{ font-size:1.1rem; font-weight:800; color:#fbbf24; }
   .alert-months{ display:flex; gap:6px; flex-wrap:wrap; font-size:0.9rem; color:var(--muted); }
+  .summary-card{ display:flex; flex-direction:column; gap:10px; }
+  .summary-header{ display:flex; align-items:center; justify-content:space-between; gap:8px; }
+  .summary-header h3{ margin:0; font-size:1rem; }
+  .summary-count{ font-weight:700; font-size:1.1rem; color:#fff; }
+  .summary-list{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:6px; }
+  .summary-list li{ display:flex; align-items:center; gap:6px; flex-wrap:wrap; }
+  .summary-link{ color:var(--accent); text-decoration:none; font-weight:600; }
+  .summary-link:hover{ text-decoration:underline; }
+  .summary-meta{ font-size:0.85rem; color:var(--muted); }
   @keyframes spin{ to{ transform:rotate(360deg); } }
   @media (max-width:640px){
     .visit{ grid-template-columns:60px 1fr; }
@@ -84,6 +93,14 @@
   </header>
 
   <div id="errorBox" class="error-box" style="display:none;"></div>
+
+  <div class="section">
+    <div class="grid" id="overviewGrid">
+      <div class="card summary-card" id="invoiceSummary"></div>
+      <div class="card summary-card" id="consentSummary"></div>
+      <div class="card summary-card" id="visitSummary"></div>
+    </div>
+  </div>
 
   <div class="section">
     <div class="section-header">
@@ -200,6 +217,7 @@ function setLoading(flag) {
 function renderAll() {
   renderMeta();
   renderWarnings();
+  renderOverview();
   renderTasks();
   renderUnpaidAlerts();
   renderVisits();
@@ -251,6 +269,71 @@ function renderWarnings() {
     item.textContent = w;
     list.appendChild(item);
   });
+}
+
+function renderOverview() {
+  renderInvoiceSummary();
+  renderConsentSummary();
+  renderVisitSummary();
+}
+
+function renderInvoiceSummary() {
+  const container = document.getElementById('invoiceSummary');
+  if (!container) return;
+  const overview = dashboardState.data && dashboardState.data.overview ? dashboardState.data.overview : {};
+  const data = overview && overview.invoiceUnconfirmed ? overview.invoiceUnconfirmed : { count: 0, items: [] };
+  renderSummaryCard_(container, {
+    title: '請求書受渡 未確認',
+    count: data.count || 0,
+    items: data.items || [],
+    emptyText: '未確認の請求書はありません'
+  });
+}
+
+function renderConsentSummary() {
+  const container = document.getElementById('consentSummary');
+  if (!container) return;
+  const overview = dashboardState.data && dashboardState.data.overview ? dashboardState.data.overview : {};
+  const data = overview && overview.consentRelated ? overview.consentRelated : { count: 0, items: [] };
+  renderSummaryCard_(container, {
+    title: '同意期限／未取得／関連通知',
+    count: data.count || 0,
+    items: data.items || [],
+    emptyText: '同意に関する注意はありません'
+  });
+}
+
+function renderVisitSummary() {
+  const container = document.getElementById('visitSummary');
+  if (!container) return;
+  container.innerHTML = '';
+  const overview = dashboardState.data && dashboardState.data.overview ? dashboardState.data.overview : {};
+  const data = overview && overview.visitSummary ? overview.visitSummary : null;
+  const today = data && data.today ? data.today : { count: 0, items: [] };
+  const yesterday = data && data.yesterday ? data.yesterday : { count: 0, items: [] };
+
+  const header = document.createElement('div');
+  header.className = 'summary-header';
+  const title = document.createElement('h3');
+  title.textContent = '今日／昨日の施術実績';
+  header.appendChild(title);
+  const count = document.createElement('div');
+  count.className = 'summary-count';
+  count.textContent = `今日${today.count || 0}件／昨日${yesterday.count || 0}件`;
+  header.appendChild(count);
+  container.appendChild(header);
+
+  const todayBlock = document.createElement('div');
+  todayBlock.className = 'summary-meta';
+  todayBlock.textContent = '今日の患者';
+  container.appendChild(todayBlock);
+  container.appendChild(renderSummaryList_(today.items || [], '今日の施術はありません'));
+
+  const yesterdayBlock = document.createElement('div');
+  yesterdayBlock.className = 'summary-meta';
+  yesterdayBlock.textContent = '昨日の患者';
+  container.appendChild(yesterdayBlock);
+  container.appendChild(renderSummaryList_(yesterday.items || [], '昨日の施術はありません'));
 }
 
 function renderTasks() {
@@ -573,6 +656,59 @@ function makeBadge(text) {
   span.className = 'badge';
   span.textContent = text;
   return span;
+}
+
+function renderSummaryCard_(container, options) {
+  const opts = options || {};
+  container.innerHTML = '';
+
+  const header = document.createElement('div');
+  header.className = 'summary-header';
+  const title = document.createElement('h3');
+  title.textContent = opts.title || '';
+  header.appendChild(title);
+  const count = document.createElement('div');
+  count.className = 'summary-count';
+  count.textContent = `${opts.count || 0}件`;
+  header.appendChild(count);
+  container.appendChild(header);
+
+  const items = Array.isArray(opts.items) ? opts.items : [];
+  container.appendChild(renderSummaryList_(items, opts.emptyText || '対象はありません'));
+}
+
+function renderSummaryList_(items, emptyText) {
+  const filteredItems = (items || []).filter(item => item && item.patientId);
+  if (!filteredItems.length) {
+    const empty = document.createElement('div');
+    empty.className = 'muted';
+    empty.textContent = emptyText || '対象はありません';
+    return empty;
+  }
+
+  const list = document.createElement('ul');
+  list.className = 'summary-list';
+  filteredItems
+    .slice()
+    .sort((a, b) => (a.name || '').localeCompare(b.name || '', 'ja'))
+    .forEach(item => {
+      const row = document.createElement('li');
+      const link = document.createElement('a');
+      link.className = 'summary-link';
+      link.href = buildRecordLink_(item.patientId);
+      link.target = '_top';
+      link.rel = 'noreferrer';
+      link.textContent = item.name || item.patientId;
+      row.appendChild(link);
+      list.appendChild(row);
+    });
+  return list;
+}
+
+function buildRecordLink_(patientId) {
+  const base = typeof baseUrl !== 'undefined' ? baseUrl : '';
+  const id = encodeURIComponent(patientId || '');
+  return `${base}?view=record&id=${id}`;
 }
 
 function formatTaskLabel(type) {


### PR DESCRIPTION
### Motivation
- Surface three high-priority summary blocks on the practitioner dashboard so staff can quickly see invoice confirmation status, consent-related issues, and today/yesterday visit counts without adding new data structures or editing records.

### Description
- Added an `overview` section to `getDashboardData` response and implemented aggregation helpers `buildDashboardOverview_`, `resolveDashboardOverviewTargets_`, `buildOverviewFromTasks_`, `buildOverviewFromConsent_`, and `buildOverviewFromVisits_` in `src/dashboard/api/getDashboardData.js` to collect and filter items (practitioner-scoped vs admin) and sort names in Japanese locale.
- Extended the dashboard UI in `src/dashboard.html` with styles and three summary cards (`請求書受渡 未確認`, `同意期限／未取得／関連通知`, `今日／昨日の施術実績`), added `renderOverview`, per-card renderers, `renderSummaryCard_`, `renderSummaryList_`, and `buildRecordLink_` to render counts and patient links that open the record view (`?view=record&id=...`).
- Kept behavior non-destructive: lists are read-only, ordered by name (五十音順), and use existing data sources (`tasks`, `todayVisits`, `patients`, `patientInfo`, `treatmentLogs`) with no schema changes.

### Testing
- Performed a headless UI render check by serving `src/` (`python -m http.server`) and running a Playwright script that injected a sample `dashboardState.data` and called `renderAll()`, producing `artifacts/dashboard-overview.png` successfully.
- No new automated unit tests were added; existing `buildDashboardMockData_` can be used for further validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69865afdeee88321814413a318468c71)