### PR TITLE
Auto-confirm record view URL patient once after PID list initialization

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -552,6 +552,7 @@ let _initialPatientIdResolveFailureNotified = false;
 let _initialPatientIdRecordView = false;
 let _initialRecordViewUrlAutoRefreshDone = false;
 let _initialRecordViewRefreshCompleted = false;
+let _initialRecordViewUrlPatientId = '';
 let _patientIdSelectionLocked = false;
 let _patientIdInputEditing = false;
 let _patientInfoLoadInFlight = false;
@@ -2657,6 +2658,9 @@ function loadPidList(){
           finalize: opts.finalize,
           patientId: _initialPatientIdRequested
         });
+        if (opts.finalize){
+          maybeAutoRefreshFromUrl_({ finalize: true });
+        }
         schedulePatientIdSearchUpdate(true);
         return;
       }
@@ -2681,6 +2685,7 @@ function loadPidList(){
         clearPatientDisplay({ keepInput: false, force: true });
       }
       if (opts.finalize){
+        maybeAutoRefreshFromUrl_({ finalize: true });
         runInitialRecordViewRefreshOnce_('finalize fallback after initial patient selection from request');
       }
       schedulePatientIdSearchUpdate(true);
@@ -2799,13 +2804,15 @@ function resolveDirectRecordViewPatientIdFromUrl_(){
   }
 }
 
-function maybeAutoRefreshFromUrl_(){
+function maybeAutoRefreshFromUrl_(options){
+  const opts = Object.assign({ finalize: false }, options || {});
   if (_initialRecordViewUrlAutoRefreshDone) return;
-  const directRecordPatientId = resolveDirectRecordViewPatientIdFromUrl_();
+  if (!opts.finalize) return;
+
+  const directRecordPatientId = _initialRecordViewUrlPatientId || resolveDirectRecordViewPatientIdFromUrl_();
   if (!String(directRecordPatientId || '').trim()) return;
 
   _initialRecordViewUrlAutoRefreshDone = true;
-  _initialRecordViewRefreshCompleted = true;
   setv('pid', directRecordPatientId);
   console.info('[record-view] confirm from URL', directRecordPatientId);
   handlePatientIdConfirm();
@@ -4399,6 +4406,7 @@ function saveHandoverUI(){
 /* 起動時 */
 (function init(){
   _initialPatientIdRequested = resolveInitialPatientIdRequest();
+  _initialRecordViewUrlPatientId = resolveDirectRecordViewPatientIdFromUrl_();
   tracePatientIdState_('init', '_initialPatientIdRequested', _initialPatientIdRequested, 'init');
   if (_initialPatientIdRequested){
     setv('pid', _initialPatientIdRequested);
@@ -4416,7 +4424,6 @@ function saveHandoverUI(){
     hideGlobalLoading();
   }
   q('consentModal')?.classList.remove('open');
-  maybeAutoRefreshFromUrl_();
 })();
 
 google.script.run.withSuccessHandler(r=>console.log('[ping]', r))


### PR DESCRIPTION
### Motivation
- Direct record-link URLs (`?view=record&id=...` / `?view=record&patientId=...`) set the PID input early but could miss firing the confirm/refresh flow because initialization (candidate list load) wasn't finished, so the patient info didn't display automatically.

### Description
- Added `let _initialRecordViewUrlPatientId = ''` to capture the URL-derived patient id at startup in `src/app.html`.
- Introduced `maybeAutoRefreshFromUrl_(options)` that requires `finalize: true`, reads the cached URL pid or resolves from the URL, and performs a one-shot `setv('pid')` + `handlePatientIdConfirm()` guarded by `_initialRecordViewUrlAutoRefreshDone` to avoid repeats.
- Triggered `maybeAutoRefreshFromUrl_({ finalize: true })` from the `loadPidList()` finalize paths (both after `applyInitialPatientSelectionFromRequest_` and the fallback finalize branch) so the auto-confirm runs only after initialization completes.
- Removed the eager call from `init()` so the URL auto-confirm does not execute before candidate initialization, preserving all manual input/autocomplete/Enter behaviors.

### Testing
- Ran `git diff --check` which reported no issues.
- Inspected working tree with `git status --short` to confirm the intended file change (`src/app.html`).
- Committed the change with `git commit` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698acf90ce588321b3874844d1eb1622)