### PR TITLE
test: enforce removal of priority summary from dashboard overview

### DIFF
--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -629,6 +629,29 @@ function testWarningsAreDedupedAndSetupFlagged() {
   assert.strictEqual(result.meta.setupIncomplete, true, 'セットアップ未完了フラグが伝搬する');
 }
 
+function testOverviewContainsOnlyThreeCardsPayload() {
+  const ctx = createContext();
+  const result = ctx.getDashboardData({
+    user: { email: 'user@example.com', role: 'admin' },
+    now: new Date('2025-02-01T00:00:00Z'),
+    patientInfo: { patients: { '001': { name: '患者A' } }, warnings: [] },
+    notes: { notes: {}, warnings: [] },
+    aiReports: { reports: {}, warnings: [] },
+    invoices: { invoices: {}, warnings: [] },
+    treatmentLogs: { logs: [], warnings: [] },
+    responsible: { responsible: {}, warnings: [] },
+    unpaidAlerts: { alerts: [], warnings: [] },
+    tasksResult: { tasks: [], warnings: [] },
+    visitsResult: { visits: [], warnings: [] }
+  });
+
+  const overview = result && result.overview ? JSON.parse(JSON.stringify(result.overview)) : {};
+  const keys = Object.keys(overview).sort();
+  assert.deepStrictEqual(keys, ['consentRelated', 'invoiceUnconfirmed', 'visitSummary'], 'overview は ①請求/②同意/③施術実績 の3項目のみ返す');
+  assert.strictEqual(Object.prototype.hasOwnProperty.call(overview, 'patientStatusSummary'), false, 'patientStatusSummary は返さない');
+  assert.strictEqual(Object.prototype.hasOwnProperty.call(overview, 'criticalPatients'), false, 'criticalPatients は返さない');
+}
+
 (function run() {
   testAggregatesDashboardData();
   testPatientStatusTagsGeneration();
@@ -644,5 +667,6 @@ function testWarningsAreDedupedAndSetupFlagged() {
   testErrorIsCapturedInMeta();
   testSpreadsheetIsOpenedOnceAndPerfCheckIsLogged();
   testWarningsAreDedupedAndSetupFlagged();
+  testOverviewContainsOnlyThreeCardsPayload();
   console.log('dashboardGetDashboardData tests passed');
 })();

--- a/tests/dashboardPatientStatusTagsRendering.test.js
+++ b/tests/dashboardPatientStatusTagsRendering.test.js
@@ -128,4 +128,13 @@ function createContext() {
   assert.ok(doneTag.className.includes('tag-report-done'), '作成済 should use done class');
 })();
 
+(function testOverviewSectionDoesNotContainPrioritySummary() {
+  assert.strictEqual(dashboardHtml.includes('優先度集計'), false, 'dashboard.html に「優先度集計」の文言を含めない');
+  assert.strictEqual(dashboardHtml.includes('patientStatusSummary'), false, 'patientStatusSummary の参照を含めない');
+  assert.strictEqual(dashboardHtml.includes('criticalPatients'), false, 'criticalPatients の参照を含めない');
+
+  const summaryCardIds = Array.from(dashboardHtml.matchAll(/class="card summary-card" id="([^"]+)"/g)).map(match => match[1]);
+  assert.deepStrictEqual(summaryCardIds, ['invoiceSummary', 'consentSummary', 'visitSummary'], 'overview 直下カードは①請求/②同意/③施術実績のみ');
+})();
+
 console.log('dashboard patient status tags rendering tests passed');


### PR DESCRIPTION
### Motivation
- Remove the dashboard "優先度集計" (priority aggregation) UI/API surface and prevent its accidental reintroduction by adding regression tests that detect any remaining references or fields.

### Description
- Added an API-level regression test to `tests/dashboardGetDashboardData.test.js` that asserts the returned `overview` contains only `invoiceUnconfirmed`, `consentRelated`, and `visitSummary`, and does not include `patientStatusSummary` or `criticalPatients`.
- Added an HTML/regression test to `tests/dashboardPatientStatusTagsRendering.test.js` that asserts `src/dashboard.html` does not contain the literal text `優先度集計` nor references to `patientStatusSummary`/`criticalPatients`, and that the overview grid only exposes `invoiceSummary`, `consentSummary`, and `visitSummary` cards.
- No runtime source code under `src/` was changed; this PR only introduces tests to lock the UI/API surface.

### Testing
- Ran `node tests/dashboardGetDashboardData.test.js`, which passed.
- Ran `node tests/dashboardPatientStatusTagsRendering.test.js`, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991146c84208321993c48ae4884f97f)