### PR TITLE
Record view: route URL-origin patient auto-selection through confirm handler

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -663,14 +663,6 @@ function resolveInitialPatientIdRequest(){
   } catch (err){
     console.warn('[resolveInitialPatientIdRequest] template read failed', err);
   }
-  if (!candidate && typeof window !== 'undefined' && window.location){
-    try {
-      const params = new URLSearchParams(window.location.search);
-      candidate = params.get('patientId') || params.get('id') || '';
-    } catch (err){
-      console.warn('[resolveInitialPatientIdRequest] URL params read failed', err);
-    }
-  }
   const normalized = normalizePatientIdKey(candidate);
   tracePatientIdState_('init', 'currentKey', normalized, 'resolveInitialPatientIdRequest');
   console.info('[resolveInitialPatientIdRequest]', {
@@ -2793,8 +2785,14 @@ function resolveDirectRecordViewPatientIdFromUrl_(){
     const params = new URLSearchParams(window.location.search || '');
     const view = String(params.get('view') || '').trim().toLowerCase();
     if (view !== 'record') return '';
-    const candidate = params.get('patientId') || params.get('id') || '';
-    return normalizePatientIdKey(candidate);
+
+    let candidate = '';
+    if (params.has('patientId')){
+      candidate = params.get('patientId') || '';
+    } else if (params.has('id')){
+      candidate = params.get('id') || '';
+    }
+    return String(candidate);
   } catch (err){
     console.warn('[resolveDirectRecordViewPatientIdFromUrl_] URL params read failed', err);
     return '';
@@ -2804,13 +2802,13 @@ function resolveDirectRecordViewPatientIdFromUrl_(){
 function maybeAutoRefreshFromUrl_(){
   if (_initialRecordViewUrlAutoRefreshDone) return;
   const directRecordPatientId = resolveDirectRecordViewPatientIdFromUrl_();
-  if (!directRecordPatientId) return;
+  if (!String(directRecordPatientId || '').trim()) return;
 
   _initialRecordViewUrlAutoRefreshDone = true;
-  setv('pid', directRecordPatientId);
   _initialRecordViewRefreshCompleted = true;
-  console.info('[record-view] auto refresh from URL', directRecordPatientId);
-  refresh();
+  setv('pid', directRecordPatientId);
+  console.info('[record-view] confirm from URL', directRecordPatientId);
+  handlePatientIdConfirm();
 }
 
 function applyInitialPatientSelectionFromRequest_(options){


### PR DESCRIPTION
### Motivation
- Ensure direct record links like `/exec?view=record&id=374` auto-fill the `#pid` input and display patient info while keeping manual input UX unchanged.
- Unify patient confirmation into a single route so URL-origin logic does not call `refresh()` directly and mirrors the manual confirm flow.
- Avoid mixing URL-origin handling into candidate/ensure/normalize logic and treat explicitly empty URL params as no-op to prevent accidental behavior for cases like `id=&id=326`.

### Description
- Extracted URL patient-id in `resolveDirectRecordViewPatientIdFromUrl_()` using `params.has(...)` with priority `patientId` → `id`, returning the raw string (no normalization) and treating explicitly empty params as empty.
- Modified `maybeAutoRefreshFromUrl_()` to guard with `_initialRecordViewUrlAutoRefreshDone`, set the `#pid` via `setv('pid', ...)`, mark the initial refresh state, and invoke `handlePatientIdConfirm()` once instead of calling `refresh()` directly.
- Removed URL param reading from `resolveInitialPatientIdRequest()` so initial-template patient id handling remains separate and URL-origin logic is confined to the dedicated functions.
- Preserved existing one-shot guards and ensured URL-origin path uses the same confirmation handler as manual input (`handlePatientIdConfirm()`), maintaining the two-character candidate UX and other manual flows.

### Testing
- Ran `node --test tests/dashboardNavigationLinks.test.js tests/deleteTreatment.test.js` and both tests passed.
- Verified that the modified functions are exercised in the codebase and that the URL-origin path no longer calls `refresh()` directly during initial load.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ac82f7f30832198b90d3ddaf374f6)