### PR TITLE
Unify dashboard display scope and apply visiblePatientIds upstream

### DIFF
--- a/src/dashboard/api/getTasks.js
+++ b/src/dashboard/api/getTasks.js
@@ -6,6 +6,7 @@
  * @param {Object} [options.aiReports] - loadAIReports() の戻り値を差し替える際に利用。
  * @param {Object<string, boolean>} [options.invoiceConfirmations] - 請求書確認フラグを患者ID単位で差し込む。
  * @param {Date} [options.now] - テスト用に現在日時を差し替え。
+ * @param {Set<string>} [options.visiblePatientIds] - 表示対象患者ID。null の場合は全件。
  * @return {{tasks: Object[], warnings: string[]}}
  */
 function getTasks(options) {
@@ -18,6 +19,7 @@ function getTasks(options) {
   const notesResult = opts.notes || (typeof loadNotes === 'function' ? loadNotes() : null);
   const aiReports = opts.aiReports || (typeof loadAIReports === 'function' ? loadAIReports() : null);
   const invoiceConfirmations = opts.invoiceConfirmations || {};
+  const visiblePatientIds = opts.visiblePatientIds && typeof opts.visiblePatientIds.has === 'function' ? opts.visiblePatientIds : null;
 
   const warnings = [];
   if (patientInfo && Array.isArray(patientInfo.warnings)) warnings.push.apply(warnings, patientInfo.warnings);
@@ -40,6 +42,7 @@ function getTasks(options) {
     const patient = patients[pid] || {};
     const normalized = dashboardNormalizePatientId_(pid);
     if (!normalized) return;
+    if (visiblePatientIds && !visiblePatientIds.has(normalized)) return;
     const name = patient.name || patient.patientName || '';
 
     // 同意書期限

--- a/tests/dashboardGetDashboardDataOptions.test.js
+++ b/tests/dashboardGetDashboardDataOptions.test.js
@@ -61,6 +61,8 @@ function testOptionsArePropagated() {
   assert.strictEqual(seen.unpaidAlerts.patientInfo, patientInfo, '未回収アラートに患者情報が伝搬する');
   assert.strictEqual(seen.unpaidAlerts.now, now, '未回収アラートに now が伝搬する');
   assert.strictEqual(seen.unpaidAlerts.cache, false, '未回収アラート読み込みも cache:false を受け取る');
+  assert.ok(seen.unpaidAlerts.visiblePatientIds instanceof Set, '未回収アラートに visiblePatientIds(Set) が伝搬する');
+  assert.strictEqual(seen.unpaidAlerts.visiblePatientIds.size, 0, '一致ログがないスタッフは visiblePatientIds が空集合になる');
 }
 
 (function run() {

--- a/tests/dashboardLoadUnpaidAlerts.test.js
+++ b/tests/dashboardLoadUnpaidAlerts.test.js
@@ -102,6 +102,26 @@ function testPatientIdIsResolvedFromName() {
   assert.strictEqual(result.alerts[0].patientName, '山田太郎');
 }
 
+
+function testVisiblePatientIdsFiltersAlerts() {
+  const sheet = createSheet([
+    ['001', '2024-01-10', 10000, '確認中', '', '2024-02-05T00:00:00Z'],
+    ['001', '2023/12/01', 20000, '', '', '2024-01-10T00:00:00Z'],
+    ['001', '2023-11-01', 30000, '', '', '2023-12-05T00:00:00Z'],
+    ['002', '2024-01-10', 7000, '', '', '2024-02-05T00:00:00Z'],
+    ['002', '2023/12/01', 8000, '', '', '2024-01-10T00:00:00Z'],
+    ['002', '2023-11-01', 9000, '', '', '2023-12-05T00:00:00Z']
+  ]);
+  const ctx = createContext(sheet);
+  const result = ctx.loadUnpaidAlerts({
+    visiblePatientIds: new Set(['001']),
+    patientInfo: { patients: { '001': { name: '山田太郎' }, '002': { name: '佐藤花子' } }, warnings: [] }
+  });
+
+  assert.strictEqual(result.alerts.length, 1);
+  assert.strictEqual(result.alerts[0].patientId, '001');
+}
+
 function testMissingSheetProducesWarning() {
   const workbook = { getSheetByName: () => null };
   const context = createContext(null);
@@ -115,6 +135,7 @@ function testMissingSheetProducesWarning() {
 
 (function run() {
   testConsecutiveUnpaidAlertsAreCollected();
+  testVisiblePatientIdsFiltersAlerts();
   testMissingSheetProducesWarning();
   testPatientIdIsResolvedFromName();
   console.log('dashboardLoadUnpaidAlerts tests passed');


### PR DESCRIPTION
### Motivation
- Separate display-scope concern from aggregation logic by computing a single `visiblePatientIds` in `getDashboardData` and passing it to downstream loaders, preventing post-hoc filtering and future inconsistencies. 
- Ensure admin detection is explicit and staff visibility is based on staff-matched treatment logs within the last 50 days.

### Description
- Compute `isAdmin = Boolean(user && user.role === 'admin')` and build `responsiblePatientIds` from `staffMatchedLogs` with timestamps within 50 days, then set `visiblePatientIds = isAdmin ? null : responsiblePatientIds` in `getDashboardData`.
- Pass `visiblePatientIds` into `getTasks`, `getTodayVisits`, `loadUnpaidAlerts`, and `buildDashboardPatients_` so each function limits candidates up-front instead of filtering later. 
- Add `visiblePatientIds` parameter handling inside `getTasks`, `getTodayVisits`, and `loadUnpaidAlerts` (and `buildUnpaidAlerts_`), and update `buildDashboardPatients_` to accept an `allowedPatientIds` arg. 
- Remove post-return re-filtering of `tasks`, `todayVisits`, `unpaidAlerts`, and `patients`, and remove debug-only final visible-patient logs; preserve `overview.invoiceUnconfirmed` behavior by forwarding `allowedPatientIds` into overview builders.
- Update and add unit tests to verify admin full visibility, staff-scoped visibility (within 50 days), staff-no-recent-logs => zero, and that today+latest-past-day visit logic continues to work under visibility filtering.

### Testing
- Ran `node tests/dashboardTodayVisits.test.js`, `node tests/dashboardGetDashboardData.test.js`, and `node tests/dashboardGetDashboardDataOptions.test.js`, and those suites passed.
- Added/updated tests in `tests/dashboardGetDashboardData.test.js`, `tests/dashboardTodayVisits.test.js`, and `tests/dashboardLoadUnpaidAlerts.test.js` to cover the new scope propagation and behavior. 
- `tests/dashboardLoadUnpaidAlerts.test.js` currently could not be executed in one combined run in this environment due to a missing helper file (`src/dashboard/utils/cacheUtils.js`), causing a run-time file-not-found in this CI-like environment (the test itself verifies `visiblePatientIds` behavior and was added); static (`node --check`) checks completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d1cc48010832193a780e25d831e63)