### PR TITLE
Unify record URL patient loading with patient ID confirm flow

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -550,10 +550,7 @@ let _initialPatientIdRequested = '';
 let _initialPatientIdResolved = false;
 let _initialPatientIdResolveFailureNotified = false;
 let _initialPatientIdRecordView = false;
-let _initialRecordViewAutoConfirmed = false;
-let _initialRecordViewRefreshCompleted = false;
-let _initialRecordViewUrlPatientId = '';
-let _currentPatientRecord = null;
+let _initialUrlApplied = false;
 let _patientIdSelectionLocked = false;
 let _patientIdInputEditing = false;
 let _patientInfoLoadInFlight = false;
@@ -1253,14 +1250,12 @@ function setCurrentPatientRecord_(record, source){
   const sourceLabel = source || 'manual';
   console.log('[SET-RECORD] record=' + String(record == null ? null : 'present'), 'patientId=' + String(record && record.id ? record.id : ''), 'source=' + sourceLabel);
   if (!record || !record.id) return false;
-  _currentPatientRecord = record;
   setConfirmedPatientId(record.id);
   return true;
 }
 
 function clearConfirmedPatientId(){
   _confirmedPatientId = '';
-  _currentPatientRecord = null;
   _patientIdSelectionLocked = false;
 }
 
@@ -2669,9 +2664,6 @@ function loadPidList(){
           finalize: opts.finalize,
           patientId: _initialPatientIdRequested
         });
-        if (opts.finalize){
-          autoConfirmFromUrlOnce_();
-        }
         schedulePatientIdSearchUpdate(true);
         return;
       }
@@ -2695,13 +2687,12 @@ function loadPidList(){
       if (!result && _patientIdList.length){
         clearPatientDisplay({ keepInput: false, force: true });
       }
-      if (opts.finalize){
-        const initialRecordViewUrlId = normalizePatientIdKey(_initialRecordViewUrlPatientId);
-        const hasInitialRecordViewUrlId = !!(initialRecordViewUrlId && _patientIdIndex[initialRecordViewUrlId]);
-        console.log('[PID-LIST] requested=' + String(_initialRecordViewUrlPatientId || ''), 'initialPatientIdRequested=' + String(_initialPatientIdRequested || ''), 'indexSize=' + Object.keys(_patientIdIndex).length, 'existsInIndex=' + hasInitialRecordViewUrlId);
-        const autoConfirmed = autoConfirmFromUrlOnce_();
-        if (!autoConfirmed){
-          runInitialRecordViewRefreshOnce_('finalize fallback after initial patient selection from request');
+      if (opts.finalize && !_initialUrlApplied) {
+        const urlId = getRecordViewPatientIdFromUrl_();
+        if (urlId) {
+          _initialUrlApplied = true;
+          setv('pid', urlId);
+          handlePatientIdConfirm();
         }
       }
       schedulePatientIdSearchUpdate(true);
@@ -2788,60 +2779,10 @@ function notifyInitialPatientIdResolveFailure_(reason){
   toast(`指定された患者ID（${_initialPatientIdRequested}）を初期表示で確定できませんでした。${detail}`);
 }
 
-function runInitialRecordViewRefreshOnce_(reason){
-  if (!_initialPatientIdRecordView || !_initialPatientIdRequested) return false;
-  if (_initialRecordViewRefreshCompleted) return false;
-  _initialRecordViewRefreshCompleted = true;
-  console.info('[initialRecordViewRefresh] refresh', {
-    reason: reason || 'fallback',
-    patientId: _initialPatientIdRequested
-  });
-  refresh();
-  return true;
-}
-
-function resolveDirectRecordViewPatientIdFromUrl_(){
-  if (typeof window === 'undefined' || !window.location) return '';
-  try {
-    const params = new URLSearchParams(window.location.search || '');
-    const view = String(params.get('view') || '').trim().toLowerCase();
-    if (view !== 'record') return '';
-
-    let candidate = '';
-    if (params.has('patientId')){
-      candidate = params.get('patientId') || '';
-    } else if (params.has('id')){
-      candidate = params.get('id') || '';
-    }
-    const rawCandidate = String(candidate);
-    const normalizedCandidate = normalizePatientIdKey(rawCandidate);
-    console.log('[URL-RESOLVE] rawUrl=' + String(window.location.href || ''), 'id=' + rawCandidate, 'patientId=' + rawCandidate, 'normalized=' + normalizedCandidate);
-    return rawCandidate;
-  } catch (err){
-    console.warn('[resolveDirectRecordViewPatientIdFromUrl_] URL params read failed', err);
-    return '';
-  }
-}
-
-function autoConfirmFromUrlOnce_() {
-  if (_initialRecordViewAutoConfirmed) return false;
-
-  const params = new URLSearchParams(window.location.search);
-  const idFromUrl = normalizePatientIdKey(params.get('id') || params.get('patientId'));
-
-  if (!idFromUrl) return false;
-  if (!_patientIdIndex[idFromUrl]) return false;
-
-  _confirmedPatientId = idFromUrl;
-  _currentPatientRecord = _patientIdIndex[idFromUrl];
-
-  _initialRecordViewAutoConfirmed = true;
-  _initialRecordViewRefreshCompleted = true;
-
-  console.log('[AUTO-CONFIRM-URL]', idFromUrl);
-
-  refresh();
-  return true;
+function getRecordViewPatientIdFromUrl_() {
+  const params = new URLSearchParams(location.search);
+  if (params.get('view') !== 'record') return '';
+  return params.get('id') || params.get('patientId') || '';
 }
 
 function applyInitialPatientSelectionFromRequest_(options){
@@ -2870,7 +2811,7 @@ function applyInitialPatientSelectionFromRequest_(options){
       finalize: opts.finalize,
       patientId: record.id
     });
-    runInitialRecordViewRefreshOnce_('matched candidate list record');
+    refresh();
     return true;
   }
   if (!opts.finalize){
@@ -2899,7 +2840,7 @@ function applyInitialPatientSelectionFromRequest_(options){
             finalize: opts.finalize,
             patientId: _initialPatientIdRequested
           });
-          runInitialRecordViewRefreshOnce_('record view URL fallback resolved by input value on finalize');
+          refresh();
           return true;
         }
         if (resolved && resolved.skipped){
@@ -2922,7 +2863,6 @@ function applyInitialPatientSelectionFromRequest_(options){
     patientId: _initialPatientIdRequested
   });
   notifyInitialPatientIdResolveFailure_(failureReason);
-  runInitialRecordViewRefreshOnce_('finalize fallback after unresolved URL patientId');
   return true;
 }
 
@@ -3423,8 +3363,7 @@ function loadPatientInfoWithRetry(patientId, options){
 
 /* 画面更新 */
 function refresh(targetPatientId){
-  const source = _initialRecordViewAutoConfirmed ? 'URL' : 'manual';
-  console.log('[REFRESH] confirmedId=' + String(_confirmedPatientId || ''), '_initialRecordViewAutoConfirmed=' + String(!!_initialRecordViewAutoConfirmed), 'source=' + source);
+  console.log('[REFRESH] confirmedId=' + String(_confirmedPatientId || ''));
   const normalizedTarget = normalizePatientIdKey(targetPatientId != null ? targetPatientId : pid());
   _queuedPatientIdForLoad = normalizedTarget;
   if (_patientInfoLoadInFlight) {
@@ -4437,7 +4376,6 @@ function saveHandoverUI(){
 /* 起動時 */
 (function init(){
   _initialPatientIdRequested = resolveInitialPatientIdRequest();
-  _initialRecordViewUrlPatientId = resolveDirectRecordViewPatientIdFromUrl_();
   tracePatientIdState_('init', '_initialPatientIdRequested', _initialPatientIdRequested, 'init');
   if (_initialPatientIdRequested){
     setv('pid', _initialPatientIdRequested);


### PR DESCRIPTION
### Motivation

- Simplify and consolidate URL-driven "record view" patient selection by reusing the existing manual confirm route rather than special-case URL-only logic.
- Remove internal state mutations tied to URL auto-confirm paths to reduce complexity and avoid touching internal record state directly.

### Description

- Removed URL-only auto-confirm / auto-refresh helpers and state (`autoConfirmFromUrlOnce_`, `resolveDirectRecordViewPatientIdFromUrl_`, `runInitialRecordViewRefreshOnce_`, `_initialRecordViewAutoConfirmed`, `_initialRecordViewRefreshCompleted`, `_initialRecordViewUrlPatientId`, and `_currentPatientRecord`) and related direct writes to `_confirmedPatientId` in favor of a single unified path in `src/app.html`.
- Added `getRecordViewPatientIdFromUrl_()` to extract `id`/`patientId` when `view=record` and added a single guard `let _initialUrlApplied = false;` for one-time application.
- Updated `loadPidList()` finalize flow to, on first finalize, read the URL via `getRecordViewPatientIdFromUrl_()`, set the PID input with `setv('pid', urlId)`, and call `handlePatientIdConfirm()` so the existing confirm/refresh flow handles loading.
- Adjusted `setCurrentPatientRecord_`, `clearConfirmedPatientId`, and `refresh()` to remove direct dependencies on the removed URL-only state and to avoid direct URL-path manipulations; all changes are localized to `src/app.html`.

### Testing

- Ran `node --test tests/*.test.js`, which executed the repository test suite and produced 24 tests with 10 passing and 14 failing; failures are part of the repository's pre-existing unrelated test failures and not limited to the modified URL logic.
- Attempted a Playwright-based page load and screenshot of `src/app.html`, which failed due to the environment reporting `ERR_FILE_NOT_FOUND` when loading the local file, so no browser screenshot validation was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c27bae7c4832182a1cd5dde6f6ad8)