### PR TITLE
施術記録の月切替ヘッダーUI改善（前月/当月の視覚化）

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -43,6 +43,14 @@
   .news-item[data-status="handover-reminder"]{ background:#fef3c7; border-left-color:#f59e0b; }
   .news-item[data-status="consent-doctor-report"]{ background:#ede9fe; border-left-color:#7c3aed; }
   .section-title{ font-weight:700; margin:8px 0 }
+  .treatment-list-header{ margin-bottom:8px; }
+  .treatment-list-header-top{ display:flex; align-items:center; justify-content:space-between; gap:8px; }
+  .treatment-list-header-title{ font-weight:700; margin:0; }
+  .treatment-list-readonly-badge{ font-size:11px; padding:2px 8px; }
+  .treatment-list-month-row{ display:flex; align-items:center; justify-content:center; margin-top:4px; }
+  .treatment-list-month{ font-weight:700; font-size:1.05rem; letter-spacing:0.03em; }
+  .btn.outline{ background:transparent; border:1px solid #cbd5e1; color:#334155; padding:5px 10px; font-size:12px; transition:background-color .15s ease, border-color .15s ease, color .15s ease; }
+  .btn.outline:hover{ background:#f8fafc; border-color:#94a3b8; color:#0f172a; }
   .btnrow{ display:flex; gap:8px; flex-wrap:wrap; align-items:center }
   .save-button-group{ display:flex; flex-direction:column; gap:8px; }
   .save-button-row{ display:flex; flex-wrap:wrap; gap:8px; }
@@ -188,9 +196,17 @@
 
       <!-- 当月の施術記録 -->
       <div class="card">
-        <div class="section-title" id="treatmentListTitle">当月の施術記録（この患者）</div>
+        <div class="treatment-list-header">
+          <div class="treatment-list-header-top">
+            <p class="treatment-list-header-title">施術記録</p>
+            <span id="treatmentReadOnlyBadge" class="badge treatment-list-readonly-badge" style="display:none">閲覧専用</span>
+          </div>
+          <div class="treatment-list-month-row">
+            <div id="treatmentListTitle" class="treatment-list-month">＜ 0000年00月 ＞</div>
+          </div>
+        </div>
         <div style="margin:6px 0 8px">
-          <a href="#" id="monthlyPrevLink" onclick="return onClickMonthlyPrev(event)">← 前月</a>
+          <button id="monthlyToggleBtn" class="btn outline" type="button" onclick="onClickMonthlyToggle(event)">前月を見る</button>
         </div>
         <div id="list"></div>
       </div>
@@ -3209,20 +3225,25 @@ function isTreatmentViewCurrentMonth(){
 
 function updateTreatmentListTitle(){
   const titleEl = q('treatmentListTitle');
+  const isCurrentMonth = isTreatmentViewCurrentMonth();
   if (titleEl) {
     const month = resolveTreatmentViewMonth(_treatmentViewMonthOffset);
-    titleEl.textContent = `当月の施術記録（この患者）${formatTreatmentViewMonthLabel(month)}`;
+    titleEl.textContent = `＜ ${formatTreatmentViewMonthLabel(month)} ＞`;
   }
-  const prevLink = q('monthlyPrevLink');
-  if (prevLink) {
-    prevLink.style.display = isTreatmentViewCurrentMonth() ? '' : 'none';
+  const toggleBtn = q('monthlyToggleBtn');
+  if (toggleBtn) {
+    toggleBtn.textContent = isCurrentMonth ? '前月を見る' : '当月に戻る';
+  }
+  const readOnlyBadge = q('treatmentReadOnlyBadge');
+  if (readOnlyBadge) {
+    readOnlyBadge.style.display = isCurrentMonth ? 'none' : 'inline-block';
   }
 }
 
-function onClickMonthlyPrev(event){
+function onClickMonthlyToggle(event){
   if (event && typeof event.preventDefault === 'function') event.preventDefault();
   if (!pid()) return false;
-  _treatmentViewMonthOffset -= 1;
+  _treatmentViewMonthOffset = isTreatmentViewCurrentMonth() ? -1 : 0;
   refresh();
   return false;
 }


### PR DESCRIPTION
### Motivation
- 施術記録カードの月表示が分かりにくいため、上段に固定タイトル・下段に強調された月表示を導入して前月/当月の状態を視覚的に明確化する。
- UIは最小変更で済ませ、既存の `monthOffset` ロジックとデータ取得は変更しない制約に従う。

### Description
- `src/app.html` の施術記録カードヘッダーを2段構成に変更し、上段にタイトル `施術記録`、下段中央に `＜ YYYY年MM月 ＞` を表示するようにした。
- テキストリンクの「前月」を小型アウトラインボタン `#monthlyToggleBtn` に置き換え、ホバー時の軽微な視覚変化を CSS で追加した（`.btn.outline`）。
- 当月表示時はボタンが `前月を見る`、前月表示時は `当月に戻る` とトグルし、表示中が前月のときのみ `閲覧専用` バッジ `#treatmentReadOnlyBadge` を表示するロジックを追加した。
- 月移動挙動は既存の `_treatmentViewMonthOffset` を使い、当月(0) ⇔ 前月(-1) のトグルに制限してデータ取得ロジックは変更していない。

### Testing
- `git diff --check` を実行して差分の問題がないことを確認済み（成功）。
- 開発静的サーバーを `python3 -m http.server 4173` で起動してページを配信できることを確認済み（成功）。
- Playwright を使って `http://127.0.0.1:4173/src/app.html` を開きスクリーンショットを取得してレンダリングの目視確認を行った（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c5c7a7fb083219d033d87940aa8b2)