### PR TITLE
Canonicalize dashboard patient links to exec?view=record&id=ID

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -703,7 +703,15 @@ function navigateToPatient_(patientId) {
 }
 
 function configurePatientLinkElement_(anchor, patientId) {
-  if (!anchor || !patientId) return;
+  if (!anchor) return;
+  if (!patientId) {
+    anchor.removeAttribute('href');
+    anchor.removeAttribute('target');
+    anchor.removeAttribute('rel');
+    anchor.classList.add('disabled');
+    anchor.setAttribute('aria-disabled', 'true');
+    return;
+  }
   const link = buildTreatmentAppLink_(patientId);
   if (!link) {
     anchor.removeAttribute('href');
@@ -727,8 +735,7 @@ function buildTreatmentAppLink_(patientId) {
   if (!rawExecUrl) return '';
   const id = encodeURIComponent(patientId || '');
   if (!id) return '';
-  const joiner = rawExecUrl.indexOf('?') >= 0 ? '&' : '?';
-  return `${rawExecUrl}${joiner}view=record&id=${id}`;
+  return `${rawExecUrl}?view=record&id=${id}`;
 }
 
 function resolveTreatmentAppExecUrl_() {
@@ -740,9 +747,19 @@ function resolveTreatmentAppExecUrl_() {
     ? String(treatmentAppExecUrl || '').trim()
     : '';
   const resolved = configured || injected;
-  if (resolved && isValidTreatmentExecUrl_(resolved)) return resolved;
+  if (resolved && isValidTreatmentExecUrl_(resolved)) {
+    return normalizeTreatmentExecUrl_(resolved);
+  }
 
   return '';
+}
+
+function normalizeTreatmentExecUrl_(url) {
+  if (!url) return '';
+  const trimmed = String(url || '').trim();
+  if (!trimmed) return '';
+  const noHash = trimmed.split('#')[0];
+  return noHash.split('?')[0];
 }
 
 function isValidTreatmentExecUrl_(url) {

--- a/tests/dashboardNavigationLinks.test.js
+++ b/tests/dashboardNavigationLinks.test.js
@@ -54,6 +54,18 @@ function createContext() {
   );
 })();
 
+(function testBuildTreatmentAppLinkAlwaysUsesCanonicalQuery() {
+  const context = createContext();
+  context.DASHBOARD_TREATMENT_APP_EXEC_URL = 'https://script.google.com/macros/s/DEPLOY123/exec?foo=bar#anchor';
+
+  const link = context.buildTreatmentAppLink_('P-003');
+  assert.strictEqual(
+    link,
+    'https://script.google.com/macros/s/DEPLOY123/exec?view=record&id=P-003',
+    'buildTreatmentAppLink_ never reuses existing query parameters'
+  );
+})();
+
 
 (function testInvalidGoogleusercontentExecUrlIsRejected() {
   const context = createContext();
@@ -81,6 +93,15 @@ function createContext() {
     '施術録WebアプリURLが未設定のため、患者画面を開けません。',
     'navigate sets a clear UI error message when URL is missing'
   );
+})();
+
+(function testFalsyPatientIdDoesNotNavigate() {
+  const context = createContext();
+  context.DASHBOARD_TREATMENT_APP_EXEC_URL = 'https://script.google.com/macros/s/DEPLOY123/exec';
+
+  assert.strictEqual(context.buildTreatmentAppLink_(''), '', 'empty patient id does not build URL');
+  context.navigateToPatient_('');
+  assert.strictEqual(context.__openCalls.length, 0, 'empty patient id does not open new tab');
 })();
 
 console.log('dashboard navigation link tests passed');


### PR DESCRIPTION
### Motivation
- Prevent malformed patient links from the dashboard (missing `id=`, duplicated `view=record&id=` or reusing existing query/hash) which breaks automatic patient display on the record screen.

### Description
- Centralized URL generation into `buildTreatmentAppLink_` and changed it to always return the canonical form ``${EXEC_URL}?view=record&id=${encodeURIComponent(patientId)}`` without appending existing query strings. 
- Added `normalizeTreatmentExecUrl_` to strip any `?` query and `#` hash from configured/injected exec URLs before building links, and made `resolveTreatmentAppExecUrl_` return the normalized value. 
- Hardened `configurePatientLinkElement_` so falsy `patientId` never sets `href/target/rel` and keeps the element disabled, and kept `navigateToPatient_` early-return for falsy `patientId` to prevent navigation. 
- Added unit tests verifying canonical query enforcement and that falsy `patientId` does not build or navigate to a URL (`tests/dashboardNavigationLinks.test.js`).

### Testing
- Ran `node tests/dashboardNavigationLinks.test.js` and the tests passed. 
- Ran `node tests/dashboardExecUrlResolution.test.js` and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698acd3eeddc8321958a9c66f7c7ef1f)