### PR TITLE
Ensure News loading state is always cleared (handle success/failure/timeout/token mismatch)

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3506,12 +3506,37 @@ function loadNews(patientId, next){
 
   return new Promise(resolve => {
     let settled = false;
+    let finalized = false;
     const resolveOnce = value => {
       if (settled) return;
       settled = true;
       resolve(value);
     };
+    const finalizeNewsRender = (kind, list) => {
+      if (finalized) return;
+      finalized = true;
+      const safeList = Array.isArray(list) ? list : [];
+      const activeRequest = isActivePatientInfoRequest(requestToken);
+      if (kind === 'success') {
+        if (activeRequest) {
+          renderNewsList(safeList, { patientId: targetPid, isGlobalRequest, done });
+        } else {
+          renderNewsList([], { patientId: targetPid, isGlobalRequest, done });
+        }
+        return;
+      }
+      if (kind === 'failure') {
+        if (activeRequest) {
+          renderNewsList([], { patientId: targetPid, isGlobalRequest, error: true, done });
+        } else {
+          renderNewsList([], { patientId: targetPid, isGlobalRequest, done });
+        }
+        return;
+      }
+      renderNewsList([], { patientId: targetPid, isGlobalRequest, done });
+    };
     const timeoutId = setTimeout(() => {
+      finalizeNewsRender('timeout', []);
       resolveOnce([]);
     }, NEWS_RENDER_TIMEOUT_MS);
 
@@ -3519,18 +3544,14 @@ function loadNews(patientId, next){
       .withSuccessHandler(list => {
         clearTimeout(timeoutId);
         if (settled) return;
-        if (isActivePatientInfoRequest(requestToken)) {
-          renderNewsList(list, { patientId: targetPid, isGlobalRequest, done });
-        }
+        finalizeNewsRender('success', list);
         resolveOnce(list || []);
       })
       .withFailureHandler(err => {
         clearTimeout(timeoutId);
         if (settled) return;
         console.error('[loadNews] failed', err);
-        if (isActivePatientInfoRequest(requestToken)) {
-          renderNewsList([], { patientId: targetPid, isGlobalRequest, error: true, done });
-        }
+        finalizeNewsRender('failure', []);
         resolveOnce([]);
       })
       .getNews(targetPid);

--- a/tests/loadNewsTimeoutRender.test.js
+++ b/tests/loadNewsTimeoutRender.test.js
@@ -1,0 +1,68 @@
+// Manual verification (local HTML):
+// 1. Open src/app.html in Apps Script preview / local host where google.script.run is available.
+// 2. Trigger a patient switch rapidly so older getNews responses become token-mismatched.
+// 3. Confirm #news does not stay on "読み込み中…" after success/failure/timeout.
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const html = fs.readFileSync(path.join(__dirname, '../src/app.html'), 'utf8');
+const loadNewsMatch = html.match(/function loadNews\(patientId, next\)\{[\s\S]*?\n\}/);
+assert.ok(loadNewsMatch, 'loadNews should exist in app.html');
+
+const script = `${loadNewsMatch[0]}\nthis.loadNews = loadNews;`;
+
+async function runTimeoutCase() {
+  const newsEl = { innerHTML: '' };
+  let renderCalls = 0;
+  const context = {
+    NEWS_RENDER_TIMEOUT_MS: 5,
+    q: id => (id === 'news' ? newsEl : null),
+    pid: () => 'P001',
+    isActivePatientInfoRequest: () => true,
+    renderNewsList: (list) => {
+      renderCalls += 1;
+      newsEl.innerHTML = Array.isArray(list) && list.length
+        ? '<div>rendered</div>'
+        : '<div class="muted">Newsはありません</div>';
+    },
+    google: {
+      script: {
+        run: {
+          withSuccessHandler(handler) {
+            this._success = handler;
+            return this;
+          },
+          withFailureHandler(handler) {
+            this._failure = handler;
+            return this;
+          },
+          getNews() {
+            // Intentionally never resolves to trigger timeout path.
+          }
+        }
+      }
+    },
+    console,
+    setTimeout,
+    clearTimeout,
+    Promise
+  };
+
+  vm.createContext(context);
+  vm.runInContext(script, context);
+
+  await context.loadNews('P001', { requestToken: 'token-1' });
+
+  assert.ok(!newsEl.innerHTML.includes('読み込み中…'), 'timeout should clear loading message');
+  assert.strictEqual(renderCalls, 1, 'timeout should render exactly once');
+}
+
+runTimeoutCase().then(() => {
+  console.log('loadNews timeout render test passed');
+}).catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Fix a bug where the News area could remain showing “読み込み中…” when `loadNews` times out or when a response fails the `requestToken` guard.  
- Ensure every `loadNews` execution always transitions the UI out of the loading placeholder regardless of success/failure/timeout/token mismatch.  
- Preserve the `requestToken` guard semantics so stale responses are not rendered while still avoiding a stuck loading UI.

### Description
- Added a centralized `finalizeNewsRender(kind, list)` inside `loadNews` and a one-time `finalized` flag to guarantee UI finalization runs exactly once for each call.  
- `finalizeNewsRender` invokes `renderNewsList` with the fetched list when the request is active, otherwise it falls back to an empty list (or non-loading message) so token-mismatched responses don't re-enable loading.  
- Invoked `finalizeNewsRender` from success, failure, and timeout paths (timeout now calls `finalizeNewsRender('timeout', [])`).  
- Added a Node VM test `tests/loadNewsTimeoutRender.test.js` that simulates an unresolved `getNews` to assert timeout clears the loading UI exactly once, and included brief manual verification notes in the test file; updated `src/app.html` accordingly.

### Testing
- Ran `node tests/loadNewsTimeoutRender.test.js` which passed and asserts timeout clears the loading placeholder.  
- Re-ran `node tests/treatmentDeleteButtonTemplate.test.js` to ensure unrelated templates remain valid and it passed.  
- Both automated tests succeeded (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698df19d283c8321a05c6b09998e2b40)