### PR TITLE
Fix loadNews stale token rendering guard

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3517,20 +3517,15 @@ function loadNews(patientId, next){
       finalized = true;
       const safeList = Array.isArray(list) ? list : [];
       const activeRequest = isActivePatientInfoRequest(requestToken);
+      if (!activeRequest) {
+        return;
+      }
       if (kind === 'success') {
-        if (activeRequest) {
-          renderNewsList(safeList, { patientId: targetPid, isGlobalRequest, done });
-        } else {
-          renderNewsList([], { patientId: targetPid, isGlobalRequest, done });
-        }
+        renderNewsList(safeList, { patientId: targetPid, isGlobalRequest, done });
         return;
       }
       if (kind === 'failure') {
-        if (activeRequest) {
-          renderNewsList([], { patientId: targetPid, isGlobalRequest, error: true, done });
-        } else {
-          renderNewsList([], { patientId: targetPid, isGlobalRequest, done });
-        }
+        renderNewsList([], { patientId: targetPid, isGlobalRequest, error: true, done });
         return;
       }
       renderNewsList([], { patientId: targetPid, isGlobalRequest, done });

--- a/tests/loadNewsInactiveRequestRenderGuard.test.js
+++ b/tests/loadNewsInactiveRequestRenderGuard.test.js
@@ -1,0 +1,59 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const html = fs.readFileSync(path.join(__dirname, '../src/app.html'), 'utf8');
+const loadNewsMatch = html.match(/function loadNews\(patientId, next\)\{[\s\S]*?\n\}/);
+assert.ok(loadNewsMatch, 'loadNews should exist in app.html');
+
+const script = `${loadNewsMatch[0]}\nthis.loadNews = loadNews;`;
+
+async function runInactiveRequestCase() {
+  const newsEl = { innerHTML: '' };
+  let renderCalls = 0;
+  const context = {
+    NEWS_RENDER_TIMEOUT_MS: 100,
+    q: id => (id === 'news' ? newsEl : null),
+    pid: () => 'P001',
+    isActivePatientInfoRequest: () => false,
+    renderNewsList: () => {
+      renderCalls += 1;
+    },
+    google: {
+      script: {
+        run: {
+          withSuccessHandler(handler) {
+            this._success = handler;
+            return this;
+          },
+          withFailureHandler(handler) {
+            this._failure = handler;
+            return this;
+          },
+          getNews() {
+            setTimeout(() => this._success([{ title: 'new' }]), 0);
+          }
+        }
+      }
+    },
+    console,
+    setTimeout,
+    clearTimeout,
+    Promise
+  };
+
+  vm.createContext(context);
+  vm.runInContext(script, context);
+
+  await context.loadNews('P001', { requestToken: 'stale-token' });
+
+  assert.strictEqual(renderCalls, 0, 'inactive request should not render news list');
+}
+
+runInactiveRequestCase().then(() => {
+  console.log('loadNews inactive request render guard test passed');
+}).catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Stale `getNews` responses could overwrite a currently displayed news list with the empty-state text because `finalizeNewsRender` called `renderNewsList` even when the request token was no longer active.  
- The intent is to leave the DOM unchanged for inactive/mismatched requests while preserving existing `resolveOnce` and timeout semantics.  

### Description
- Updated `finalizeNewsRender` inside `loadNews` to compute `activeRequest` with `isActivePatientInfoRequest(requestToken)` and return early when it is false, before any `renderNewsList` calls, preventing stale responses from rendering.  
- Simplified the branch logic so `renderNewsList` is only invoked for active requests on `success`, `failure`, and `timeout` paths.  
- Added a focused unit test `tests/loadNewsInactiveRequestRenderGuard.test.js` that stubs `isActivePatientInfoRequest` to `false` and asserts `renderNewsList` is not called.  
- No server-side `getNews` changes, cache logic, or external dependencies were introduced.  

### Testing
- Ran `node tests/loadNewsTimeoutRender.test.js` and it passed.  
- Ran `node tests/loadNewsInactiveRequestRenderGuard.test.js` and it passed.  
- Manual behavior preserved: `resolveOnce` and timeout handling remain unchanged and loading indicator is cleared only for active requests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698df4278f00832189ca3ff43ebf0c19)