### PR TITLE
Adjust visit summary counts for unique patients

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -322,9 +322,9 @@ function buildOverviewFromVisits_(visits, scope, patientNameMap, now, tz) {
     if (!pid || (applyFilter && allowedPatientIds && !allowedPatientIds.has(pid))) return;
     const dateKey = entry.dateKey || '';
     if (!Object.prototype.hasOwnProperty.call(byDate, dateKey)) return;
-    byDate[dateKey].count += 1;
     if (seenByDate[dateKey].has(pid)) return;
     seenByDate[dateKey].add(pid);
+    byDate[dateKey].count += 1;
     const name = entry.patientName || patientNameMap[pid] || '';
     byDate[dateKey].items.push({ patientId: pid, name });
   });


### PR DESCRIPTION
### Motivation
- Ensure the visit summary counts shown in the dashboard reflect unique patients per day so the numeric counts match the displayed patient name lists.

### Description
- In `src/dashboard/api/getDashboardData.js` inside `buildOverviewFromVisits_` moved the `byDate[dateKey].count += 1` increment to occur after the duplicate-patient check (`seenByDate`) so each patient is counted only once per date.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986c4bbf08c832196f5eea9787cc135)