### PR TITLE
Fix dashboard invoice summary not rendering for previous-month-only patients

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -192,23 +192,28 @@ function getDashboardData(options) {
     meta.setupIncomplete = warningState.setupIncomplete;
     logContext('getDashboardData:setupIncomplete', `result=${meta.setupIncomplete} warnings=${warningState.warnings.length}`);
 
+    const overview = buildDashboardOverview_({
+      tasks: filteredTasks,
+      visits: filteredVisits,
+      patients,
+      patientInfo,
+      treatmentLogs,
+      invoices,
+      notes,
+      user: meta.user,
+      now: opts.now,
+      allowedPatientIds: displayTargets.patientIds
+    });
+    const invoiceUnconfirmed = overview && overview.invoiceUnconfirmed ? overview.invoiceUnconfirmed : { count: 0, items: [] };
+    logContext('getDashboardData:overviewInvoiceUnconfirmed', `count=${Number(invoiceUnconfirmed.count) || 0} items.length=${Array.isArray(invoiceUnconfirmed.items) ? invoiceUnconfirmed.items.length : 0}`);
+
     return {
       tasks: filteredTasks,
       todayVisits: filteredVisits,
       patients,
       unpaidAlerts: filteredAlerts,
       warnings: warningState.warnings,
-      overview: buildDashboardOverview_({
-        tasks: filteredTasks,
-        visits: filteredVisits,
-        patients,
-        patientInfo,
-        treatmentLogs,
-        invoices,
-        user: meta.user,
-        now: opts.now,
-        allowedPatientIds: displayTargets.patientIds
-      }),
+      overview,
       meta
     };
   } catch (err) {
@@ -330,6 +335,7 @@ function buildDashboardOverview_(params) {
   const user = payload.user || '';
   const allowedPatientIds = payload.allowedPatientIds instanceof Set ? payload.allowedPatientIds : null;
   const scope = { patientIds: allowedPatientIds, applyFilter: !!allowedPatientIds };
+  const invoiceScope = { patientIds: null, applyFilter: false };
 
   const patientNameMap = {};
   patients.forEach(entry => {
@@ -348,7 +354,7 @@ function buildDashboardOverview_(params) {
     invoices,
     treatmentLogs,
     payload.notes,
-    scope,
+    invoiceScope,
     patientNameMap,
     now,
     tz

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -229,6 +229,41 @@ function testInvoiceUnconfirmedUsesPositiveConfirmationEvidence() {
   assert.strictEqual(result.items[0].patientId, '002');
 }
 
+function testInvoiceUnconfirmedIgnoresDisplayTargetFilter() {
+  const ctx = createContext({
+    Utilities: {
+      formatDate: (date, _tz, fmt) => {
+        const iso = new Date(date).toISOString();
+        if (fmt === 'yyyy-MM') return iso.slice(0, 7);
+        if (fmt === 'yyyy-MM-dd') return iso.slice(0, 10);
+        return iso;
+      }
+    }
+  });
+
+  const result = ctx.getDashboardData({
+    user: 'user@example.com',
+    now: new Date('2025-02-10T00:00:00Z'),
+    patientInfo: { patients: { '001': { name: '患者A' } }, warnings: [] },
+    notes: { notes: {}, warnings: [] },
+    aiReports: { reports: {}, warnings: [] },
+    invoices: { invoices: {}, warnings: [] },
+    treatmentLogs: {
+      logs: [
+        { patientId: '001', timestamp: new Date('2025-01-10T00:00:00Z'), dateKey: '2025-01-10', createdByEmail: 'user@example.com', staffKeys: { email: 'user@example.com', name: '', staffId: '' } }
+      ],
+      warnings: []
+    },
+    responsible: { responsible: {}, warnings: [] },
+    unpaidAlerts: { alerts: [], warnings: [] },
+    tasksResult: { tasks: [], warnings: [] },
+    visitsResult: { visits: [], warnings: [] }
+  });
+
+  assert.strictEqual(result.overview.invoiceUnconfirmed.count, 1, 'displayTarget が空でも①請求の対象を保持する');
+  assert.strictEqual(result.overview.invoiceUnconfirmed.items[0].patientId, '001');
+}
+
 function testErrorIsCapturedInMeta() {
   const ctx = createContext({
     loadPatientInfo: () => { throw new Error('boom'); }
@@ -309,6 +344,7 @@ function testWarningsAreDedupedAndSetupFlagged() {
   testStaffMatchingUsesEmailNameAndStaffIdWithLogs();
   testVisitSummaryUsesCountsForTodayAndRecentOneDay();
   testInvoiceUnconfirmedUsesPositiveConfirmationEvidence();
+  testInvoiceUnconfirmedIgnoresDisplayTargetFilter();
   testErrorIsCapturedInMeta();
   testSpreadsheetIsOpenedOnceAndPerfCheckIsLogged();
   testWarningsAreDedupedAndSetupFlagged();


### PR DESCRIPTION
### Motivation
- Patients with only previous-month treatment logs were excluded from the invoice summary because the invoice aggregation was accidentally scoped by `displayTargets` (which can be empty), causing 「①請求」 not to appear. 
- Add API diagnostics to make it easy to observe `overview.invoiceUnconfirmed` shape (`count` and `items.length`) when investigating this issue.

### Description
- Stop applying `displayTargets` when building the invoice overview by adding `invoiceScope = { patientIds: null, applyFilter: false }` and passing it to `buildOverviewFromInvoiceUnconfirmed_` so invoice aggregation is not filtered out by current-month display targets (file: `src/dashboard/api/getDashboardData.js`, functions `getDashboardData` and `buildDashboardOverview_`).
- Construct `overview` once and return it (instead of re-calling `buildDashboardOverview_`), and log `getDashboardData:overviewInvoiceUnconfirmed` with `count` and `items.length` for diagnostics (file: `src/dashboard/api/getDashboardData.js`, function `getDashboardData`).
- Add a regression test `testInvoiceUnconfirmedIgnoresDisplayTargetFilter` to `tests/dashboardGetDashboardData.test.js` to verify `overview.invoiceUnconfirmed` is produced even when `displayTargets` is empty.

### Testing
- Ran `node tests/dashboardGetDashboardData.test.js` and the full test suite in that file passed (output: "dashboardGetDashboardData tests passed").
- Executed a runtime invocation of `getDashboardData(...)` to print diagnostics and confirmed API output `count=1` and `items.length=1` after the change.
- Performed a front-end forced-render DOM check (simulated) that set `emptyText` to `①請求テスト表示` and confirmed DOM generation produced `innerText=①請求|①請求テスト表示` and children count `2`, validating the rendering path is exercised.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c67ec95f4832191dfd53541869a59)