### PR TITLE
Add dashboard patient links to treatment app and auto-select by patientId

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -9601,7 +9601,11 @@ function doGet(e) {
     return createJsonResponse_(data);
   }
 
-  const view = e.parameter ? (e.parameter.view || 'welcome') : 'welcome';
+  const path = (e && e.pathInfo ? String(e.pathInfo) : '').replace(/^\/+|\/+$/g, '').toLowerCase();
+  let view = e.parameter ? (e.parameter.view || 'welcome') : 'welcome';
+  if (path === 'treatmentapp') {
+    view = 'record';
+  }
   let templateFile = '';
 
   switch(view){
@@ -9628,9 +9632,9 @@ function doGet(e) {
   // ここでURLを渡す
   t.baseUrl = ScriptApp.getService().getUrl();
 
-  // 患者ID（?id=XXXX）をテンプレートに渡す
-  if (e.parameter && e.parameter.id) {
-    t.patientId = e.parameter.id;
+  // 患者ID（?patientId=XXXX / ?id=XXXX）をテンプレートに渡す
+  if (e.parameter && (e.parameter.patientId || e.parameter.id)) {
+    t.patientId = e.parameter.patientId || e.parameter.id;
   } else {
     t.patientId = "";
   }

--- a/src/app.html
+++ b/src/app.html
@@ -516,6 +516,8 @@ let _patientIdInitialRenderBuffer = null;
 let _patientIdInitialRenderWaiters = [];
 let _patientIdInitialRenderNoticeShown = false;
 let _confirmedPatientId = '';
+let _initialPatientIdRequested = '';
+let _initialPatientIdResolved = false;
 let _patientIdSelectionLocked = false;
 let _patientIdInputEditing = false;
 let _patientInfoLoadInFlight = false;
@@ -602,6 +604,25 @@ function waitMs(ms){
     const delay = typeof ms === 'number' && ms > 0 ? ms : 0;
     setTimeout(resolve, delay);
   });
+}
+
+function resolveInitialPatientIdRequest(){
+  let candidate = '';
+  try {
+    const templatePid = "<?= patientId ?>";
+    if (templatePid) candidate = String(templatePid).trim();
+  } catch (err){
+    console.warn('[resolveInitialPatientIdRequest] template read failed', err);
+  }
+  if (!candidate && typeof window !== 'undefined' && window.location){
+    try {
+      const params = new URLSearchParams(window.location.search);
+      candidate = params.get('patientId') || params.get('id') || '';
+    } catch (err){
+      console.warn('[resolveInitialPatientIdRequest] URL params read failed', err);
+    }
+  }
+  return normalizePatientIdKey(candidate);
 }
 
 function invalidatePatientInfoRequests(){
@@ -2570,8 +2591,18 @@ function savePatientIdCache(list){
 }
 
 function loadPidList(){
-  const ensureAfterApply = () => {
+  const ensureAfterApply = (options) => {
+    const opts = Object.assign({ finalize: false }, options || {});
     try {
+      const initialApplied = applyInitialPatientSelectionFromRequest_({ finalize: opts.finalize });
+      if (initialApplied) {
+        schedulePatientIdSearchUpdate(true);
+        return;
+      }
+      if (_initialPatientIdRequested && !_initialPatientIdResolved && !_patientIdList.length && !opts.finalize){
+        schedulePatientIdSearchUpdate(true);
+        return;
+      }
       const result = ensurePatientIdDisplayFromInput({
         allowPlainOnMiss: !_patientIdList.length,
         clearOnReject: !!_patientIdList.length,
@@ -2589,13 +2620,13 @@ function loadPidList(){
       console.error('[loadPidList] ensurePatientIdDisplayFromInput failed', err);
     }
   };
-  const useList = (list, source) => {
+  const useList = (list, source, options) => {
     return applyPatientIdList(list, { source })
       .catch(err => {
         console.error('[applyPatientIdList] failed', err);
       })
       .then(() => {
-        ensureAfterApply();
+        ensureAfterApply(options);
       });
   };
   let cacheApplied = false;
@@ -2606,7 +2637,7 @@ function loadPidList(){
         return Promise.resolve(true);
       }
       cacheApplied = true;
-      return useList(cached, 'cache').then(() => true);
+      return useList(cached, 'cache', { finalize: false }).then(() => true);
     }
     return Promise.resolve(false);
   };
@@ -2617,11 +2648,13 @@ function loadPidList(){
     .withSuccessHandler(list => {
       if (Array.isArray(list) && list.length){
         savePatientIdCache(list);
-        useList(list, 'network');
+        useList(list, 'network', { finalize: true });
       } else {
         applyCache().then(fromCache => {
           if (!fromCache){
-            useList([], 'network');
+            useList([], 'network', { finalize: true });
+          } else {
+            applyInitialPatientSelectionFromRequest_({ finalize: true });
           }
         });
       }
@@ -2630,9 +2663,10 @@ function loadPidList(){
       console.error('[loadPidList] failed', err);
       applyCache().then(fromCache => {
         if (fromCache){
+          applyInitialPatientSelectionFromRequest_({ finalize: true });
           toast('ID候補の取得に失敗したため、キャッシュから復元しました。');
         } else {
-          useList([], 'network').then(() => {
+          useList([], 'network', { finalize: true }).then(() => {
             toast('ID候補の取得に失敗しました。IDのみで続行します。');
           });
         }
@@ -2650,6 +2684,34 @@ function handlePatientIdKeydown(evt){
     evt.preventDefault();
     handlePatientIdConfirm();
   }
+}
+
+function applyInitialPatientSelectionFromRequest_(options){
+  const opts = Object.assign({ finalize: false }, options || {});
+  if (_initialPatientIdResolved) return false;
+  if (!_initialPatientIdRequested) return false;
+  const record = _patientIdIndex[_initialPatientIdRequested];
+  if (record){
+    setConfirmedPatientId(record.id);
+    setv('pid', formatPatientIdDisplay(record.id, record.name, record.kana));
+    _initialPatientIdResolved = true;
+    refresh();
+    return true;
+  }
+  if (!opts.finalize){
+    return false;
+  }
+  _initialPatientIdResolved = true;
+  const inputEl = q('pid');
+  if (inputEl){
+    const currentKey = normalizePatientIdKey(splitPatientIdDisplay(String(inputEl.value || '')).id);
+    if (currentKey === _initialPatientIdRequested){
+      setv('pid', '');
+    }
+  }
+  clearConfirmedPatientId();
+  hideGlobalLoading();
+  return true;
 }
 
 function handlePatientIdInput(){
@@ -4082,17 +4144,17 @@ function saveHandoverUI(){
 }
 /* 起動時 */
 (function init(){
+  _initialPatientIdRequested = resolveInitialPatientIdRequest();
+  if (_initialPatientIdRequested){
+    setv('pid', _initialPatientIdRequested);
+  }
   loadPidList();
   loadPresets();
   setupIcfSummaryUI();
   if (!IS_STANDALONE_DISPLAY_MODE){
     focusPatientIdInput();
   }
-  const p = "<?= patientId ?>";
-  if (p) {
-    setConfirmedPatientId(p);
-    refresh();
-  } else {
+  if (!_initialPatientIdRequested) {
     hideGlobalLoading();
   }
   q('consentModal')?.classList.remove('open');

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -20,6 +20,8 @@
   *{ box-sizing:border-box; }
   body{ margin:0; font-family:system-ui,-apple-system,"Segoe UI","Noto Sans JP",sans-serif; background:var(--bg); color:var(--text); }
   a{ color:var(--accent); }
+  .patient-link{ color:inherit; text-decoration:none; }
+  .patient-link:hover{ text-decoration:underline; }
   .page{ max-width:1080px; margin:0 auto; padding:20px 16px 64px; display:flex; flex-direction:column; gap:18px; }
   header{ display:flex; align-items:center; gap:12px; flex-wrap:wrap; }
   h1{ margin:0; font-size:1.4rem; letter-spacing:0.02em; }
@@ -353,7 +355,13 @@ function renderTasks() {
 
     card.appendChild(meta);
 
-    const name = document.createElement('div');
+    const name = document.createElement(task.patientId ? 'a' : 'div');
+    if (task.patientId) {
+      name.href = buildTreatmentAppLink_(task.patientId);
+      name.target = '_top';
+      name.rel = 'noreferrer';
+      name.className = 'patient-link';
+    }
     name.style.fontWeight = '700';
     name.textContent = task.name || '患者不明';
     card.appendChild(name);
@@ -394,8 +402,13 @@ function renderUnpaidAlerts() {
 
     const header = document.createElement('div');
     header.className = 'patient-header';
-    const name = document.createElement('div');
-    name.className = 'patient-name';
+    const name = document.createElement(alert.patientId ? 'a' : 'div');
+    name.className = alert.patientId ? 'patient-name patient-link' : 'patient-name';
+    if (alert.patientId) {
+      name.href = buildTreatmentAppLink_(alert.patientId);
+      name.target = '_top';
+      name.rel = 'noreferrer';
+    }
     name.textContent = alert.patientName || '氏名未登録';
     header.appendChild(name);
     const tags = document.createElement('div');
@@ -469,7 +482,13 @@ function renderVisits() {
 
       const body = document.createElement('div');
       body.className = 'visit-body';
-      const name = document.createElement('div');
+      const name = document.createElement(v.patientId ? 'a' : 'div');
+      if (v.patientId) {
+        name.href = buildTreatmentAppLink_(v.patientId);
+        name.target = '_top';
+        name.rel = 'noreferrer';
+        name.className = 'patient-link';
+      }
       name.textContent = v.patientName || v.patientId || '患者不明';
       name.style.fontWeight = '700';
       body.appendChild(name);
@@ -523,8 +542,13 @@ function renderPatients() {
     const summary = document.createElement('summary');
     const header = document.createElement('div');
     header.className = 'patient-header';
-    const name = document.createElement('div');
-    name.className = 'patient-name';
+    const name = document.createElement(p.patientId ? 'a' : 'div');
+    name.className = p.patientId ? 'patient-name patient-link' : 'patient-name';
+    if (p.patientId) {
+      name.href = buildTreatmentAppLink_(p.patientId);
+      name.target = '_top';
+      name.rel = 'noreferrer';
+    }
     name.textContent = p.name || '氏名未登録';
     header.appendChild(name);
 
@@ -675,7 +699,7 @@ function renderSummaryList_(items, emptyText) {
       main.className = 'summary-main';
       const link = document.createElement('a');
       link.className = 'summary-link';
-      link.href = buildRecordLink_(item.patientId);
+      link.href = buildTreatmentAppLink_(item.patientId);
       link.target = '_top';
       link.rel = 'noreferrer';
       link.textContent = item.name || item.patientId;
@@ -698,10 +722,11 @@ function renderSummaryList_(items, emptyText) {
   return list;
 }
 
-function buildRecordLink_(patientId) {
-  const base = typeof baseUrl !== 'undefined' ? baseUrl : '';
+function buildTreatmentAppLink_(patientId) {
+  const base = typeof baseUrl !== 'undefined' ? String(baseUrl) : '';
+  const normalizedBase = base.replace(/\/+$/, '');
   const id = encodeURIComponent(patientId || '');
-  return `${base}?view=record&id=${id}`;
+  return `${normalizedBase}/treatmentApp?patientId=${id}`;
 }
 
 function formatTaskLabel(type) {


### PR DESCRIPTION
### Motivation
- Provide a single click path from the practitioner dashboard to the treatment-record app and pre-select the target patient when possible. 
- Preserve existing spreadsheet/save logic and keep UI changes minimal while avoiding any error messages when the passed `patientId` is missing or not found.

### Description
- Dashboard (`src/dashboard.html`) now renders patient names as links that point to the treatment app using `/treatmentApp?patientId=XXXX`, with a small CSS rule for link styling and a new `buildTreatmentAppLink_` helper to generate the link URL.  
- Server routing (`src/Code.js`) was updated so requests to the `/treatmentApp` path serve the treatment app (`app.html`) and the server now accepts `patientId` (or legacy `id`) query parameters and passes them into the template.  
- Treatment app (`src/app.html`) reads the template `patientId` and URL query (`patientId`/`id`) via a new `resolveInitialPatientIdRequest()` flow, tracks `_initialPatientIdRequested`/_`initialPatientIdResolved`, and attempts to auto-select the patient only when the ID is present in the loaded patient master list; if not present the app leaves the normal initial state and shows no error.  
- 【共有用サマリー】
変更点: ダッシュボードの患者名クリックを施術録アプリへの遷移（`/treatmentApp?patientId=...`）に統一し、サーバー/テンプレートで `patientId` を受け渡して施術録アプリ側で患者マスタに存在する場合のみ自動選択するロジックを追加しました。
理由: ダッシュボードから施術録アプリへの明確な導線を作り、遷移後に対象患者が即時選択されることで操作を簡素化するためです。
影響範囲: ダッシュボード表示と施術録アプリの初期表示・ルーティング周りのみで、スプレッドシート構造や保存/登録ロジックは変更していません。

### Testing
- Performed a smoke render by serving `src/` with a local HTTP server and automating a page load with Playwright to capture a screenshot of `dashboard.html`, which completed successfully and produced an artifacts screenshot.  
- Verified the modified `doGet` routing logic compiles in the repository and committed the changes; no unit tests were present or executed as part of this change.  
- No automated failure observed during the lightweight smoke test; further integration testing on the Apps Script deployment is recommended before production rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69884280b4648321b68a6b4d39c1c641)