### PR TITLE
施術保存後の反映を高速化 — 患者バンドル再取得をやめ一覧のみ更新

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3035,6 +3035,32 @@ function scheduleRefresh(delayMs){
   }, ms);
 }
 
+function refreshTreatmentListOnly(patientId, options){
+  const opts = options || {};
+  const done = typeof opts.done === 'function' ? opts.done : null;
+  const targetPid = patientId || pid();
+  if (!targetPid){
+    if (done) done();
+    return;
+  }
+  const month = getTreatmentViewMonthPayload();
+  google.script.run
+    .withSuccessHandler(rows => {
+      renderThisMonthList(rows, { patientId: targetPid, done });
+    })
+    .withFailureHandler(err => {
+      console.error('[refreshTreatmentListOnly] failed', err);
+      const msg = err && err.message ? err.message : String(err || '不明なエラー');
+      renderThisMonthList([], {
+        patientId: targetPid,
+        error: true,
+        errorMessage: `施術一覧の取得に失敗しました：${escapeHtml(msg)}`,
+        done
+      });
+    })
+    .listTreatmentsForMonth(targetPid, month.year, month.month);
+}
+
 function save(ev){
   let endTiming = () => {};
   const finalizeSave = () => {
@@ -3147,8 +3173,7 @@ function save(ev){
             resetFlags();
             setv('obs','');
             q('preset').selectedIndex = 0;
-            refresh();
-            scheduleRefresh(700);
+            refreshTreatmentListOnly(p);
           }
         } finally {
           finalizeSave();


### PR DESCRIPTION
### Motivation
- 現状は保存成功時に`refresh()`が呼ばれ`getPatientBundle`経由で患者ページ全体を再取得しており反映が遅い問題を解消するための変更です。 
- 既存の保存ロジック・データ構造・キャッシュ設計を変更せず、表示中の月だけを素早く更新することを目的としています。

### Description
- `src/app.html`に`refreshTreatmentListOnly(patientId, options)`を追加し、`getTreatmentViewMonthPayload()`で解決した`year/month`を使って`google.script.run.listTreatmentsForMonth(...)`のみを呼ぶようにしました。 
- 成功時は`renderThisMonthList`で施術一覧(`#list`)のみを再描画し、ヘッダー／News／レポート履歴の再取得は行わない仕様です。 
- `save()`の成功時の更新処理を、旧来の`refresh(); scheduleRefresh(700);`から`refreshTreatmentListOnly(p);`へ置き換えました。 
- 変更は該当の画面更新箇所に限定され、保存処理そのものやサーバ側ロジックは変更していません。

### Testing
- `node tests/treatmentListMonthFilter.test.js` を実行して成功を確認しました（テストはパスしました）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dc70c3fcc83219173aad61cacda0c)