### PR TITLE
Defer previous-month aggregation from initial `getPatientHeader` load

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -6936,9 +6936,6 @@ function getRecentActivity_(pid, options) {
   if (Array.isArray(opts.currentTreatments)) {
     treatmentRows.push.apply(treatmentRows, opts.currentTreatments);
   }
-  if (Array.isArray(opts.previousTreatments)) {
-    treatmentRows.push.apply(treatmentRows, opts.previousTreatments);
-  }
 
   let latestTimestamp = -Infinity;
   treatmentRows.forEach(row => {
@@ -7038,16 +7035,11 @@ function getPatientHeader(pid){
     const shareDisp = shareNorm ? toBurdenDisp_(shareNorm) : shareRaw;
 
     const monthContext = resolveYearMonthOrCurrent_();
-    const previousMonthContext = resolveYearMonthOrCurrent_(monthContext.year, monthContext.month - 1);
     const unit = APP.BASE_FEE_YEN || 4170;
 
     const tCurrent = Date.now();
     const currentTreatments = listTreatmentsForMonth(normalized, monthContext.year, monthContext.month);
     console.log('[perf] monthly.current 集計: ' + (Date.now() - tCurrent) + 'ms');
-
-    const tPrevious = Date.now();
-    const previousTreatments = listTreatmentsForMonth(normalized, previousMonthContext.year, previousMonthContext.month);
-    console.log('[perf] monthly.previous 集計: ' + (Date.now() - tPrevious) + 'ms');
 
     const monthlyStart = Date.now();
     const monthly = {
@@ -7056,16 +7048,15 @@ function getPatientHeader(pid){
         est: Math.round(currentTreatments.length * unit * 0.1)
       },
       previous: {
-        count: previousTreatments.length,
-        est: Math.round(previousTreatments.length * unit * 0.1)
+        count: null,
+        est: null
       }
     };
     console.log('[perf][getPatientHeader] monthly summary: ' + (Date.now() - monthlyStart) + 'ms');
     const tRecent = Date.now();
     const recent  = getRecentActivity_(pid, {
       lastConsent: consent || '',
-      currentTreatments,
-      previousTreatments
+      currentTreatments
     });
     console.log('[perf][getPatientHeader] recent optimized: ' + (Date.now() - tRecent) + 'ms');
     const statusStart = Date.now();

--- a/tests/getPatientHeaderMonthlySummary.test.js
+++ b/tests/getPatientHeaderMonthlySummary.test.js
@@ -47,19 +47,17 @@ const monthlyCalls = [];
 sandbox.listTreatmentsForMonth = (pid, year, month) => {
   monthlyCalls.push({ pid, year, month });
   if (year === 2025 && month === 3) return [{}, {}, {}];
-  if (year === 2025 && month === 2) return [{}];
   return [];
 };
 
 const header = sandbox.getPatientHeader('P001');
 
 assert.strictEqual(header.monthly.current.count, 3);
-assert.strictEqual(header.monthly.previous.count, 1);
+assert.strictEqual(header.monthly.previous.count, null);
 assert.strictEqual(header.monthly.current.est, Math.round(3 * 4170 * 0.1));
-assert.strictEqual(header.monthly.previous.est, Math.round(1 * 4170 * 0.1));
+assert.strictEqual(header.monthly.previous.est, null);
 assert.deepStrictEqual(monthlyCalls, [
-  { pid: 'P001', year: 2025, month: 3 },
-  { pid: 'P001', year: 2025, month: 2 }
+  { pid: 'P001', year: 2025, month: 3 }
 ]);
 
 console.log('getPatientHeader monthly summary tests passed');


### PR DESCRIPTION
### Motivation
- Improve initial render performance by removing expensive previous-month aggregation from `getPatientHeader` so only the current month is computed during initial load.
- Keep the API response shape unchanged while allowing the UI to load previous-month data lazily via existing month-based fetching.

### Description
- Removed the `previousTreatments = listTreatmentsForMonth(...)` call from `getPatientHeader` and eliminated the related previous-month perf logging in `src/Code.js`.
- Changed `monthly.previous` to return a placeholder `{ count: null, est: null }` while keeping `monthly.current` calculation intact using `currentTreatments.length`.
- Stopped passing `previousTreatments` into `getRecentActivity_` and removed the `previousTreatments` aggregation in `getRecentActivity_` so it only considers `currentTreatments`.
- Updated `tests/getPatientHeaderMonthlySummary.test.js` to reflect the deferred previous-month behavior and adjusted expected calls to `listTreatmentsForMonth`.

### Testing
- Ran `node tests/getPatientHeaderMonthlySummary.test.js` and it passed.
- Ran `node tests/treatmentListMonthFilter.test.js` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dededa56c8321a01bd9cf7faf0a7a)