### PR TITLE
Add diagnostic logs for direct record-view patient resolution flow

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1248,7 +1248,9 @@ function setConfirmedPatientId(id){
   _patientIdSelectionLocked = true;
 }
 
-function setCurrentPatientRecord_(record){
+function setCurrentPatientRecord_(record, source){
+  const sourceLabel = source || 'manual';
+  console.log('[SET-RECORD] record=' + String(record == null ? null : 'present'), 'patientId=' + String(record && record.id ? record.id : ''), 'source=' + sourceLabel);
   if (!record || !record.id) return false;
   setConfirmedPatientId(record.id);
   return true;
@@ -2691,6 +2693,9 @@ function loadPidList(){
         clearPatientDisplay({ keepInput: false, force: true });
       }
       if (opts.finalize){
+        const initialRecordViewUrlId = normalizePatientIdKey(_initialRecordViewUrlPatientId);
+        const hasInitialRecordViewUrlId = !!(initialRecordViewUrlId && _patientIdIndex[initialRecordViewUrlId]);
+        console.log('[PID-LIST] requested=' + String(_initialRecordViewUrlPatientId || ''), 'initialPatientIdRequested=' + String(_initialPatientIdRequested || ''), 'indexSize=' + Object.keys(_patientIdIndex).length, 'existsInIndex=' + hasInitialRecordViewUrlId);
         const autoConfirmed = maybeAutoConfirmDirectRecordViewPatientFromUrl_({ finalize: true });
         if (!autoConfirmed){
           runInitialRecordViewRefreshOnce_('finalize fallback after initial patient selection from request');
@@ -2805,7 +2810,10 @@ function resolveDirectRecordViewPatientIdFromUrl_(){
     } else if (params.has('id')){
       candidate = params.get('id') || '';
     }
-    return String(candidate);
+    const rawCandidate = String(candidate);
+    const normalizedCandidate = normalizePatientIdKey(rawCandidate);
+    console.log('[URL-RESOLVE] rawUrl=' + String(window.location.href || ''), 'id=' + rawCandidate, 'patientId=' + rawCandidate, 'normalized=' + normalizedCandidate);
+    return rawCandidate;
   } catch (err){
     console.warn('[resolveDirectRecordViewPatientIdFromUrl_] URL params read failed', err);
     return '';
@@ -2823,7 +2831,7 @@ function maybeAutoConfirmDirectRecordViewPatientFromUrl_(options){
   const record = _patientIdIndex[directRecordPatientId];
   if (!record) return false;
 
-  if (!setCurrentPatientRecord_(record)) return false;
+  if (!setCurrentPatientRecord_(record, 'URL')) return false;
 
   _initialRecordViewAutoConfirmed = true;
   _initialRecordViewRefreshCompleted = true;
@@ -2956,6 +2964,7 @@ function handlePatientIdConfirm(evt){
   const rawValue = inputEl && inputEl.value != null ? String(inputEl.value) : '';
   const trimmed = rawValue.trim();
   if (!trimmed){
+    console.log('[CONFIRM] input=' + trimmed, 'resolved=false', 'willRefresh=false');
     clearPatientDisplay({ keepInput: false, force: true });
     schedulePatientIdSearchUpdate(true);
     return;
@@ -2968,10 +2977,12 @@ function handlePatientIdConfirm(evt){
     if (_patientIdList.length){
       alert('⚠️ リストに存在しない患者は登録できません。');
     }
+    console.log('[CONFIRM] input=' + trimmed, 'resolved=false', 'willRefresh=false');
     clearPatientDisplay({ keepInput: !_patientIdList.length, force: true });
     schedulePatientIdSearchUpdate(true);
     return;
   }
+  console.log('[CONFIRM] input=' + trimmed, 'resolved=true', 'willRefresh=true');
   schedulePatientIdSearchUpdate(true);
   refresh();
 }
@@ -3408,6 +3419,8 @@ function loadPatientInfoWithRetry(patientId, options){
 
 /* 画面更新 */
 function refresh(targetPatientId){
+  const source = _initialRecordViewAutoConfirmed ? 'URL' : 'manual';
+  console.log('[REFRESH] confirmedId=' + String(_confirmedPatientId || ''), '_initialRecordViewAutoConfirmed=' + String(!!_initialRecordViewAutoConfirmed), 'source=' + source);
   const normalizedTarget = normalizePatientIdKey(targetPatientId != null ? targetPatientId : pid());
   _queuedPatientIdForLoad = normalizedTarget;
   if (_patientInfoLoadInFlight) {


### PR DESCRIPTION
### Motivation

- 調査目的は `view=record&id=XXX` で「入力欄には値が入るが患者情報が表示されない」事象の原因をログで一点特定するため、動作変更せずに詳細ログを追加することでした。 

### Description

- `resolveDirectRecordViewPatientIdFromUrl_()` に `[URL-RESOLVE]` ログを追加し、`window.location.href`（rawUrl）、抽出した `id`/`patientId`、および正規化値を出力するようにしました。 
- `loadPidList()` の `opts.finalize` 処理直前に `[PID-LIST]` ログを追加し、`_initialRecordViewUrlPatientId`、`_initialPatientIdRequested`、`Object.keys(_patientIdIndex).length`、および URL id が `_patientIdIndex` に存在するかを出力するようにしました。 
- `setCurrentPatientRecord_()` に `[SET-RECORD]` ログを追加して `record` の有無、`record.id`（patientId 相当）、および呼び出し元ラベル（`URL`/`manual`）を出力するようにし、URL 経路からの呼び出しでは `source='URL'` を渡すようにしました（既存挙動は変更していません）。 
- `handlePatientIdConfirm()` に `[CONFIRM]` ログを追加して、`input.value`（trim後）、resolved 可否、および refresh 到達の有無を分岐ごとに出力するようにしました。 
- `refresh()` 入口に `[REFRESH]` ログを追加して、`_confirmedPatientId`、`_initialRecordViewAutoConfirmed`、および呼び出し経路（URL/manual）を出力するようにしました。 
- すべての変更はログ出力のみで、ロジック・条件分岐・UX の変更は行っていません。変更ファイル: `src/app.html`。

### Testing

- ソース差分確認として `nl`/`sed` による該当箇所の出力確認を実行し、挿入されたログ行を検証しました（成功）。
- `git status --short` と `git commit` を実行して変更をコミットし、コミットが作成されることを確認しました（成功）。
- 自動テストは追加しておらず、変更はログ追加のみのため既存の動作を変えないことを前提に動作確認用ログ挿入に留めています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c1853ebe08321a0d4914da499bd3e)