### PR TITLE
Add URL-only one-shot path for record-view direct links

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -550,7 +550,7 @@ let _initialPatientIdRequested = '';
 let _initialPatientIdResolved = false;
 let _initialPatientIdResolveFailureNotified = false;
 let _initialPatientIdRecordView = false;
-let _initialRecordViewAutoRefreshDone = false;
+let _initialRecordViewUrlAutoRefreshDone = false;
 let _initialRecordViewRefreshCompleted = false;
 let _patientIdSelectionLocked = false;
 let _patientIdInputEditing = false;
@@ -2787,17 +2787,29 @@ function runInitialRecordViewRefreshOnce_(reason){
   return true;
 }
 
-function maybeAutoRefreshFromUrl_(){
-  const isDirectRecordLink =
-    _initialPatientIdRecordView === true &&
-    typeof _initialPatientIdRequested === 'string' &&
-    _initialPatientIdRequested.length > 0;
-  if (_initialRecordViewAutoRefreshDone) return;
-  if (!isDirectRecordLink) return;
+function resolveDirectRecordViewPatientIdFromUrl_(){
+  if (typeof window === 'undefined' || !window.location) return '';
+  try {
+    const params = new URLSearchParams(window.location.search || '');
+    const view = String(params.get('view') || '').trim().toLowerCase();
+    if (view !== 'record') return '';
+    const candidate = params.get('patientId') || params.get('id') || '';
+    return normalizePatientIdKey(candidate);
+  } catch (err){
+    console.warn('[resolveDirectRecordViewPatientIdFromUrl_] URL params read failed', err);
+    return '';
+  }
+}
 
-  _initialRecordViewAutoRefreshDone = true;
+function maybeAutoRefreshFromUrl_(){
+  if (_initialRecordViewUrlAutoRefreshDone) return;
+  const directRecordPatientId = resolveDirectRecordViewPatientIdFromUrl_();
+  if (!directRecordPatientId) return;
+
+  _initialRecordViewUrlAutoRefreshDone = true;
+  setv('pid', directRecordPatientId);
   _initialRecordViewRefreshCompleted = true;
-  console.info('[record-view] auto refresh from URL', _initialPatientIdRequested);
+  console.info('[record-view] auto refresh from URL', directRecordPatientId);
   refresh();
 }
 


### PR DESCRIPTION
### Motivation
- Direct `/exec?view=record&id=...` links could fail due to complex, timing-sensitive initial-selection logic and input overwrites. 
- A deterministic, minimal path that reads URL params and drives the UI is required to guarantee the PID is populated and `refresh()` runs exactly once on direct links. 
- The change must not alter the manual selection/search/confirm flows or existing `applyInitialPatientSelectionFromRequest_` / `ensurePatientIdDisplayFromInput` behavior. 

### Description
- Added `resolveDirectRecordViewPatientIdFromUrl_()` which reads `view`, `patientId`, and `id` directly from `URLSearchParams` and returns a normalized patient id or `''` when absent. 
- Introduced a URL-only one-shot guard `let _initialRecordViewUrlAutoRefreshDone = false;` to prevent multiple URL-triggered refreshes. 
- Reworked `maybeAutoRefreshFromUrl_()` to use only the new resolver, directly `setv('pid', ...)`, mark the URL guard, set `_initialRecordViewRefreshCompleted`, log the event, and call `refresh()` exactly once. 
- Preserved existing initial-selection and finalize fallback code paths and did not reuse `_initialPatientIdRequested` for this URL-only flow. 

### Testing
- Ran `node --test tests/dashboardExecUrlResolution.test.js` and it passed. 
- Attempted an automated browser run to capture a screenshot, but the environment failed to open the local `file://` page (`net::ERR_FILE_NOT_FOUND`), so visual verification was not completed in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ac2864d988321a8ea577b1748f1bd)