### PR TITLE
Refactor dashboard spreadsheet loading to single open

### DIFF
--- a/src/dashboard/data/assignResponsibleStaff.js
+++ b/src/dashboard/data/assignResponsibleStaff.js
@@ -7,12 +7,12 @@
  */
 function assignResponsibleStaff(options) {
   const opts = options || {};
-  const patientInfo = opts.patientInfo || (typeof loadPatientInfo === 'function' ? loadPatientInfo() : null);
+  const patientInfo = opts.patientInfo || (typeof loadPatientInfo === 'function' ? loadPatientInfo({ dashboardSpreadsheet: opts.dashboardSpreadsheet }) : null);
   const patients = patientInfo && patientInfo.patients ? patientInfo.patients : {};
   const warnings = patientInfo && Array.isArray(patientInfo.warnings) ? [].concat(patientInfo.warnings) : [];
   const setupIncomplete = !!(patientInfo && patientInfo.setupIncomplete);
 
-  const treatment = opts.treatmentLogs || (typeof loadTreatmentLogs === 'function' ? loadTreatmentLogs({ patientInfo, now: opts.now }) : null);
+  const treatment = opts.treatmentLogs || (typeof loadTreatmentLogs === 'function' ? loadTreatmentLogs({ patientInfo, now: opts.now, dashboardSpreadsheet: opts.dashboardSpreadsheet }) : null);
   const lastStaffByPatient = treatment && treatment.lastStaffByPatient ? treatment.lastStaffByPatient : {};
   if (treatment && Array.isArray(treatment.warnings)) {
     warnings.push.apply(warnings, treatment.warnings);

--- a/src/dashboard/data/loadAIReports.js
+++ b/src/dashboard/data/loadAIReports.js
@@ -3,10 +3,12 @@
  * @return {{reports: Object<string, string>, warnings: string[]}}
  */
 function loadAIReports(options) {
-  return loadAIReportsUncached_();
+  const opts = options || {};
+  return loadAIReportsUncached_(opts);
 }
 
-function loadAIReportsUncached_() {
+function loadAIReportsUncached_(options) {
+  const opts = options || {};
   const reports = {};
   const warnings = [];
   let setupIncomplete = false;
@@ -19,7 +21,7 @@ function loadAIReportsUncached_() {
     }
   };
 
-  const wb = dashboardGetSpreadsheet_();
+  const wb = opts.dashboardSpreadsheet || null;
   if (!wb || typeof wb.getSheetByName !== 'function') {
     warnings.push('スプレッドシートを取得できませんでした');
     setupIncomplete = true;

--- a/src/dashboard/data/loadNotes.js
+++ b/src/dashboard/data/loadNotes.js
@@ -31,7 +31,8 @@ function loadNotes(options) {
   return { notes, warnings, lastReadAt, setupIncomplete: !!base.setupIncomplete };
 }
 
-function loadNotesUncached_(_options) {
+function loadNotesUncached_(options) {
+  const opts = options || {};
   const warnings = [];
   const latestByPatient = {};
   let setupIncomplete = false;
@@ -44,7 +45,7 @@ function loadNotesUncached_(_options) {
     }
   };
 
-  const wb = dashboardGetSpreadsheet_();
+  const wb = opts.dashboardSpreadsheet || null;
   if (!wb) {
     const warning = 'スプレッドシートを取得できませんでした';
     warnings.push(warning);

--- a/src/dashboard/data/loadPatientInfo.js
+++ b/src/dashboard/data/loadPatientInfo.js
@@ -6,7 +6,8 @@ function loadPatientInfo(options) {
   return loadPatientInfoUncached_(opts);
 }
 
-function loadPatientInfoUncached_(_options) {
+function loadPatientInfoUncached_(options) {
+  const opts = options || {};
   const patients = {};
   const nameToId = {};
   const warnings = [];
@@ -20,7 +21,7 @@ function loadPatientInfoUncached_(_options) {
     }
   };
 
-  const wb = dashboardGetSpreadsheet_();
+  const wb = opts.dashboardSpreadsheet || null;
   if (!wb) {
     const warning = 'スプレッドシートを取得できませんでした';
     warnings.push(warning);

--- a/src/dashboard/data/loadTreatmentLogs.js
+++ b/src/dashboard/data/loadTreatmentLogs.js
@@ -10,7 +10,7 @@ function loadTreatmentLogs(options) {
 
 function loadTreatmentLogsUncached_(options) {
   const opts = options || {};
-  const patientInfo = opts.patientInfo || (typeof loadPatientInfo === 'function' ? loadPatientInfo() : null);
+  const patientInfo = opts.patientInfo || (typeof loadPatientInfo === 'function' ? loadPatientInfo({ dashboardSpreadsheet: opts.dashboardSpreadsheet }) : null);
   const nameToId = opts.nameToId || (patientInfo && patientInfo.nameToId) || {};
   const warnings = patientInfo && Array.isArray(patientInfo.warnings) ? [].concat(patientInfo.warnings) : [];
   let setupIncomplete = !!(patientInfo && patientInfo.setupIncomplete);
@@ -26,7 +26,7 @@ function loadTreatmentLogsUncached_(options) {
     }
   };
 
-  const wb = dashboardGetSpreadsheet_();
+  const wb = opts.dashboardSpreadsheet || null;
   if (!wb) {
     warnings.push('スプレッドシートを取得できませんでした');
     setupIncomplete = true;

--- a/src/dashboard/data/loadUnpaidAlerts.js
+++ b/src/dashboard/data/loadUnpaidAlerts.js
@@ -61,7 +61,7 @@ function readUnpaidHistory_(options) {
     }
   };
 
-  const wb = dashboardGetSpreadsheet_();
+  const wb = opts.dashboardSpreadsheet || null;
   if (!wb) {
     warnings.push('スプレッドシートを取得できませんでした');
     setupIncomplete = true;

--- a/tests/dashboardGetDashboardDataOptions.test.js
+++ b/tests/dashboardGetDashboardDataOptions.test.js
@@ -33,6 +33,7 @@ function testOptionsArePropagated() {
   const now = new Date('2025-04-15T00:00:00Z');
   const seen = {};
   const patientInfo = { patients: {}, nameToId: {}, warnings: [] };
+  const workbook = { getSheetByName: () => null };
   const ctx = createContext({
     loadPatientInfo: () => patientInfo,
     loadNotes: () => ({ notes: {}, warnings: [] }),
@@ -45,9 +46,13 @@ function testOptionsArePropagated() {
     getTodayVisits: () => ({ visits: [], warnings: [] })
   });
 
+  ctx.dashboardGetSpreadsheet_ = () => workbook;
   ctx.getDashboardData({ now, cache: false });
 
   assert.strictEqual(seen.invoices.now, now, 'loadInvoices に now が伝搬する');
+  assert.strictEqual(seen.treatmentLogs.dashboardSpreadsheet, workbook, 'loadTreatmentLogs に spreadsheet が伝搬する');
+  assert.strictEqual(seen.responsible.dashboardSpreadsheet, workbook, 'assignResponsibleStaff に spreadsheet が伝搬する');
+  assert.strictEqual(seen.unpaidAlerts.dashboardSpreadsheet, workbook, 'loadUnpaidAlerts に spreadsheet が伝搬する');
   assert.strictEqual(seen.treatmentLogs.now, now, 'loadTreatmentLogs に now が伝搬する');
   assert.strictEqual(seen.responsible.now, now, 'assignResponsibleStaff に now が伝搬する');
   assert.strictEqual(seen.invoices.cache, false, 'cache:false が請求書読み込みに伝搬する');


### PR DESCRIPTION
### Motivation
- Avoid repeatedly opening the Dashboard `Spreadsheet` inside `getDashboardData` sub-loaders to reduce overhead and improve performance.
- Ensure a single `Spreadsheet` instance is opened once and shared with downstream loaders to prevent multiple `dashboardGetSpreadsheet_` calls.

### Description
- Open the dashboard spreadsheet once at the start of `getDashboardData` and store it as `dashboardSpreadsheet`, with a counter `spreadsheetOpenCount` to track opens. 
- Thread the same `dashboardSpreadsheet` instance into downstream loaders by passing `dashboardSpreadsheet` via each loader call to `loadPatientInfo`, `loadNotes`, `loadAIReports`, `loadTreatmentLogs`, `assignResponsibleStaff`, and `loadUnpaidAlerts`.
- Replace direct `dashboardGetSpreadsheet_()` calls inside loaders with `opts.dashboardSpreadsheet` usage (updated functions: `loadPatientInfo`, `loadNotesUncached_`, `loadAIReportsUncached_`, `loadTreatmentLogsUncached_`, `readUnpaidHistory_`, and `assignResponsibleStaff`).
- Add a perf check log output `"[perf-check] spreadsheetOpenCount=1"` and updated/added unit tests to assert propagation and single-open behavior.

### Testing
- Ran `node tests/dashboardGetDashboardData.test.js` and `node tests/dashboardGetDashboardDataOptions.test.js`, and both test files passed after updates that assert spreadsheet propagation and `spreadsheetOpenCount` logging.
- Attempted to run the broader test set via `npm test` but `package.json` is absent in this environment so that flow was not executed (`npm` failed with ENOENT). 
- Several dashboard tests (`dashboardLoadAIReports`, `dashboardLoadUnpaidAlerts`, `dashboardCacheKeyIsolation`, `dashboardReadAndCache`) could not be completed here due to a missing test dependency file `src/dashboard/utils/cacheUtils.js`, which is unrelated to the changes in this PR and prevented those test files from running in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c58a3a0bc8321a77d6c8b0b3c4b67)