### PR TITLE
Fix treatment log patientId extraction and trimming for dashboard

### DIFF
--- a/src/dashboard/data/loadTreatmentLogs.js
+++ b/src/dashboard/data/loadTreatmentLogs.js
@@ -57,7 +57,9 @@ function loadTreatmentLogsUncached_(options) {
   const displayValues = sheet.getRange(2, 1, lastRow - 1, lastCol).getDisplayValues();
 
   const colTimestamp = dashboardResolveColumn_(headers, ['日時', '日付', 'timestamp', 'ts', 'タイムスタンプ'], 1);
-  const colPatientId = dashboardResolveColumn_(headers, ['患者ID', 'patientId', 'id'], 0);
+  const colPatientId = dashboardResolveColumn_(headers, [
+    '施術録番号', '施術録No', '施術録NO', '記録番号', 'カルテ番号', '患者ID', '患者番号', 'recNo', 'patientId', 'id'
+  ], 2);
   const colPatientName = dashboardResolveColumn_(headers, ['氏名', '名前', '患者名'], colPatientId ? 0 : 2);
   const colEmail = dashboardResolveColumn_(headers, ['作成者', '担当者', 'email', 'createdbyemail'], 0);
 
@@ -77,7 +79,11 @@ function loadTreatmentLogsUncached_(options) {
       continue;
     }
 
-    const patientIdRaw = colPatientId ? dashboardNormalizePatientId_(row[colPatientId - 1] || rowDisplay[colPatientId - 1]) : '';
+    const patientIdCell = colPatientId ? row[colPatientId - 1] : '';
+    const patientIdDisplay = colPatientId ? rowDisplay[colPatientId - 1] : '';
+    const patientIdRaw = colPatientId
+      ? (dashboardNormalizePatientId_(patientIdCell) || dashboardNormalizePatientId_(patientIdDisplay))
+      : '';
     const patientName = String((colPatientName && (rowDisplay[colPatientName - 1] || row[colPatientName - 1])) || '').trim();
     const mappedPatientId = patientIdRaw || dashboardResolvePatientIdFromName_(patientName, nameToId);
     const createdByEmail = colEmail ? String(rowDisplay[colEmail - 1] || row[colEmail - 1] || '').trim() : '';

--- a/src/dashboard/utils/sheetUtils.js
+++ b/src/dashboard/utils/sheetUtils.js
@@ -162,9 +162,13 @@ function dashboardCoerceDate_(value) {
   return Number.isNaN(parsed.getTime()) ? null : parsed;
 }
 
-function dashboardNormalizePatientId_(value) {
+function dashboardTrimText_(value) {
   const raw = value == null ? '' : value;
-  return String(raw).trim();
+  return String(raw).replace(/^[\s\u3000]+|[\s\u3000]+$/g, '');
+}
+
+function dashboardNormalizePatientId_(value) {
+  return dashboardTrimText_(value);
 }
 
 function dashboardNormalizeNameKey_(name) {


### PR DESCRIPTION
### Motivation
- Dashboard load of treatment logs returned zero entries because `patientId` values were treated as missing and rows were skipped. 
- The root cause was misaligned column resolution and insufficient normalization (did not trim full-width spaces or prefer raw cell values). 
- The change aims to reliably extract and normalize `patientId` from the treatment sheet without changing UI/aggregation/validation rules. 

### Description
- Added `dashboardTrimText_` and updated `dashboardNormalizePatientId_` to trim both half-width and full-width whitespace (`src/dashboard/utils/sheetUtils.js`).
- Aligned patient ID column resolution in `loadTreatmentLogsUncached_` to use the treatment sheet header labels and a sensible fallback index (`src/dashboard/data/loadTreatmentLogs.js`).
- Updated extraction to prefer normalized cell values and fallback to normalized display values when building `patientIdRaw`, while keeping the existing name-to-id mapping and patient existence checks intact (`src/dashboard/data/loadTreatmentLogs.js`).
- Left existing debug/logging behavior unchanged. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a8a2565f0832195a53456e9da4850)