### PR TITLE
記録 News の30日超過表示を抑止

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -6115,6 +6115,7 @@ function formatNewsOutput_(rows){
     .slice()
     .sort((a, b) => (b.ts || 0) - (a.ts || 0))
       .map(row => ({
+        ts: row.ts,
         when: row.when,
         type: row.type,
         message: row.message,

--- a/src/app.html
+++ b/src/app.html
@@ -3392,6 +3392,14 @@ function buildNewsItemHtml(news, idx){
   const statusAttr = status ? ` data-status="${escapeHtml(status)}"` : '';
   return `<div class="news-item" data-type="${typeAttr}"${statusAttr}><div class="muted">${escapeHtml(news && news.when||'')} ／ ${typeLabel}</div><div>${messageHtml}</div>${actions}</div>`;
 }
+
+function isExpiredRecordNews(news){
+  if(!news || String(news.type || '').trim() !== '記録') return false;
+  const ts = Number(news.ts);
+  if (!Number.isFinite(ts) || ts <= 0) return false;
+  return (Date.now() - ts) > (30 * 24 * 60 * 60 * 1000);
+}
+
 function renderNewsList(list, options){
   const el = q('news');
   const done = options && options.done;
@@ -3406,7 +3414,7 @@ function renderNewsList(list, options){
     return;
   }
   const visibleList = Array.isArray(list)
-    ? list.filter(item => !item.dismissed && !item.clearedAt)
+    ? list.filter(item => !item.dismissed && !item.clearedAt && !isExpiredRecordNews(item))
     : [];
   if (!visibleList.length) {
     _latestNewsList = [];


### PR DESCRIPTION
### Motivation
- 施術記録の日時修正などで追加される種別「記録」の News が無期限に表示され続ける問題を改善するため、表示ロジックで古い記録Newsを隠す必要がある。 
- データは削除せず表示のみ制御し、既存の `cleared` / `dismissed` など他ロジックには影響を与えない方針を遵守する。 

### Description
- `src/Code.js` の `formatNewsOutput_` に `ts` を含めるよう出力を拡張してフロント側で経過時間判定できるようにした。 
- `src/app.html` に `isExpiredRecordNews(news)` を追加し、`type === '記録'` の News を `news.ts` から30日超過で判定する関数を実装した。 
- `renderNewsList` のフィルタ条件に `!isExpiredRecordNews(item)` を追加し、`dismissed` / `clearedAt` の既存条件は変更せずに表示から除外するようにした。 

### Testing
- `node tests/deleteTreatment.test.js` を実行して成功を確認した（テストはパス）。 
- `node --check src/Code.js` を実行して構文チェックが通ることを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c521cd8d48321a1c6c933eb06f5d9)