### PR TITLE
Dashboard: render top overview blocks as patient lists with subtext and badges

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -72,10 +72,12 @@
   .summary-header h3{ margin:0; font-size:1rem; }
   .summary-count{ font-weight:700; font-size:1.1rem; color:#fff; }
   .summary-list{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:6px; }
-  .summary-list li{ display:flex; align-items:center; gap:6px; flex-wrap:wrap; }
+  .summary-list li{ display:flex; align-items:center; justify-content:space-between; gap:8px; flex-wrap:wrap; padding:6px 8px; border-radius:10px; border:1px solid var(--border); background:rgba(255,255,255,0.02); }
+  .summary-main{ display:flex; flex-direction:column; gap:2px; }
   .summary-link{ color:var(--accent); text-decoration:none; font-weight:600; }
   .summary-link:hover{ text-decoration:underline; }
   .summary-meta{ font-size:0.85rem; color:var(--muted); }
+  .summary-subtext{ font-size:0.82rem; color:var(--muted); }
   @keyframes spin{ to{ transform:rotate(360deg); } }
   @media (max-width:640px){
     .visit{ grid-template-columns:60px 1fr; }
@@ -131,7 +133,6 @@
       <h2>担当患者一覧</h2>
       <span class="small" id="patientCount"></span>
     </div>
-    <div class="warning-list" id="warningList"></div>
     <div class="section" id="patientList"></div>
   </div>
 </div>
@@ -216,7 +217,6 @@ function setLoading(flag) {
 
 function renderAll() {
   renderMeta();
-  renderWarnings();
   renderOverview();
   renderTasks();
   renderUnpaidAlerts();
@@ -247,28 +247,6 @@ function renderError() {
   }
   box.style.display = 'none';
   box.textContent = '';
-}
-
-function renderWarnings() {
-  const list = document.getElementById('warningList');
-  if (!list) return;
-  list.innerHTML = '';
-  const warnings = dashboardState.data && Array.isArray(dashboardState.data.warnings)
-    ? dashboardState.data.warnings
-    : [];
-  if (!warnings.length) {
-    const empty = document.createElement('div');
-    empty.className = 'muted';
-    empty.textContent = '警告はありません';
-    list.appendChild(empty);
-    return;
-  }
-  warnings.forEach(w => {
-    const item = document.createElement('div');
-    item.className = 'warning-item';
-    item.textContent = w;
-    list.appendChild(item);
-  });
 }
 
 function renderOverview() {
@@ -693,13 +671,28 @@ function renderSummaryList_(items, emptyText) {
     .sort((a, b) => (a.name || '').localeCompare(b.name || '', 'ja'))
     .forEach(item => {
       const row = document.createElement('li');
+      const main = document.createElement('div');
+      main.className = 'summary-main';
       const link = document.createElement('a');
       link.className = 'summary-link';
       link.href = buildRecordLink_(item.patientId);
       link.target = '_top';
       link.rel = 'noreferrer';
       link.textContent = item.name || item.patientId;
-      row.appendChild(link);
+      main.appendChild(link);
+      if (item.subText) {
+        const sub = document.createElement('div');
+        sub.className = 'summary-subtext';
+        sub.textContent = item.subText;
+        main.appendChild(sub);
+      }
+      row.appendChild(main);
+      if (item.badge) {
+        const badge = document.createElement('span');
+        badge.className = 'badge';
+        badge.textContent = item.badge;
+        row.appendChild(badge);
+      }
       list.appendChild(row);
     });
   return list;


### PR DESCRIPTION
### Motivation
- Convert the three top overview blocks (invoice unconfirmed / consent-related / today‑yesterday visits) into fixed patient-list UIs that show only valid patientIds within the monthly/daily scope. 
- Remove developer/maintenance warnings from the visible UI so only patient-facing state is shown. 
- Ensure counts and lists are computed from the exact same scoped patient set and presented in Japanese collation order.

### Description
- UI: updated `src/dashboard.html` to replace compact summary items with styled patient rows, adding `.summary-main`, `.summary-subtext` and per-row badge support, and removed rendering of the warning list from the page and from `renderAll()` calls. 
- API/data: updated `src/dashboard/api/getDashboardData.js` to pass the computed `allowedPatientIds` (monthly/daily display set) into `buildDashboardOverview_` and to scope overview calculations to that set. 
- Logic: replaced the generic overview-from-tasks flow with specialized builders: `buildOverviewFromInvoiceUnconfirmed_`, and adjusted consent and visit overview builders to produce `subText` (status like "未確認" / "期限切れ" / "未取得" / "施術日: 今日/昨日") and optional `badge` (visit counts), while keeping all lists sorted by Japanese locale. 
- Small behavioral detail: `buildDashboardPatients_` already respects `allowedPatientIds` and continues to filter patients by existence in the patient master, so only master-backed patientIds are included. 
- 【共有用サマリー】: 変更点: 上段3ブロックを患者名＋状態サブテキスト／件数バッジの一覧表示に刷新し、警告一覧表示を削除しました; 理由: 患者一覧UIとして固定表示し整備用警告をUIに出さない要件に合わせるため; 影響範囲: 請求書／同意／施術実績の集計と一覧が月次・日次スコープの患者IDに限定され、同一スコープで算出されます。 

### Testing
- Automated tests: none were executed in this rollout. 
- Notes for verification: a dashboard mock generator exists (`src/dashboard/tests/dashboardMockData.gs` / `getDashboardMockData`) and can be used to exercise `getDashboardData()` and visually confirm the new lists (recommended smoke test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69883819b9948321970ea44c339d5a16)