### PR TITLE
Guard cache logging in non-GAS tests and invalidate monthly treatments cache on mutations

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3147,6 +3147,7 @@ function save(ev){
             resetFlags();
             setv('obs','');
             q('preset').selectedIndex = 0;
+            refresh();
             scheduleRefresh(700);
           }
         } finally {


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when cache helper logging runs outside Google Apps Script where `Logger` is unavailable.  
- Ensure monthly patient treatment lists refresh immediately after creating/updating/deleting records by invalidating month-scoped treatment cache keys.  
- Keep existing cache invalidation semantics and TTLs while adding targeted month-key invalidation to fix stale-list issues.  

### Description
- Add safe logging fallback in cache helpers so code uses `Logger.log` when available and falls back to `console.warn` or no-op checks when `Logger` is undefined.  
- Introduce `buildTreatmentsCacheKeyForMonth_`, `invalidateTreatmentsCacheForMonth_`, and `invalidateTreatmentsCacheForDate_` helpers to construct and remove month-scoped cache keys (format: `patient:treatments:<pid>:YYYYMM`).  
- Call `invalidateTreatmentsCacheForDate_` from `updateTreatmentRow`, `deleteTreatmentRow`, `updateTreatmentTimestamp`, and `submitTreatment` to explicitly clear the affected month cache after mutations.  
- Trigger an immediate `refresh()` in the frontend `save` success handler in addition to the existing `scheduleRefresh(700)` to prompt immediate list re-fetch and redraw.  

### Testing
- Ran `node tests/getPatientBundleCompat.test.js` and it passed.  
- Ran `node tests/updateTreatmentMonthGuard.test.js` and it passed.  
- Ran `node tests/treatmentListMonthFilter.test.js`, `node tests/treatmentListOrdering.test.js`, and `node tests/deleteTreatment.test.js` and all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dbeae515c832188d469001373dfb0)