### PR TITLE
Reduce submitTreatment duplicate/same-day scan window to 30 rows

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -11105,7 +11105,7 @@ function detectRecentDuplicateTreatment_(sheet, pid, note, nowDate, tz, ignoreTr
   const lr = sheet.getLastRow();
   if (lr < 2) return null;
 
-  const rowsToScan = Math.min(lr - 1, 100);
+  const rowsToScan = Math.min(lr - 1, 30);
   const startRow = Math.max(2, lr - rowsToScan + 1);
   const width = 13;
   console.log('[perf][submitTreatment] optimizedDuplicate rows=' + rowsToScan + ' startRow=' + startRow + ' lastRow=' + lr);
@@ -11162,9 +11162,9 @@ function findExistingTreatmentOnDate_(sheet, pid, targetDate, tz, ignoreTreatmen
 
   const maxCols = typeof sheet.getMaxColumns === 'function' ? sheet.getMaxColumns() : 13;
   const width = Math.min(TREATMENT_SHEET_HEADER.length, maxCols);
-  const rowsToScan = Math.min(lr - 1, 100);
+  const rowsToScan = Math.min(lr - 1, 30);
   const startRow = Math.max(2, lr - rowsToScan + 1);
-  console.log('[perf][submitTreatment] sameDayScan rows=' + rowsToScan + ' startRow=' + startRow + ' lastRow=' + lr);
+  console.log('[perf][submitTreatment] optimizedDuplicate rows=' + rowsToScan + ' scan=sameDay startRow=' + startRow + ' lastRow=' + lr);
   const values = sheet.getRange(startRow, 1, rowsToScan, width).getValues();
 
   const targetDateStr = Utilities.formatDate(targetDate, tz, 'yyyy-MM-dd');

--- a/tests/submitTreatmentScanOptimization.test.js
+++ b/tests/submitTreatmentScanOptimization.test.js
@@ -67,15 +67,15 @@ function createSheet(rows) {
       '202603'
     ]);
   }
-  rows[31] = [new Date('2026-03-15T11:59:30+09:00'), 'P001', '重複ノート', '', '', '', 'tid-target', '', '', '', '', '', '202603'];
+  rows[111] = [new Date('2026-03-15T11:59:30+09:00'), 'P001', '重複ノート', '', '', '', 'tid-target', '', '', '', '', '', '202603'];
 
   const sheet = createSheet(rows);
   const result = sandbox.detectRecentDuplicateTreatment_(sheet, 'P001', '重複ノート', base, 'Asia/Tokyo', '', '202603');
 
   assert.ok(result);
   assert.strictEqual(result.reason, 'recentContent');
-  assert.strictEqual(sheet.calls[0].numRows, 100);
-  assert.ok(logs.some(line => line.includes('[perf][submitTreatment] optimizedDuplicate rows=100')));
+  assert.strictEqual(sheet.calls[0].numRows, 30);
+  assert.ok(logs.some(line => line.includes('[perf][submitTreatment] optimizedDuplicate rows=30')));
 })();
 
 (function testFindExistingTreatmentOnDateUsesMonthKeyFilter() {
@@ -93,14 +93,15 @@ function createSheet(rows) {
     ]);
   }
   rows[80] = [new Date('2026-03-20T09:30:00+09:00'), 'P001', '他月', '', '', '', 'tid-wrong-month', '', '', '', '', '', '202602'];
-  rows[90] = [new Date('2026-03-20T10:30:00+09:00'), 'P001', '同日', '', '', '', 'tid-right', '', '', '', '', '', '202603'];
+  rows[130] = [new Date('2026-03-20T10:30:00+09:00'), 'P001', '同日', '', '', '', 'tid-right', '', '', '', '', '', '202603'];
 
   const sheet = createSheet(rows);
   const result = sandbox.findExistingTreatmentOnDate_(sheet, 'P001', base, 'Asia/Tokyo', '', '202603');
 
   assert.ok(result);
   assert.strictEqual(result.treatmentId, 'tid-right');
-  assert.strictEqual(sheet.calls[0].numRows, 100);
+  assert.strictEqual(sheet.calls[0].numRows, 30);
+  assert.ok(logs.some(line => line.includes('[perf][submitTreatment] optimizedDuplicate rows=30')));
 })();
 
 console.log('submit treatment scan optimization tests passed');


### PR DESCRIPTION
### Motivation
- The duplicate and same-day scans in `submitTreatment` were scanning up to 100 rows and causing performance overhead, so the window should be reduced to 30 rows while keeping monthKey filtering intact.

### Description
- Lowered the scan upper bound from 100 to 30 in `detectRecentDuplicateTreatment_` by changing `rowsToScan` to `Math.min(lr - 1, 30)`.
- Lowered the scan upper bound from 100 to 30 in `findExistingTreatmentOnDate_` by changing `rowsToScan` to `Math.min(lr - 1, 30)`.
- Kept `monthKey`-based filtering and return structures unchanged to preserve API behavior.
- Unified/updated performance logging so both paths emit the optimized format (e.g. `[perf][submitTreatment] optimizedDuplicate rows=<count>` and the same-day path includes `scan=sameDay`).
- Updated `tests/submitTreatmentScanOptimization.test.js` fixtures and expectations to reflect the 30-row window.

### Testing
- Ran `node tests/submitTreatmentScanOptimization.test.js` and it passed (prints `submit treatment scan optimization tests passed`).
- Ran `node tests/monthKeyWrite.test.js` and it passed (prints `month key write tests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698deeb817788321b02dd82960f18795)