### PR TITLE
Refactor dashboard patient row statuses to consent/report-only model

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -52,7 +52,6 @@
   .patient-name{ font-weight:700; letter-spacing:0.01em; }
   .status-tags{ display:flex; gap:6px; flex-wrap:wrap; }
   .status-tag{ display:inline-flex; align-items:center; padding:4px 10px; border-radius:999px; font-size:0.8rem; border:1px solid var(--border); color:var(--muted); background:rgba(255,255,255,0.04); }
-  .status-tag.tag-consent-expiry{ color:#fbbf24; background:rgba(245,158,11,0.14); border-color:rgba(245,158,11,0.32); }
   .status-tag.tag-consent{ color:#fdba74; background:rgba(249,115,22,0.14); border-color:rgba(249,115,22,0.32); }
   .status-tag.tag-report{ color:#fca5a5; background:rgba(239,68,68,0.14); border-color:rgba(239,68,68,0.32); }
   .patient-body{ border-top:1px solid var(--border); padding:12px 14px 14px; display:flex; flex-direction:column; gap:8px; background:rgba(255,255,255,0.02); }
@@ -312,7 +311,7 @@ function renderPatientStatusSummary() {
   reportRow.className = 'overview-metric';
   const reportLabel = document.createElement('span');
   reportLabel.className = 'overview-metric-label';
-  reportLabel.textContent = '報告書遅延件数';
+  reportLabel.textContent = '報告書未作成件数';
   const reportValue = document.createElement('span');
   reportValue.className = 'overview-metric-value';
   reportValue.textContent = `${data.reportDelayedCount || 0}件`;
@@ -568,12 +567,7 @@ function renderPatients() {
   list.innerHTML = '';
 
   const patients = dashboardState.data && Array.isArray(dashboardState.data.patients)
-    ? dashboardState.data.patients.slice().sort((a, b) => {
-      const aPriority = getPatientPriority_(a);
-      const bPriority = getPatientPriority_(b);
-      if (bPriority !== aPriority) return bPriority - aPriority;
-      return (a.name || '').localeCompare(b.name || '', 'ja');
-    })
+    ? dashboardState.data.patients.slice().sort((a, b) => (a.name || '').localeCompare(b.name || '', 'ja'))
     : [];
 
   if (count) count.textContent = patients.length ? `${patients.length}名` : '患者データなし';
@@ -602,12 +596,9 @@ function renderPatients() {
     if (Array.isArray(p.statusTags) && p.statusTags.length > 0) {
       const statusTags = document.createElement('div');
       statusTags.className = 'status-tags';
-      p.statusTags.slice().sort((a, b) => {
-        const diff = (Number(b && b.priority) || 0) - (Number(a && a.priority) || 0);
-        if (diff !== 0) return diff;
-        return String(a && a.label ? a.label : '').localeCompare(String(b && b.label ? b.label : ''), 'ja');
-      }).forEach(tag => {
+      p.statusTags.forEach(tag => {
         if (!tag || !tag.label || !tag.type) return;
+        if (tag.type !== 'consent' && tag.type !== 'report') return;
         const statusTag = document.createElement('span');
         statusTag.className = `status-tag tag-${tag.type}`;
         statusTag.textContent = tag.label;
@@ -618,28 +609,11 @@ function renderPatients() {
       }
     }
 
-    const tags = document.createElement('div');
-    tags.className = 'status-tags';
-
-    if (p.note && p.note.unread) {
-      const unread = document.createElement('span');
-      unread.className = 'tag';
-      unread.textContent = '未読報告書作成ヒント';
-      tags.appendChild(unread);
-    }
-    if (p.responsible) {
-      const resp = document.createElement('span');
-      resp.className = 'tag';
-      resp.textContent = p.responsible;
-      tags.appendChild(resp);
-    }
-    header.appendChild(tags);
     summary.appendChild(header);
 
     const meta = document.createElement('div');
     meta.className = 'meta-row';
     if (p.consentExpiry) meta.appendChild(makeBadge('同意期限: ' + p.consentExpiry));
-    if (p.aiReportAt) meta.appendChild(makeBadge('AI報告: ' + p.aiReportAt));
     if (p.invoiceUrl) meta.appendChild(makeBadge('請求書リンクあり'));
     summary.appendChild(meta);
 
@@ -693,16 +667,6 @@ function renderPatients() {
 
     list.appendChild(details);
   });
-}
-
-function getPatientPriority_(patient) {
-  const tags = Array.isArray(patient && patient.statusTags) ? patient.statusTags : [];
-  let max = 0;
-  tags.forEach(tag => {
-    const priority = Number(tag && tag.priority) || 0;
-    if (priority > max) max = priority;
-  });
-  return max;
 }
 
 function markNoteAsRead(patient) {

--- a/tests/dashboardPatientStatusTagsRendering.test.js
+++ b/tests/dashboardPatientStatusTagsRendering.test.js
@@ -71,7 +71,7 @@ function createContext() {
   const { context, patientList } = createContext();
   vm.runInContext(`dashboardState.data = {
     patients: [
-      { patientId: '1', name: 'あり', statusTags: [{ type: 'todo', label: '要対応' }] },
+      { patientId: '1', name: 'あり', statusTags: [{ type: 'consent', label: '遅延' }] },
       { patientId: '2', name: 'なし', statusTags: [] },
       { patientId: '3', name: '未定義' }
     ]
@@ -89,11 +89,11 @@ function createContext() {
   const withoutTagContainers = headerWithoutTag.children.filter((child) => child.className === 'status-tags');
   const withoutTagUndefinedContainers = headerWithoutTagUndefined.children.filter((child) => child.className === 'status-tags');
 
-  assert.strictEqual(withTagContainers.length, 2, 'patient with status tag has status-tag container and info tags container');
+  assert.strictEqual(withTagContainers.length, 1, 'patient with status tag has one status-tags container');
   assert.strictEqual(withTagContainers[0].children.length, 1, 'status tag container has one child');
 
-  assert.strictEqual(withoutTagContainers.length, 1, 'patient with empty statusTags only has info tags container');
-  assert.strictEqual(withoutTagUndefinedContainers.length, 1, 'patient without statusTags only has info tags container');
+  assert.strictEqual(withoutTagContainers.length, 0, 'patient with empty statusTags has no status-tags container');
+  assert.strictEqual(withoutTagUndefinedContainers.length, 0, 'patient without statusTags has no status-tags container');
 })();
 
 console.log('dashboard patient status tags rendering tests passed');


### PR DESCRIPTION
### Motivation

- Reduce complexity of patient row status display to a minimal two-tag model (`consent` / `report`) and remove secondary/info tags and priority-based behavior for a clearer dashboard.

### Description

- Simplified `buildDashboardPatientStatusTags_` (in `src/dashboard/api/getDashboardData.js`) to only emit `consent` and `report` tags and removed days-remaining, warning thresholds, priority and info tags; `consent` emits `期限超過` when expired or `遅延` when submission is pending before expiry, and `report` emits `未作成` only when a report is not present and consent has not been acquired/updated.
- Updated overview logic (`buildOverviewCriticalPatients_` and `buildOverviewFromPatientStatusTags_`) to derive critical items and counts from the simplified `consent`/`report` tags (`期限超過` for consent; presence of `report` for report counts).
- Changed patient list rendering (`src/dashboard.html`) to: remove priority-based sorting and `getPatientPriority_` usage, drop AI report badge/`aiReportAt`, drop responsible display and unread-hint chips, render `status-tags` container only when actual `consent`/`report` tags exist, and filter rendered tags to only `consent` and `report` (preserves array order so consent → report stays).
- Minor presentation updates in `src/dashboard.html` (CSS cleanup for removed tag type, and overview label changed to "報告書未作成件数").
- Tests updated to match the new model: `tests/dashboardGetDashboardData.test.js` and `tests/dashboardPatientStatusTagsRendering.test.js` now expect only `consent` and `report` tags and verify that report tags disappear after consent update.

### Testing

- Ran `node tests/dashboardGetDashboardData.test.js` and it passed.
- Ran `node tests/dashboardPatientStatusTagsRendering.test.js` and it passed.
- Ran `node tests/dashboardCriticalPatientsRendering.test.js` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699100832d5883218b19b2900f3ab29c)