### PR TITLE
Fix dashboard patient navigation to always use treatment exec URL

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -22,6 +22,7 @@
   a{ color:var(--accent); }
   .patient-link{ color:inherit; text-decoration:none; }
   .patient-link:hover{ text-decoration:underline; }
+  .disabled{ opacity:0.55; cursor:not-allowed; pointer-events:none; }
   .page{ max-width:1080px; margin:0 auto; padding:20px 16px 64px; display:flex; flex-direction:column; gap:18px; }
   header{ display:flex; align-items:center; gap:12px; flex-wrap:wrap; }
   h1{ margin:0; font-size:1.4rem; letter-spacing:0.02em; }
@@ -240,6 +241,11 @@ function renderError() {
     box.style.display = 'block';
     return;
   }
+  if (!resolveTreatmentAppExecUrl_()) {
+    box.textContent = '施術録WebアプリURLが未設定のため、患者画面への遷移を無効化しています。';
+    box.style.display = 'block';
+    return;
+  }
   box.style.display = 'none';
   box.textContent = '';
 }
@@ -346,9 +352,7 @@ function renderUnpaidAlerts() {
     const name = document.createElement(alert.patientId ? 'a' : 'div');
     name.className = alert.patientId ? 'patient-name patient-link' : 'patient-name';
     if (alert.patientId) {
-      name.href = buildTreatmentAppLink_(alert.patientId);
-      name.target = '_top';
-      name.rel = 'noreferrer';
+      configurePatientLinkElement_(name, alert.patientId);
     }
     name.textContent = alert.patientName || '氏名未登録';
     header.appendChild(name);
@@ -412,9 +416,7 @@ function renderVisits() {
     body.className = 'visit-body';
     const name = document.createElement(v.patientId ? 'a' : 'div');
     if (v.patientId) {
-      name.href = buildTreatmentAppLink_(v.patientId);
-      name.target = '_top';
-      name.rel = 'noreferrer';
+      configurePatientLinkElement_(name, v.patientId);
       name.className = 'patient-link';
     }
     name.textContent = v.patientName || v.patientId || '患者不明';
@@ -503,7 +505,7 @@ function renderPatients() {
     if (p.invoiceUrl) meta.appendChild(makeBadge('請求書リンクあり'));
     summary.appendChild(meta);
 
-    if (p.patientId) {
+    if (p.patientId && buildTreatmentAppLink_(p.patientId)) {
       summary.setAttribute('role', 'link');
       summary.setAttribute('tabindex', '0');
       summary.addEventListener('click', (event) => {
@@ -541,7 +543,7 @@ function renderPatients() {
       link.href = p.invoiceUrl;
       link.textContent = '請求書PDFを開く';
       link.target = '_blank';
-      link.rel = 'noreferrer';
+      link.rel = 'noopener noreferrer';
       body.appendChild(link);
     }
 
@@ -655,6 +657,11 @@ function renderOverviewList_(items, emptyText) {
 
 function bindPatientRow_(row, patientId) {
   if (!row || !patientId) return;
+  if (!buildTreatmentAppLink_(patientId)) {
+    row.classList.add('disabled');
+    row.setAttribute('aria-disabled', 'true');
+    return;
+  }
   row.setAttribute('role', 'link');
   row.setAttribute('tabindex', '0');
   row.dataset.patientId = patientId;
@@ -686,17 +693,40 @@ function bindPatientRow_(row, patientId) {
 function navigateToPatient_(patientId) {
   if (!patientId) return;
   const link = buildTreatmentAppLink_(patientId);
-  if (typeof window !== 'undefined' && window.top) {
-    window.top.location.href = link;
+  if (!link) {
+    showNavigationError_('施術録WebアプリURLが未設定のため、患者画面を開けません。');
     return;
   }
-  window.location.href = link;
+  if (typeof window !== 'undefined' && typeof window.open === 'function') {
+    window.open(link, '_blank', 'noopener,noreferrer');
+  }
+}
+
+function configurePatientLinkElement_(anchor, patientId) {
+  if (!anchor || !patientId) return;
+  const link = buildTreatmentAppLink_(patientId);
+  if (!link) {
+    anchor.removeAttribute('href');
+    anchor.removeAttribute('target');
+    anchor.removeAttribute('rel');
+    anchor.classList.add('disabled');
+    anchor.setAttribute('aria-disabled', 'true');
+    anchor.addEventListener('click', (event) => {
+      event.preventDefault();
+      showNavigationError_('施術録WebアプリURLが未設定のため、患者画面を開けません。');
+    });
+    return;
+  }
+  anchor.href = link;
+  anchor.target = '_blank';
+  anchor.rel = 'noopener noreferrer';
 }
 
 function buildTreatmentAppLink_(patientId) {
   const rawExecUrl = resolveTreatmentAppExecUrl_();
-  if (rawExecUrl === '#') return '#';
+  if (!rawExecUrl) return '';
   const id = encodeURIComponent(patientId || '');
+  if (!id) return '';
   const joiner = rawExecUrl.indexOf('?') >= 0 ? '&' : '?';
   return `${rawExecUrl}${joiner}view=record&id=${id}`;
 }
@@ -705,15 +735,28 @@ function resolveTreatmentAppExecUrl_() {
   const configured = typeof DASHBOARD_TREATMENT_APP_EXEC_URL !== 'undefined'
     ? String(DASHBOARD_TREATMENT_APP_EXEC_URL || '').trim()
     : '';
-  if (configured) return configured;
 
   const injected = typeof treatmentAppExecUrl !== 'undefined'
     ? String(treatmentAppExecUrl || '').trim()
     : '';
-  if (injected) return injected;
+  const resolved = configured || injected;
+  if (resolved && isValidTreatmentExecUrl_(resolved)) return resolved;
 
-  console.error('施術録WebアプリURLが未設定です');
-  return '#';
+  return '';
+}
+
+function isValidTreatmentExecUrl_(url) {
+  if (!url) return false;
+  const normalized = String(url || '').trim().toLowerCase();
+  if (!normalized) return false;
+  if (normalized.indexOf('googleusercontent.com/usercodeapppanel') >= 0) return false;
+  return normalized.indexOf('script.google.com/') >= 0 && normalized.indexOf('/exec') >= 0;
+}
+
+function showNavigationError_(message) {
+  if (!message) return;
+  dashboardState.error = message;
+  renderError();
 }
 function formatTaskLabel(type) {
   switch(type) {
@@ -768,15 +811,15 @@ function resolveDashboardMockParam_() {
 
 /*
 共有用サマリー
-- 変更点
-  - `DASHBOARD_SUPPRESS_HANDOVER_REMINDER_UI` を追加し、「報告書作成ヒント未入力」のUI表示を一時抑止。
-  - タイムラインの報告書作成ヒントバッジで、未入力時のみ描画をスキップする条件分岐を追加。
-  - `formatTaskLabel('handoverDelayed')` で未入力ラベルを空文字にし、アラート表示文言を無効化（データは保持）。
-- 理由
-  - 現時点では「報告書作成ヒント未入力」警告がノイズとなるため、将来再有効化可能な形でUIのみ一時的に非表示化するため。
-- 影響範囲
-  - ダッシュボードのタイムラインバッジ表示。
-  - ダッシュボードのタスクラベル表示（handoverDelayed）。
+- 変更点:
+  - 患者遷移URLの組み立てを `buildTreatmentAppLink_` / `navigateToPatient_` / `configurePatientLinkElement_` に集約し、常に `.../exec?view=record&id=...` 形式で新規タブ遷移するよう統一。
+  - `resolveTreatmentAppExecUrl_` がURL未設定・不正（googleusercontent系）時に空文字を返すよう修正し、`#` フォールバックを廃止。
+  - exec URLが解決できない場合は `#errorBox` にエラーを表示し、患者リンク/行の操作を無効化する防御処理を追加。
+- 理由:
+  - ダッシュボードから患者クリック時に userCodeAppPanel へ飛んで空白になる問題を防ぎ、必ず公開Webアプリexec URLに遷移させるため。
+- 影響範囲:
+  - 未回収アラート、訪問タイムライン、概要カード、担当患者一覧の患者遷移動線。
+  - 施術録URL解決とナビゲーション時のエラー表示。
 */
 </script>
 </body>

--- a/tests/dashboardExecUrlResolution.test.js
+++ b/tests/dashboardExecUrlResolution.test.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const dashboardMainCode = fs.readFileSync(
+  path.join(__dirname, '..', 'src', 'dashboard', 'main.gs'),
+  'utf8'
+);
+
+function createContext(options = {}) {
+  const props = options.properties || {};
+  const context = {
+    console,
+    DASHBOARD_TREATMENT_APP_EXEC_URL: options.constant || '',
+    ScriptApp: {
+      getService: () => ({
+        getUrl: () => options.serviceUrl || ''
+      })
+    },
+    PropertiesService: {
+      getScriptProperties: () => ({
+        getProperty: key => props[key] || ''
+      })
+    }
+  };
+  vm.createContext(context);
+  vm.runInContext(dashboardMainCode, context);
+  return context;
+}
+
+(function testConstantExecUrlWins() {
+  const context = createContext({
+    constant: 'https://script.google.com/a/macros/belltree1102.com/s/CONST/exec',
+    properties: { DASHBOARD_TREATMENT_APP_EXEC_URL: 'https://script.google.com/a/macros/belltree1102.com/s/PROP/exec' },
+    serviceUrl: 'https://script.google.com/a/macros/belltree1102.com/s/SVC/exec'
+  });
+  assert.strictEqual(
+    context.resolveDashboardTreatmentAppExecUrl_(),
+    'https://script.google.com/a/macros/belltree1102.com/s/CONST/exec'
+  );
+})();
+
+(function testScriptPropertyUsedWhenConstantMissing() {
+  const context = createContext({
+    constant: '',
+    properties: { DASHBOARD_TREATMENT_APP_EXEC_URL: 'https://script.google.com/a/macros/belltree1102.com/s/PROP/exec' },
+    serviceUrl: 'https://script.google.com/a/macros/belltree1102.com/s/SVC/exec'
+  });
+  assert.strictEqual(
+    context.resolveDashboardTreatmentAppExecUrl_(),
+    'https://script.google.com/a/macros/belltree1102.com/s/PROP/exec'
+  );
+})();
+
+(function testGoogleusercontentRejectedAndFallsBackToServiceUrl() {
+  const context = createContext({
+    constant: 'https://script.googleusercontent.com/userCodeAppPanel?createOAuthDialog=true#',
+    serviceUrl: 'https://script.google.com/a/macros/belltree1102.com/s/SVC/exec'
+  });
+  assert.strictEqual(
+    context.resolveDashboardTreatmentAppExecUrl_(),
+    'https://script.google.com/a/macros/belltree1102.com/s/SVC/exec'
+  );
+})();
+
+console.log('dashboard exec URL resolution tests passed');
+
+// 共有用サマリー
+// - 変更点: サーバー側のダッシュボードexec URL解決（定数優先・Script Properties・service URLフォールバック）を検証するテストを追加。
+// - 理由: userCodeAppPanel系URLの混入を防ぎ、公開exec URLが確実に注入されることを担保するため。
+// - 影響範囲: tests 配下のNode実行テストのみ。

--- a/tests/dashboardNavigationLinks.test.js
+++ b/tests/dashboardNavigationLinks.test.js
@@ -1,0 +1,91 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const dashboardHtml = fs.readFileSync(
+  path.join(__dirname, '..', 'src', 'dashboard.html'),
+  'utf8'
+);
+
+const scriptMatch = dashboardHtml.match(/<script>([\s\S]*?)<\/script>/);
+assert(scriptMatch, 'dashboard script block exists');
+
+const dashboardScript = scriptMatch[1]
+  .replace(/const DASHBOARD_TREATMENT_APP_EXEC_URL =[^\n]*\n/, 'var DASHBOARD_TREATMENT_APP_EXEC_URL = "";\n');
+
+function createContext() {
+  const openCalls = [];
+  const context = {
+    console,
+    URLSearchParams,
+    treatmentAppExecUrl: '',
+    window: {
+      location: { search: '' },
+      open: (...args) => openCalls.push(args)
+    },
+    document: {
+      addEventListener: () => {},
+      getElementById: () => null,
+      createElement: () => ({
+        appendChild: () => {},
+        setAttribute: () => {},
+        addEventListener: () => {},
+        classList: { add: () => {} },
+        style: {}
+      })
+    }
+  };
+  vm.createContext(context);
+  vm.runInContext(dashboardScript, context);
+  context.__openCalls = openCalls;
+  return context;
+}
+
+(function testBuildTreatmentAppLinkFromExecUrl() {
+  const context = createContext();
+  context.DASHBOARD_TREATMENT_APP_EXEC_URL = 'https://script.google.com/a/macros/belltree1102.com/s/DEPLOY123/exec';
+
+  const link = context.buildTreatmentAppLink_('P-001');
+  assert.strictEqual(
+    link,
+    'https://script.google.com/a/macros/belltree1102.com/s/DEPLOY123/exec?view=record&id=P-001',
+    'buildTreatmentAppLink_ returns exec URL with view and patient id'
+  );
+})();
+
+
+(function testInvalidGoogleusercontentExecUrlIsRejected() {
+  const context = createContext();
+  context.DASHBOARD_TREATMENT_APP_EXEC_URL = 'https://script.googleusercontent.com/userCodeAppPanel?createOAuthDialog=true#';
+
+  assert.strictEqual(
+    context.resolveTreatmentAppExecUrl_(),
+    '',
+    'googleusercontent userCodeAppPanel URL is treated as invalid'
+  );
+})();
+
+(function testMissingExecUrlStopsNavigationAndSetsError() {
+  const context = createContext();
+  context.DASHBOARD_TREATMENT_APP_EXEC_URL = '';
+  context.treatmentAppExecUrl = '';
+
+  assert.strictEqual(context.resolveTreatmentAppExecUrl_(), '', 'resolve returns empty string when missing');
+  assert.strictEqual(context.buildTreatmentAppLink_('P-002'), '', 'link build returns empty when missing');
+
+  context.navigateToPatient_('P-002');
+  assert.strictEqual(context.__openCalls.length, 0, 'navigate does not open a new tab when URL is missing');
+  assert.strictEqual(
+    vm.runInContext('dashboardState.error', context),
+    '施術録WebアプリURLが未設定のため、患者画面を開けません。',
+    'navigate sets a clear UI error message when URL is missing'
+  );
+})();
+
+console.log('dashboard navigation link tests passed');
+
+// 共有用サマリー
+// - 変更点: ダッシュボードの患者遷移ヘルパー（URL解決・リンク構築・遷移）の期待動作を検証する単体テストを追加。
+// - 理由: exec URL未設定時に誤遷移せず、設定時は正しい新規タブ遷移URLを生成することを担保するため。
+// - 影響範囲: tests 配下のNode実行テストのみ。


### PR DESCRIPTION
### Motivation
- Clicking patient items sometimes navigated to `googleusercontent.com/userCodeAppPanel` and showed a blank page, so navigation must always target the published Web App exec URL and open in a new tab. 
- Navigation should be centralized to avoid inconsistent behavior across overview rows, timeline, unpaid alerts and patient list. 
- When the exec URL is missing or invalid, navigation must be safely disabled and a clear dashboard error shown instead of falling back to `userCodeAppPanel` or throwing.

### Description
- Centralized navigation helpers: added/updated `buildTreatmentAppLink_`, `configurePatientLinkElement_`, and `navigateToPatient_` in `src/dashboard.html` so all patient entry points construct `.../exec?view=record&id=<id>` links and open them with `target="_blank"` / `rel="noopener noreferrer"` or `window.open(..., '_blank', 'noopener,noreferrer')` for JS navigation. 
- Safe handling for missing/invalid exec URL: `resolveTreatmentAppExecUrl_` now returns `''` when unresolved, `isValidTreatmentExecUrl_` rejects `userCodeAppPanel`/googleusercontent URLs, UI elements are disabled when no valid exec URL is available, and `showNavigationError_` writes a clear message into `#errorBox`. 
- Server-side injection improvement: updated `src/dashboard/main.gs` to resolve the exec URL in order: constant `DASHBOARD_TREATMENT_APP_EXEC_URL` (normalized), Script Properties `DASHBOARD_TREATMENT_APP_EXEC_URL`, then `ScriptApp.getService().getUrl()` (normalized), rejecting invalid `googleusercontent` addresses. 
- Tests and comments: added `tests/dashboardNavigationLinks.test.js` and `tests/dashboardExecUrlResolution.test.js` covering client navigation helpers and server-side exec URL resolution/fallbacks, and appended/updated `共有用サマリー` comment blocks at the end of changed files to summarize changes.

### Testing
- Ran `node tests/dashboardNavigationLinks.test.js` and `node tests/dashboardExecUrlResolution.test.js`, and both tests passed. 
- Ran `node tests/dashboardDoGet.test.js`, which failed with an existing unrelated assertion (`doGet is defined`); this is a pre-existing test failure outside the scope of these navigation changes. 
- Combined run `node tests/dashboardNavigationLinks.test.js && node tests/dashboardExecUrlResolution.test.js` also succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aa9e347008321a533081af094db83)