### PR TITLE
施術録: `submitTreatment` で M列(月キー) を行データとして同時保存するよう変更

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -10820,11 +10820,10 @@ function submitTreatment(payload) {
       attendanceMetrics.convertedCount,
       attendanceMetrics.newPatientCount,
       attendanceMetrics.totalCount,
-      ''
+      '',
+      monthKey
     ];
     s.appendRow(row);
-    const appendedRowNumber = s.getLastRow();
-    s.getRange(appendedRowNumber, 13).setValue(monthKey);
     markTiming('appendRow');
 
     const job = { treatmentId, treatmentTimestamp: now };


### PR DESCRIPTION
### Motivation
- 施術録シートの M 列（13列目）に `monthKey` (YYYYMM) を正式導入し、保存時に確実に反映させることで既存データの整合性と今後の自動更新処理との整合を取るため。 

### Description
- `src/Code.js` の `submitTreatment` で新規行を作成する `row` 配列に `monthKey` を13列目として追加し、`appendRow` 時に同時に書き込むようにしました。 
- `appendRow` 後に別途 `getRange(...).setValue(monthKey)` で追記していた二段階書き込みを削除しました。 
- 既存の `buildMonthKeyFromDate_`、`updateTreatmentTimestamp`、`backfillMonthKey_` のロジックはそのまま維持し、挙動に影響を与えないようにしています。 

### Testing
- 実行した自動テスト: `node tests/monthKeyWrite.test.js` が成功しました。 
- 実行した自動テスト: `node tests/updateTreatmentMonthGuard.test.js` が成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dddafd49483218f0f5ab9c27fca3c)