### PR TITLE
Load previous-month treatment logs for invoice-unconfirmed detection

### DIFF
--- a/src/dashboard/data/loadTreatmentLogs.js
+++ b/src/dashboard/data/loadTreatmentLogs.js
@@ -81,6 +81,8 @@ function loadTreatmentLogsUncached_(options) {
   const tz = dashboardResolveTimeZone_();
   const now = dashboardCoerceDate_(opts.now) || new Date();
   const monthStart = dashboardStartOfMonth_(tz, now);
+  const previousMonthStart = new Date(monthStart.getTime());
+  previousMonthStart.setMonth(previousMonthStart.getMonth() - 1);
   const monthEnd = new Date(monthStart.getTime());
   monthEnd.setMonth(monthEnd.getMonth() + 1);
   const prevMonthEnd = dashboardEndOfPreviousMonth_(monthStart);
@@ -111,7 +113,7 @@ function loadTreatmentLogsUncached_(options) {
   for (let i = 0; i < dateValues.length; i++) {
     const timestamp = dashboardParseTimestamp_(dateValues[i][0] || dateDisplayValues[i][0]);
     if (!timestamp) continue;
-    if (timestamp < monthStart || timestamp >= monthEnd) continue;
+    if (timestamp < previousMonthStart || timestamp >= monthEnd) continue;
     if (startDataIndex < 0) startDataIndex = i;
     endDataIndex = i;
   }
@@ -168,7 +170,7 @@ function loadTreatmentLogsUncached_(options) {
       warnings.push(`施術日時を解釈できません (row:${rowNumber})`);
       continue;
     }
-    if (timestamp < monthStart || timestamp >= monthEnd) {
+    if (timestamp < previousMonthStart || timestamp >= monthEnd) {
       continue;
     }
 


### PR DESCRIPTION
### Motivation
- `prevMonthPatientIds` was always empty because `loadTreatmentLogsUncached_` only loaded the current month, so patients with treatments only in the previous month could not be detected. 
- The fix needs to expand the fetch window to include the previous month without changing invoice business logic or month-key comparisons. 

### Description
- Compute `previousMonthStart` and change the filter in `loadTreatmentLogsUncached_` to `timestamp >= previousMonthStart && timestamp < monthEnd` so the range is previous-month-first-day through current-month-end. 
- Remove the temporary debug logs previously added to `buildOverviewFromInvoiceUnconfirmed_`. 
- Add a test `testInvoiceUnconfirmedShouldDetectPatientWithOnlyPreviousMonthTreatment` in `tests/dashboardGetDashboardData.test.js` that asserts a patient with only a previous-month treatment appears in `overview.invoiceUnconfirmed`.

### Testing
- Ran `node tests/dashboardGetDashboardData.test.js`, and the updated dashboard tests passed. 
- Ran `node tests/dashboardCacheKeyIsolation.test.js`, which failed due to a missing file `src/dashboard/utils/cacheUtils.js` that is unrelated to this change. 
- Verified that the new test asserts `overview.invoiceUnconfirmed.count === 1` for a patient with only a previous-month treatment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c68f88b4c83218a100aea0c406a6e)