### PR TITLE
Fix record-view URL init to always trigger a single refresh

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -527,6 +527,7 @@ let _initialPatientIdRequested = '';
 let _initialPatientIdResolved = false;
 let _initialPatientIdResolveFailureNotified = false;
 let _initialPatientIdRecordView = false;
+let _initialRecordViewRefreshCompleted = false;
 let _patientIdSelectionLocked = false;
 let _patientIdInputEditing = false;
 let _patientInfoLoadInFlight = false;
@@ -2659,6 +2660,9 @@ function loadPidList(){
       if (!result && _patientIdList.length){
         clearPatientDisplay({ keepInput: false, force: true });
       }
+      if (opts.finalize){
+        runInitialRecordViewRefreshOnce_('finalize fallback after initial patient selection from request');
+      }
       schedulePatientIdSearchUpdate(true);
     } catch (err){
       console.error('[loadPidList] ensurePatientIdDisplayFromInput failed', err);
@@ -2743,6 +2747,18 @@ function notifyInitialPatientIdResolveFailure_(reason){
   toast(`指定された患者ID（${_initialPatientIdRequested}）を初期表示で確定できませんでした。${detail}`);
 }
 
+function runInitialRecordViewRefreshOnce_(reason){
+  if (!_initialPatientIdRecordView || !_initialPatientIdRequested) return false;
+  if (_initialRecordViewRefreshCompleted) return false;
+  _initialRecordViewRefreshCompleted = true;
+  console.info('[initialRecordViewRefresh] refresh', {
+    reason: reason || 'fallback',
+    patientId: _initialPatientIdRequested
+  });
+  refresh();
+  return true;
+}
+
 function applyInitialPatientSelectionFromRequest_(options){
   const opts = Object.assign({ finalize: false }, options || {});
   if (_initialPatientIdResolved){
@@ -2769,7 +2785,7 @@ function applyInitialPatientSelectionFromRequest_(options){
       finalize: opts.finalize,
       patientId: record.id
     });
-    refresh();
+    runInitialRecordViewRefreshOnce_('matched candidate list record');
     return true;
   }
   if (!opts.finalize){
@@ -2797,7 +2813,7 @@ function applyInitialPatientSelectionFromRequest_(options){
             finalize: opts.finalize,
             patientId: _initialPatientIdRequested
           });
-          refresh();
+          runInitialRecordViewRefreshOnce_('record view URL fallback resolved by input value on finalize');
           return true;
         }
         if (resolved && resolved.skipped){
@@ -2820,6 +2836,7 @@ function applyInitialPatientSelectionFromRequest_(options){
     patientId: _initialPatientIdRequested
   });
   notifyInitialPatientIdResolveFailure_(failureReason);
+  runInitialRecordViewRefreshOnce_('finalize fallback after unresolved URL patientId');
   return true;
 }
 


### PR DESCRIPTION
### Motivation
- 直リンク `view=record&id=XXX` で起動した場合に必ず患者情報が表示されるよう、初期化フローの最終責任点で `refresh()` を必ず一度だけ実行する必要があった。
- 現状は `applyInitialPatientSelectionFromRequest_()` の条件分岐で `refresh()` の呼び出し可否が分かれており、URL起点で `refresh()` が呼ばれないケースがあり手入力ルートと挙動が非対称になっている。

### Description
- `src/app.html` にブールガード ` _initialRecordViewRefreshCompleted ` を追加して URL 起点の `refresh()` が二重実行されないように制御した。  
- `runInitialRecordViewRefreshOnce_()` ヘルパーを追加し、`refresh()` の実行を一元化して最大1回に制限するようにした。  
- `applyInitialPatientSelectionFromRequest_()` 内の既存の直接 `refresh()` 呼び出しを `runInitialRecordViewRefreshOnce_()` に置き換え、候補一致時と入力フォールバック成功時に記録ビュー起点のリフレッシュを行うようにした。  
- 初期化の finalize フェーズ（`loadPidList()` → `ensureAfterApply()` 経路）および未解決時の最終責任点でフォールバックとして `runInitialRecordViewRefreshOnce_()` を呼ぶようにし、URL起点の場合に最終的に必ず1回 `refresh()` が走るようにした。  
- 変更ファイル: `src/app.html`。

### Testing
- 実行した自動テスト: `node --test tests/dashboardNavigationLinks.test.js` が成功（パス）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ab91667cc832196f172b8f0cf8c8e)