### PR TITLE
Restore parallel news loading in patient info retry flow

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3312,17 +3312,14 @@ function loadPatientInfoWithRetry(patientId, options){
   const jobs = [
     loadTreatments(targetPatientId, { requestToken }),
     loadHeader(targetPatientId, { requestToken }),
-    loadReports(targetPatientId, { requestToken })
+    loadReports(targetPatientId, { requestToken }),
+    loadNews(targetPatientId, { requestToken })
   ];
 
   return Promise.allSettled(jobs).finally(() => {
-    if (!isActivePatientInfoRequest(requestToken)) {
-      return;
+    if (isActivePatientInfoRequest(requestToken)) {
+      hideGlobalLoading();
     }
-    hideGlobalLoading();
-    setTimeout(() => {
-      loadNews(targetPatientId, { requestToken });
-    }, 0);
   });
 }
 


### PR DESCRIPTION
### Motivation
- `loadNews` was being deferred into a `finally` block and executed via `setTimeout`, which could be skipped when a `requestToken` became invalid and caused news to not render despite available rows.

### Description
- Restore `loadNews(targetPatientId, { requestToken })` to the `jobs` array inside `loadPatientInfoWithRetry` in `src/app.html` so it runs in parallel with other API calls.
- Remove the `setTimeout(() => loadNews(...))` call from the `Promise.allSettled(jobs).finally(...)` block and change the `finally` logic to only call `hideGlobalLoading()` when `isActivePatientInfoRequest(requestToken)` is true.
- Do not modify `loadNews` internals, `renderNewsList`, `requestToken` management, or `NEWS_CACHE_TTL_SECONDS`.

### Testing
- Ran `node --test tests/loadNewsInactiveRequestRenderGuard.test.js tests/loadNewsTimeoutRender.test.js` and both tests passed.
- Confirmed the change is implemented in `src/app.html` and validated by the automated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dfc7d02748321951e581382209048)