### PR TITLE
日時変更(updateTreatmentTimestamp)のUXを保存・削除と同等に統一

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1437,6 +1437,7 @@ let _saveInFlight = false;
 let _pendingSaveRequestId = null;
 let _pendingRefreshTimer = null;
 let _deleteInFlight = false;
+let _editTimeInFlight = false;
 
 function generateSaveRequestId(){
   if (window.crypto && typeof window.crypto.randomUUID === 'function'){
@@ -4241,6 +4242,10 @@ function applyConsentEdit(evt){
 
 /* 当月記録の日時編集 */
 function editRowTime(row, whenT){
+  if (_editTimeInFlight) {
+    toast('日時更新処理中です。完了までお待ちください');
+    return;
+  }
   const v = prompt('新しい日時を入力（例: 2025-09-04T14:30）', whenT || '');
   if (v == null) return;
   const curMonth = (new Date()).toISOString().slice(0,7);
@@ -4248,9 +4253,40 @@ function editRowTime(row, whenT){
   if (newMonth && newMonth !== curMonth) {
     if (!confirm('当月以外の日付に変更すると、この一覧からは見えなくなることがあります。続行しますか？')) return;
   }
+  const targetPatientId = pid();
+  const requestToken = _patientInfoRequestToken;
+  const editTimeButtons = Array.from(document.querySelectorAll('button[data-action="edit-time"]'));
+  const restoreButtons = () => {
+    editTimeButtons.forEach(btn => {
+      if (!btn || !btn.isConnected) return;
+      btn.disabled = false;
+      btn.textContent = btn.dataset.originalLabel || '日時';
+      delete btn.dataset.originalLabel;
+    });
+  };
+  editTimeButtons.forEach(btn => {
+    btn.disabled = true;
+    btn.dataset.originalLabel = btn.textContent || '日時';
+    btn.textContent = '更新中…';
+  });
+  _editTimeInFlight = true;
+  showGlobalLoading('日時を更新中です…');
   google.script.run
-    .withSuccessHandler(()=>{ refresh(); })
-    .withFailureHandler(e=> alert(e.message||e))
+    .withSuccessHandler(()=>{
+      toast('日時を更新しました');
+      loadTreatments(targetPatientId, { requestToken })
+        .finally(() => {
+          _editTimeInFlight = false;
+          hideGlobalLoading();
+          restoreButtons();
+        });
+    })
+    .withFailureHandler(e=>{
+      _editTimeInFlight = false;
+      hideGlobalLoading();
+      restoreButtons();
+      alert(e && e.message ? e.message : e);
+    })
     .updateTreatmentTimestamp(row, v);
 }
 /* === 申し送り：UI側実装（Drive保存はGAS側） === */


### PR DESCRIPTION
### Motivation
- `editRowTime`（日時変更）のUI挙動を保存・削除と同様に統一し、連続クリック防止・処理中表示・成功時の再読込を実装してUXを改善するため。

### Description
- `src/app.html` に `_editTimeInFlight` フラグを追加して処理中ガードを実装し、重複実行を抑止しました。 
- 日時変更開始時に `data-action="edit-time"` のボタン群を `disabled` にしてラベルを `更新中…` に変更し、`showGlobalLoading('日時を更新中です…')` を表示するようにしました。 
- 実行成功時に `toast('日時を更新しました')` を表示し、`refresh()` ではなく `loadTreatments(targetPatientId, { requestToken })` を呼び出してリストを再取得するように変更しました（既存の `requestToken` ロジックは維持）。 
- 失敗時はボタン復帰とローディング解除を行いエラーダイアログを表示する後始末処理を追加しました。 

### Testing
- ローカル HTTP サーバーを起動して `http://127.0.0.1:4173/src/app.html` にアクセスする環境を構築し、起動は成功しました。 
- Playwright によるページ表示確認とスクリーンショット取得（`page.goto('http://127.0.0.1:4173/src/app.html')` → スクリーンショット保存）が成功しました。 
- 変更した `src/app.html` の差分を確認して実装箇所を検証しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de8c4e4408321a018a969684711de)