### PR TITLE
Fix staffMatchedLogs always zero by improving staff key matching

### DIFF
--- a/src/dashboard/utils/sheetUtils.js
+++ b/src/dashboard/utils/sheetUtils.js
@@ -179,8 +179,36 @@ function dashboardNormalizeNameKey_(name) {
 
 function dashboardNormalizeEmail_(email) {
   const raw = email == null ? '' : email;
-  const normalized = String(raw).trim().toLowerCase();
+  const normalized = String(raw).normalize('NFKC').trim().toLowerCase();
   return normalized || '';
+}
+
+function dashboardNormalizeStaffKey_(value) {
+  const raw = dashboardTrimText_(value);
+  if (!raw) return '';
+
+  const email = dashboardExtractEmail_(raw);
+  if (email) {
+    const normalizedEmail = dashboardNormalizeEmail_(email)
+      .replace(/\+[^@]+(?=@)/, '');
+    if (normalizedEmail) return normalizedEmail;
+  }
+
+  return String(raw)
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[\s\u3000・･]/g, '')
+    .replace(/[ー－ｰ−]/g, '')
+    .replace(/[._]/g, '')
+    .replace(/[^0-9a-z\u3040-\u30ff\u3400-\u9FFF]/g, '')
+    .replace(/-/g, '');
+}
+
+function dashboardExtractEmail_(value) {
+  const text = dashboardTrimText_(value);
+  if (!text) return '';
+  const matched = text.match(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i);
+  return matched ? matched[0] : '';
 }
 
 function dashboardResolvePatientIdFromName_(name, nameToId) {


### PR DESCRIPTION
### Motivation
- staffMatchedLogs was always 0 because dashboard matching relied only on a single email field while spreadsheets store staff info in different columns (name, email, staffId) with varied formats.  
- Need to reliably detect which column contains the practitioner and normalize values (trim, NFKC, case, symbol variants and email alias + removal).  
- Admin/管理者 IDs must also match so that logs performed by administrative IDs are counted in staffMatchedLogs.

### Description
- Add robust staff normalization helpers in `src/dashboard/utils/sheetUtils.js`: `dashboardNormalizeStaffKey_` and `dashboardExtractEmail_` (NFKC, trim, lowercasing, alias removal, symbol collapse).  
- Extend `loadTreatmentLogs` (`src/dashboard/data/loadTreatmentLogs.js`) to explicitly resolve multiple staff-related columns (`作成者 / 施術者 / メール / 担当者ID`), emit a header snapshot (`loadTreatmentLogs:staffColumns`) and sample values for the first 20 rows (`loadTreatmentLogs:staffValueSample`), and attach `staffKeys: { email, name, staffId }` to each log entry.  
- Change `getDashboardData` (`src/dashboard/api/getDashboardData.js`) to match staff using three explicit strategies in order: `email → name → staffId`, produce per-strategy stats/samples, and always emit logs `getDashboardData:staffMatchStrategy`, `getDashboardData:staffMatchedLogs`, and `getDashboardData:matchedPatientIds`.  
- Add/modify unit tests in `tests/dashboardGetDashboardData.test.js` to verify email (+alias) matching, staffId matching (管理者ID), and presence of the new log outputs.  

【共有用サマリー】
変更点:
- 施術録のスタッフ列抽出を拡張し、`staffKeys(email/name/staffId)` を生成するよう変更しました。  
- スタッフ一致判定を `email/name/staffId` の3系統で明示的に判定するよう変更しました。  
- 一致戦略と件数・患者IDの詳細ログ（`staffMatchStrategy` / `staffMatchedLogs` / `matchedPatientIds`）を追加しました。  
理由:
- 施術録にメール以外（氏名・担当者ID）が保存されるケースで既存ロジックが一致判定できず、`staffMatchedLogs=0` になっていたため。  
影響範囲:
- 施術者ダッシュボードのデータ集計（施術ログの担当者一致判定とログ出力）に影響しますが、UI仕様や患者IDスコープロジックは変更していません。  

### Testing
- Ran `node tests/dashboardGetDashboardData.test.js` which includes the new staff-matching test and existing aggregation assertions, and it passed.  
- Updated unit test `tests/dashboardGetDashboardData.test.js` to cover email(+alias) and staffId matching and to assert that `staffMatchStrategy` / `staffMatchedLogs` / `matchedPatientIds` logs are emitted; these assertions passed in the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a91459c34832189ea52df437a9033)