### PR TITLE
Use monthKey (M column) index for listTreatmentsForMonth

### DIFF
--- a/tests/treatmentListOrdering.test.js
+++ b/tests/treatmentListOrdering.test.js
@@ -7,38 +7,38 @@ const code = fs.readFileSync(path.join(__dirname, '../src/Code.js'), 'utf8');
 
 const now = new Date();
 const makeDate = day => new Date(now.getFullYear(), now.getMonth(), day, 12, 0, 0);
+const monthKey = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}`;
 
 const treatmentRows = [
-  { ts: makeDate(5), pid: 'P001', note: 'newest', email: 'latest@example.com', treatmentId: 'T2', category: '30分施術（保険）' },
-  { ts: makeDate(2), pid: 'P001', note: 'older', email: 'older@example.com', treatmentId: 'T1', category: '60分施術（混合）' },
-  { ts: makeDate(1), pid: 'P002', note: 'other patient', email: 'other@example.com', treatmentId: 'X1', category: '30分施術（保険）' }
+  { ts: makeDate(5), pid: 'P001', note: 'newest', email: 'latest@example.com', treatmentId: 'T2', category: '30分施術（保険）', monthKey },
+  { ts: makeDate(2), pid: 'P001', note: 'older', email: 'older@example.com', treatmentId: 'T1', category: '60分施術（混合）', monthKey },
+  { ts: makeDate(1), pid: 'P002', note: 'other patient', email: 'other@example.com', treatmentId: 'X1', category: '30分施術（保険）', monthKey }
 ];
 
 const sheet = {
   getLastRow: () => treatmentRows.length + 1,
-  getRange: (row, col, numRows, numCols) => {
-    const accessor = idx => {
-      const record = treatmentRows[idx];
-      switch (col) {
-        case 1: return record.ts;
-        case 2: return record.pid;
-        case 3: return record.note;
-        case 4: return record.email;
-        case 7: return record.treatmentId;
-        case 8: return record.category;
-        default: return '';
-      }
-    };
-
-    const slice = [];
+  getRange: (row, col, numRows) => {
+    const values = [];
     for (let i = 0; i < numRows; i++) {
-      slice.push([accessor(i)]);
+      const record = treatmentRows[(row - 2) + i];
+      let value = '';
+      switch (col) {
+        case 1: value = record.ts; break;
+        case 2: value = record.pid; break;
+        case 3: value = record.note; break;
+        case 4: value = record.email; break;
+        case 7: value = record.treatmentId; break;
+        case 8: value = record.category; break;
+        case 13: value = record.monthKey; break;
+        default: value = '';
+      }
+      values.push([value]);
     }
-    const values = slice;
 
     return {
       getValues: () => values,
-      getDisplayValues: () => values.map(rowVals => rowVals.map(val => (val == null ? '' : String(val))))
+      getDisplayValues: () => values.map(rowVals => rowVals.map(val => (val == null ? '' : String(val)))),
+      setValues: () => {}
     };
   }
 };


### PR DESCRIPTION
### Motivation
- Improve performance of monthly treatment listing by avoiding wide sheet scans and using the existing `monthKey` stored in column M (13) as an index.
- Preserve the existing API/response shape and cache key semantics while reducing reads to only required rows and columns.

### Description
- Changed `listTreatmentsForMonth` to first read only column M (`s.getRange(2,13,rows,1)`) and collect row numbers whose `monthKey` equals `YYYYMM`.
- Group contiguous matching rows and fetch only the necessary columns (`A/B/C/D/G/H` equivalents) per group, backfilling missing `treatmentId` values per-group as before.
- Kept the response structure and sorting unchanged and preserved cache key design (`PATIENT_CACHE_KEYS.treatments(pid) + ':' + YYYYMM`).
- Added the performance log line in the requested format: `[perf][listTreatmentsForMonth] pid=xxx month=YYYYMM totalRows=... matchedRows=...`.

### Testing
- Ran `node tests/treatmentListMonthFilter.test.js` and verified month-key based selection and read-count expectations (passed).
- Ran `node tests/treatmentListOrdering.test.js` to confirm patient filtering and sort order are unchanged (passed).
- Ran `node tests/treatmentIdBackfill.test.js` to confirm missing `treatmentId` backfill and sheet write-back behavior (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ddf7a7d248321a4d051151032ea1e)