### PR TITLE
Add Critical patients panel to dashboard overview

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -69,6 +69,9 @@
   .alert-amount{ font-size:1.1rem; font-weight:800; color:#fbbf24; }
   .alert-months{ display:flex; gap:6px; flex-wrap:wrap; font-size:0.9rem; color:var(--muted); }
   .summary-card{ display:flex; flex-direction:column; gap:10px; }
+  .critical-list{ display:flex; flex-direction:column; gap:8px; }
+  .critical-item{ display:flex; justify-content:space-between; align-items:center; gap:10px; border:1px solid rgba(239,68,68,0.35); background:rgba(239,68,68,0.12); border-radius:10px; padding:10px 12px; }
+  .critical-reason{ color:#fecaca; font-size:0.9rem; }
   .summary-header{ display:flex; align-items:center; justify-content:space-between; gap:8px; }
   .summary-header h3{ margin:0; font-size:1rem; }
   .summary-count{ font-weight:700; font-size:1.1rem; color:#fff; }
@@ -108,6 +111,16 @@
       <div class="card summary-card" id="invoiceSummary"></div>
       <div class="card summary-card" id="consentSummary"></div>
       <div class="card summary-card" id="visitSummary"></div>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="section-header">
+      <h2>要対応患者</h2>
+      <span class="small" id="criticalPatientCount"></span>
+    </div>
+    <div class="card">
+      <div class="critical-list" id="criticalPatientList"></div>
     </div>
   </div>
 
@@ -221,6 +234,7 @@ function setLoading(flag) {
 function renderAll() {
   renderMeta();
   renderOverview();
+  renderCriticalPatients();
   renderUnpaidAlerts();
   renderVisits();
   renderPatients();
@@ -437,6 +451,45 @@ function renderUnpaidAlerts() {
     }
 
     list.appendChild(card);
+  });
+}
+
+function renderCriticalPatients() {
+  const list = document.getElementById('criticalPatientList');
+  const count = document.getElementById('criticalPatientCount');
+  if (!list) return;
+  list.innerHTML = '';
+
+  const overview = dashboardState.data && dashboardState.data.overview ? dashboardState.data.overview : {};
+  const criticalPatients = overview && overview.criticalPatients && Array.isArray(overview.criticalPatients.items)
+    ? overview.criticalPatients.items
+    : [];
+  if (count) count.textContent = criticalPatients.length ? `${criticalPatients.length}名` : '該当なし';
+
+  if (!criticalPatients.length) {
+    const empty = document.createElement('div');
+    empty.className = 'muted';
+    empty.textContent = '緊急対応が必要な患者はいません';
+    list.appendChild(empty);
+    return;
+  }
+
+  criticalPatients.forEach(item => {
+    const row = document.createElement('div');
+    row.className = 'critical-item';
+
+    const name = document.createElement(item.patientId ? 'a' : 'span');
+    name.className = item.patientId ? 'patient-name patient-link' : 'patient-name';
+    name.textContent = item.name || item.patientId || '氏名未登録';
+    if (item.patientId) configurePatientLinkElement_(name, item.patientId);
+    row.appendChild(name);
+
+    const reason = document.createElement('span');
+    reason.className = 'critical-reason';
+    reason.textContent = item.reason || '要確認';
+    row.appendChild(reason);
+
+    list.appendChild(row);
   });
 }
 

--- a/tests/dashboardCriticalPatientsRendering.test.js
+++ b/tests/dashboardCriticalPatientsRendering.test.js
@@ -1,0 +1,93 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const dashboardHtml = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard.html'), 'utf8');
+const scriptMatch = dashboardHtml.match(/<script>([\s\S]*?)<\/script>/);
+assert(scriptMatch, 'dashboard script block exists');
+
+const dashboardScript = scriptMatch[1]
+  .replace(/const DASHBOARD_TREATMENT_APP_EXEC_URL =[^\n]*\n/, 'var DASHBOARD_TREATMENT_APP_EXEC_URL = "";\n');
+
+function createElement(tagName) {
+  return {
+    tagName,
+    className: '',
+    textContent: '',
+    children: [],
+    style: {},
+    dataset: {},
+    appendChild(child) {
+      this.children.push(child);
+      return child;
+    },
+    set innerHTML(_value) {
+      this.children = [];
+    },
+    get innerHTML() {
+      return '';
+    },
+    addEventListener() {},
+    setAttribute(name, value) {
+      this[name] = value;
+    },
+    removeAttribute() {}
+  };
+}
+
+function createContext() {
+  const criticalPatientList = createElement('div');
+  const criticalPatientCount = createElement('div');
+
+  const context = {
+    console,
+    URLSearchParams,
+    treatmentAppExecUrl: 'https://script.google.com/macros/s/DEPLOY123/exec',
+    window: {
+      location: { search: '' },
+      open: () => {}
+    },
+    document: {
+      addEventListener: () => {},
+      createElement,
+      getElementById: (id) => {
+        if (id === 'criticalPatientList') return criticalPatientList;
+        if (id === 'criticalPatientCount') return criticalPatientCount;
+        return null;
+      }
+    }
+  };
+
+  vm.createContext(context);
+  vm.runInContext(dashboardScript, context);
+  return { context, criticalPatientList, criticalPatientCount };
+}
+
+(function testRenderCriticalPatientsShowsNameAndReasonWithNavigationLink() {
+  const { context, criticalPatientList, criticalPatientCount } = createContext();
+  vm.runInContext(`dashboardState.data = {
+    overview: {
+      criticalPatients: {
+        count: 2,
+        items: [
+          { patientId: '001', name: '患者A', reason: '同意期限超過' },
+          { patientId: '002', name: '患者B', reason: '報告書遅延' }
+        ]
+      }
+    }
+  };`, context);
+
+  context.renderCriticalPatients();
+
+  assert.strictEqual(criticalPatientCount.textContent, '2名');
+  assert.strictEqual(criticalPatientList.children.length, 2);
+  assert.strictEqual(criticalPatientList.children[0].children[0].textContent, '患者A');
+  assert.strictEqual(criticalPatientList.children[0].children[1].textContent, '同意期限超過');
+  assert.ok(
+    criticalPatientList.children[0].children[0].href.includes('?view=record&id=001'),
+    '患者名リンクは既存詳細画面に遷移できる形式'
+  );
+})();
+
+console.log('dashboard critical patients rendering tests passed');

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -107,6 +107,10 @@ function testAggregatesDashboardData() {
     consentExpiredCount: 1,
     reportDelayedCount: 0
   }, '優先度集計をoverviewへ含める');
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(result.overview.criticalPatients)), {
+    count: 1,
+    items: [{ patientId: '001', name: '山田太郎', reason: '同意期限超過' }]
+  }, 'Critical対象患者をoverviewへ含める');
 }
 
 
@@ -464,7 +468,7 @@ function testVisibleScopeForAdminShowsAllPatients() {
     now: new Date('2025-02-13T00:00:00Z'),
     patientInfo: { patients: { '001': { name: '患者A' }, '002': { name: '患者B' } }, warnings: [] },
     notes: { notes: {}, warnings: [] },
-    aiReports: { reports: {}, warnings: [] },
+    aiReports: { reports: { '001': '2024-07-01', '002': '2024-07-01' }, warnings: [] },
     invoices: { invoices: {}, warnings: [] },
     treatmentLogs: {
       logs: [
@@ -481,6 +485,7 @@ function testVisibleScopeForAdminShowsAllPatients() {
   assert.strictEqual(result.todayVisits.length, 2, '管理者は訪問全件表示する');
   assert.strictEqual(result.unpaidAlerts.length, 2, '管理者は未回収アラート全件表示する');
   assert.strictEqual(result.overview.invoiceUnconfirmed.count, 2, '管理者は請求未確認を全患者分表示する');
+  assert.strictEqual(result.overview.criticalPatients.count, 2, '管理者はCritical対象患者も全件表示する');
 }
 
 function testVisibleScopeForStaffWithin50DaysShowsMatchedPatientsOnly() {
@@ -518,7 +523,7 @@ function testVisibleScopeForStaffWithin50DaysShowsMatchedPatientsOnly() {
     now: new Date('2025-02-13T00:00:00Z'),
     patientInfo: { patients: { '001': { name: '患者A' }, '002': { name: '患者B' } }, warnings: [] },
     notes: { notes: {}, warnings: [] },
-    aiReports: { reports: {}, warnings: [] },
+    aiReports: { reports: { '001': '2024-07-01', '002': '2024-07-01' }, warnings: [] },
     invoices: { invoices: {}, warnings: [] },
     treatmentLogs: {
       logs: [
@@ -535,6 +540,7 @@ function testVisibleScopeForStaffWithin50DaysShowsMatchedPatientsOnly() {
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result.todayVisits.map(v => v.patientId))), ['001']);
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result.unpaidAlerts.map(a => a.patientId))), ['001']);
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result.overview.invoiceUnconfirmed.items.map(item => item.patientId))), ['001'], 'スタッフは請求未確認も担当患者のみ表示する');
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(result.overview.criticalPatients.items.map(item => item.patientId))), ['001'], 'スタッフはCritical対象患者も担当患者のみ表示する');
 }
 
 function testVisibleScopeForStaffOnlyOlderThan50DaysShowsNoPatients() {


### PR DESCRIPTION
### Motivation
- Provide a dedicated, easy-to-spot panel for truly critical patients (consent expiry overdue and report-delayed) so staff can quickly act on highest-priority cases described in the issue. 
- Keep existing navigation behavior, respect `visiblePatientIds` scope, and avoid breaking the current API shape and tests.

### Description
- Added `buildOverviewCriticalPatients_(patients)` in `src/dashboard/api/getDashboardData.js` that collects patients with `consent-expiry` (danger, priority=3) and `report` (priority=3) tags and returns `{ count, items }` sorted by name.
- Extended `buildDashboardOverview_` to include `overview.criticalPatients` alongside existing overview fields without removing or changing existing keys.
- Updated `src/dashboard.html` to add a new "要対応患者" section below the overview cards, new styles (`.critical-list`, `.critical-item`, `.critical-reason`), and a `renderCriticalPatients()` function wired into `renderAll()`; patient name links reuse existing `configurePatientLinkElement_` to navigate to the patient detail (`?view=record&id=...`).
- Tests: updated `tests/dashboardGetDashboardData.test.js` to assert `overview.criticalPatients` values and added `tests/dashboardCriticalPatientsRendering.test.js` to verify UI rendering and navigation link format.

### Testing
- Ran `node tests/dashboardGetDashboardData.test.js` and the suite passed (including added assertions for `overview.criticalPatients`).
- Ran `node tests/dashboardCriticalPatientsRendering.test.js` and it passed, validating UI rendering and patient link generation.
- Ran `node tests/dashboardNavigationLinks.test.js` and `node tests/dashboardPatientStatusTagsRendering.test.js` and both passed to ensure navigation logic and status tag rendering remain intact.
- Attempted a Playwright-based screenshot to visually verify the panel, but Chromium crashed in this environment (SIGSEGV); this did not affect the automated Node tests which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990666ff87883218c3fc0fcb07725cc)