### PR TITLE
Add phased trace logs for patientId during record deep-link investigation

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -9531,6 +9531,7 @@ function doGet(e) {
   } else {
     t.patientId = "";
   }
+  console.log('[init] t.patientId =', t.patientId, 'caller=doGet');
   t.payrollPdfData = {};
 
   if(e.parameter && e.parameter.lead) t.lead = e.parameter.lead;

--- a/src/app.html
+++ b/src/app.html
@@ -324,7 +324,30 @@
 <script>
 function q(id){ return document.getElementById(id); }
 function val(id){ return q(id).value.trim(); }
-function setv(id,v){ q(id).value=v; }
+function detectCallerFunctionName_(){
+  try {
+    const stack = new Error().stack || '';
+    const lines = stack.split('\n').map(line => line.trim()).filter(Boolean);
+    for (let i = 0; i < lines.length; i++){
+      const line = lines[i];
+      if (line.includes('detectCallerFunctionName_') || line.includes('tracePatientIdState_') || line.includes('setv ')) continue;
+      const m = line.match(/at\s+([^\s(]+)/);
+      if (m && m[1]) return m[1];
+    }
+  } catch (err){
+    console.warn('[trace] detect caller failed', err);
+  }
+  return 'unknown';
+}
+function tracePatientIdState_(phase, label, value, caller){
+  console.log(`[${phase}] ${label} =`, value, 'caller=' + (caller || detectCallerFunctionName_()));
+}
+function setv(id,v){
+  q(id).value=v;
+  if (id === 'pid'){
+    tracePatientIdState_('inputUpdate', 'input.value(patientId)', q(id).value, detectCallerFunctionName_());
+  }
+}
 function jsString(s){ return JSON.stringify(String(s == null ? '' : s)); }
 
 function setGlobalLoadingText(message){
@@ -630,6 +653,7 @@ function resolveInitialPatientIdRequest(){
     }
   }
   _initialPatientIdRecordView = shouldAutoLoad;
+  tracePatientIdState_('init', '_initialPatientIdRecordView', _initialPatientIdRecordView, 'resolveInitialPatientIdRequest');
   if (!shouldAutoLoad) return '';
 
   let candidate = '';
@@ -648,6 +672,7 @@ function resolveInitialPatientIdRequest(){
     }
   }
   const normalized = normalizePatientIdKey(candidate);
+  tracePatientIdState_('init', 'currentKey', normalized, 'resolveInitialPatientIdRequest');
   console.info('[resolveInitialPatientIdRequest]', {
     rawPatientId: candidate,
     normalizedPatientId: normalized,
@@ -1275,6 +1300,7 @@ function setPatientIdInputDisplay(id, name, options){
     }
     const parsedCurrent = splitPatientIdDisplay(currentInput);
     const currentKey = normalizePatientIdKey(parsedCurrent.id);
+    tracePatientIdState_('loadPidList', 'currentKey', currentKey, 'setPatientIdInputDisplay');
     if (!currentInput && !currentKey){
       return;
     }
@@ -2625,6 +2651,7 @@ function loadPidList(){
   const ensureAfterApply = (options) => {
     const opts = Object.assign({ finalize: false }, options || {});
     try {
+      tracePatientIdState_('loadPidList', '_initialPatientIdRequested', _initialPatientIdRequested, 'loadPidList.ensureAfterApply');
       console.info('[loadPidList] ensureAfterApply start', {
         finalize: opts.finalize,
         requestedInitialPatientId: _initialPatientIdRequested,
@@ -2817,6 +2844,7 @@ function applyInitialPatientSelectionFromRequest_(options){
     const inputEl = q('pid');
     if (inputEl){
       const currentKey = normalizePatientIdKey(splitPatientIdDisplay(String(inputEl.value || '')).id);
+      tracePatientIdState_(opts.finalize ? 'finalize' : 'applyInitial', 'currentKey', currentKey, 'applyInitialPatientSelectionFromRequest_');
       if (currentKey === _initialPatientIdRequested){
         const resolved = ensurePatientIdDisplayFromInput({
           clearOnReject: false,
@@ -4361,8 +4389,11 @@ function saveHandoverUI(){
 /* 起動時 */
 (function init(){
   _initialPatientIdRequested = resolveInitialPatientIdRequest();
+  tracePatientIdState_('init', '_initialPatientIdRequested', _initialPatientIdRequested, 'init');
   if (_initialPatientIdRequested){
     setv('pid', _initialPatientIdRequested);
+    const pidInput = q('pid');
+    tracePatientIdState_('init', 'input.value(patientId)', pidInput && pidInput.value != null ? String(pidInput.value) : '', 'init');
   }
   loadPidList();
   loadPresets();


### PR DESCRIPTION
### Motivation
- Investigate why direct record links (`view=record&id=...`) sometimes show no patient by tracing where the initial `patientId` becomes empty without changing behavior. 
- Capture assignments/changes to `t.patientId`, `_initialPatientIdRequested`, patient-id input value, and normalized `currentKey` across init/load/apply/finalize phases. 

### Description
- Added a diagnostic `console.log` in `doGet` to record `t.patientId` immediately after template assignment (`src/Code.js`).
- Introduced `detectCallerFunctionName_` and `tracePatientIdState_` helpers and instrumented `setv('pid', ...)` to log input updates in `src/app.html` without altering runtime logic. 
- Instrumented `resolveInitialPatientIdRequest`, the `init` bootstrap, `loadPidList` ensure/apply phase, `setPatientIdInputDisplay` `currentKey` check, and `applyInitialPatientSelectionFromRequest_` to emit phased logs (`init` / `loadPidList` / `applyInitial` / `finalize`).
- No functional/UX changes were made and `refresh()` / calling conditions were left untouched. 

### Testing
- Ran a small URL-parameter simulation via `node` to validate how the three target URLs parse and observed expected log outcomes for `/exec?view=record&id=326`, `/exec?view=record&id=&view=record&id=326`, and `/exec?view=record`, which succeeded. 
- Executed `node tests/dashboardDoGet.test.js` which failed in this environment due to test harness context (`doGet is defined` assertion failed), so unit test could not complete here. 
- Verified code locations and inserted logs by inspecting modified files `src/Code.js` and `src/app.html` and ensured no behavioral code paths were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698abf7d24e883218094fb193300998d)