### PR TITLE
Fix record view deep-linking to auto-load patient by URL id

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -615,6 +615,18 @@ function waitMs(ms){
 }
 
 function resolveInitialPatientIdRequest(){
+  let shouldAutoLoad = false;
+  if (typeof window !== 'undefined' && window.location){
+    try {
+      const params = new URLSearchParams(window.location.search || '');
+      const view = String(params.get('view') || '').trim().toLowerCase();
+      shouldAutoLoad = view === 'record';
+    } catch (err){
+      console.warn('[resolveInitialPatientIdRequest] failed to inspect view param', err);
+    }
+  }
+  if (!shouldAutoLoad) return '';
+
   let candidate = '';
   try {
     const templatePid = "<?= patientId ?>";
@@ -2714,6 +2726,15 @@ function applyInitialPatientSelectionFromRequest_(options){
   if (inputEl){
     const currentKey = normalizePatientIdKey(splitPatientIdDisplay(String(inputEl.value || '')).id);
     if (currentKey === _initialPatientIdRequested){
+      const resolved = ensurePatientIdDisplayFromInput({
+        allowPlainOnMiss: true,
+        clearOnReject: false,
+        skipIfEditing: false
+      });
+      if (resolved){
+        refresh();
+        return true;
+      }
       setv('pid', '');
     }
   }


### PR DESCRIPTION
### Motivation
- Opening the record screen with `?view=record&id=XXXX` did not auto-populate the patient ID input and therefore did not trigger patient info load, causing deep-links to the record view to appear broken.

### Description
- Updated `src/app.html` so `resolveInitialPatientIdRequest()` only returns an initial ID when the URL `view` parameter is `record`, preventing unintended auto-loads on other views.
- Added a finalize-stage fallback in `applyInitialPatientSelectionFromRequest_()` that calls `ensurePatientIdDisplayFromInput({...})` and invokes `refresh()` when that succeeds so the patient info is loaded even if the ID was not present in the preloaded candidate list, while preserving manual input UX.

### Testing
- Ran `git diff --check` to validate whitespace/formatting issues and it completed successfully.
- Ran `node --test tests/dashboardDoGet.test.js`, which failed due to the local test harness expecting `doGet` to be defined (an unrelated environment/test constraint), not because of the `app.html` changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aafcd7ab88321be78bdba0ba88ac1)