### PR TITLE
Guard Utilities.formatDate input in getRecentActivity_ (add safeFormatDate_)

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -6847,10 +6847,20 @@ function getRecentActivity_(pid, options) {
   const stats = getTreatmentPatientStats_(pid);
   let lastTreat='';
   if (stats.lastTreatDate) {
-    lastTreat = Utilities.formatDate(stats.lastTreatDate, Session.getScriptTimeZone()||'Asia/Tokyo','yyyy-MM-dd');
+    lastTreat = safeFormatDate_(stats.lastTreatDate, 'yyyy-MM-dd');
   }
   const lastConsent = opts.lastConsent || '';
   return { lastTreat, lastConsent, lastStaff: '' };
+}
+
+function safeFormatDate_(value, format) {
+  if (value === null || typeof value === 'undefined' || value === '') return '';
+  const dateValue = value instanceof Date
+    ? value
+    : (typeof value === 'string' || typeof value === 'number' ? new Date(value) : null);
+  if (!(dateValue instanceof Date)) return '';
+  if (isNaN(dateValue.getTime())) return '';
+  return Utilities.formatDate(dateValue, Session.getScriptTimeZone() || 'Asia/Tokyo', format);
 }
 
 function getTreatmentPatientStats_(pid){


### PR DESCRIPTION
### Motivation
- Fix an exception where `Utilities.formatDate` was called with non-`Date` values in `getRecentActivity_`, causing "パラメータ（String,String,String）が Utilities.formatDate のメソッドのシグネチャと一致しません" errors when `stats.lastTreatDate` can be `string`/`null`/invalid.

### Description
- Replace the direct `Utilities.formatDate(stats.lastTreatDate, ...)` call in `getRecentActivity_` with a new `safeFormatDate_(value, format)` wrapper that returns `''` for `null`/`undefined`/`''`, accepts `Date` instances, converts `string`/`number` via `new Date(...)`, and returns `''` for invalid dates, otherwise delegating to `Utilities.formatDate`.

### Testing
- Ran targeted compatibility test `node --test tests/getPatientBundleCompat.test.js`, which passed.  
- Ran full suite `node --test tests/*.test.js` for visibility, which shows unrelated existing failures in other areas of the codebase and are outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dcb8ab5b48321b0be2b86a185cc4b)