### PR TITLE
view=record の直リンクで初期化後に自動 refresh を1回実行

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -527,6 +527,7 @@ let _initialPatientIdRequested = '';
 let _initialPatientIdResolved = false;
 let _initialPatientIdResolveFailureNotified = false;
 let _initialPatientIdRecordView = false;
+let _initialRecordViewAutoRefreshDone = false;
 let _initialRecordViewRefreshCompleted = false;
 let _patientIdSelectionLocked = false;
 let _patientIdInputEditing = false;
@@ -2759,6 +2760,20 @@ function runInitialRecordViewRefreshOnce_(reason){
   return true;
 }
 
+function maybeAutoRefreshFromUrl_(){
+  const isDirectRecordLink =
+    _initialPatientIdRecordView === true &&
+    typeof _initialPatientIdRequested === 'string' &&
+    _initialPatientIdRequested.length > 0;
+  if (_initialRecordViewAutoRefreshDone) return;
+  if (!isDirectRecordLink) return;
+
+  _initialRecordViewAutoRefreshDone = true;
+  _initialRecordViewRefreshCompleted = true;
+  console.info('[record-view] auto refresh from URL', _initialPatientIdRequested);
+  refresh();
+}
+
 function applyInitialPatientSelectionFromRequest_(options){
   const opts = Object.assign({ finalize: false }, options || {});
   if (_initialPatientIdResolved){
@@ -4360,6 +4375,7 @@ function saveHandoverUI(){
     hideGlobalLoading();
   }
   q('consentModal')?.classList.remove('open');
+  maybeAutoRefreshFromUrl_();
 })();
 
 google.script.run.withSuccessHandler(r=>console.log('[ping]', r))


### PR DESCRIPTION
### Motivation
- `view=record&id=XXX` で直接アクセスした際に、手入力UXを介さず初期化完了後に患者情報を自動表示するために `refresh()` を1回だけ呼ぶ必要がありました。 
- 通常導線や手入力時の既存挙動（2文字で候補表示や `applyInitialPatientSelectionFromRequest_()` のロジック）はそのまま維持する必要がありました。

### Description
- 1変数 `_initialRecordViewAutoRefreshDone` を追加してURL起点の自動refreshの多重実行を防止しました。 
- `maybeAutoRefreshFromUrl_()` を実装し、`_initialPatientIdRecordView === true` かつ `_initialPatientIdRequested` が空でない文字列のときのみ `refresh()` を1回実行し、その際 ` _initialRecordViewRefreshCompleted = true` を立てて既存の初期refresh経路と重複しないようにしました。 
- `init()` の末尾で `maybeAutoRefreshFromUrl_()` を呼び出すようにして初期化完了後にのみ自動refreshが走るようにしました（変更ファイル: `src/app.html`）。

### Testing
- 検索で該当箇所を確認するために `rg` を実行して関係するシンボルを確認しました（成功）。
- 変更差分の整合性は `git diff --check` と `git status --short` で確認し問題なしとしてコミットしました（成功）。
- 変更後のファイル内容は `nl`/`sed` で行番号含め確認して期待通りに `maybeAutoRefreshFromUrl_()` が `init()` の末尾で呼ばれることを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698abca287b083219aecd488d62c07ce)