### PR TITLE
施術者ダッシュボードの請求未対応判定を証跡ベースに変更

### DIFF
--- a/src/dashboard/data/loadTreatmentLogs.js
+++ b/src/dashboard/data/loadTreatmentLogs.js
@@ -65,6 +65,10 @@ function loadTreatmentLogsUncached_(options) {
   const colStaffName = dashboardResolveColumn_(headers, ['施術者', '担当者', '担当', 'スタッフ名', 'staffName', 'staff'], 0);
   const colStaffEmail = dashboardResolveColumn_(headers, ['メール', '担当メール', 'email', 'mail', 'createdbyemail'], 0);
   const colStaffId = dashboardResolveColumn_(headers, ['担当者ID', 'スタッフID', 'staffId', 'staffid'], 0);
+  const searchableColumns = [
+    dashboardResolveColumn_(headers, ['施術内容', '内容', '記録', 'メモ', 'ノート', '備考', 'コメント', '対応内容', '申し送り', '自由記述', 'text', 'note', 'memo', 'comment', 'body', 'content'], 0),
+    dashboardResolveColumn_(headers, ['SOAP', 'S', 'O', 'A', 'P'], 0)
+  ].filter(function(col, index, arr) { return !!col && arr.indexOf(col) === index; });
 
   const tz = dashboardResolveTimeZone_();
   const now = dashboardCoerceDate_(opts.now) || new Date();
@@ -102,6 +106,12 @@ function loadTreatmentLogsUncached_(options) {
     const staffEmailRaw = colStaffEmail ? String(rowDisplay[colStaffEmail - 1] || row[colStaffEmail - 1] || '').trim() : '';
     const staffIdRaw = colStaffId ? String(rowDisplay[colStaffId - 1] || row[colStaffId - 1] || '').trim() : '';
     const dateKey = dashboardFormatDate_(timestamp, tz, 'yyyy-MM-dd');
+    const searchText = searchableColumns
+      .map(function(col) {
+        return String(rowDisplay[col - 1] || row[col - 1] || '').trim();
+      })
+      .filter(function(text) { return !!text; })
+      .join('\n');
 
     if (i < 20) {
       logContext('loadTreatmentLogs:staffValueSample', JSON.stringify({
@@ -136,7 +146,8 @@ function loadTreatmentLogsUncached_(options) {
         staffId: dashboardNormalizeStaffKey_(staffIdRaw)
       },
       timestamp,
-      dateKey
+      dateKey,
+      searchText
     };
 
     logs.push(entry);


### PR DESCRIPTION
### Motivation

- 施術者ダッシュボードの「①請求」カード判定を、未検出＝対応済みの消極的ロジックから、完了証跡がある場合のみ対応済みとする積極的判定へ変更するための対応です。 
- 対象は「前月（YYYY-MM）に施術が1回以上あった患者」に限定し、当月1日〜20日（JST）に定型文の存在で完了判定を行う仕様を満たします。

### Description

- `buildOverviewFromInvoiceUnconfirmed_` を再設計し、`treatmentLogs` と `notes` を受け取って「前月施術の有無」を集計し、当月1日〜20日の証跡（部分一致で `請求書・領収書を受け渡し済み` を検索）で完了判定するロジックに置き換えました。 
- 月判定・期間判定・検索用テキスト生成のヘルパーとして `resolveDashboardMonthKey_`、`isDashboardInvoiceConfirmationInWindow_`、`buildDashboardInvoiceSearchText_` を追加しました。 
- `loadTreatmentLogs` を拡張して施術内容／メモ／備考／SOAP などの列から `searchText` を抽出してログに保持するようにし、証跡検索に利用可能にしました。 
- 新しい振る舞いを検証するテスト `testInvoiceUnconfirmedUsesPositiveConfirmationEvidence` を `tests/dashboardGetDashboardData.test.js` に追加しました。 

### Testing

- 実装後に `node tests/dashboardGetDashboardData.test.js` を実行し、追加したテストを含む全テストが正常終了しました。 
- 構文チェックとして `node --check src/dashboard/data/loadTreatmentLogs.js && node --check src/dashboard/api/getDashboardData.js` を実行し問題ありませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aabd7fe3483219aa487b4e5060a17)