### PR TITLE
Remove [n件] badges from dashboard overview patient rows

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -657,12 +657,7 @@ function renderOverviewList_(items, emptyText) {
       title.className = 'overview-row-title';
       const name = document.createElement('span');
       name.textContent = item.name || item.patientId;
-      const count = document.createElement('span');
-      count.className = 'overview-count';
-      const displayCount = Math.max(1, Number(item.count) || 1);
-      count.textContent = `［${displayCount}件］`;
       title.appendChild(name);
-      title.appendChild(count);
       row.appendChild(title);
 
       const sub = document.createElement('div');

--- a/tests/dashboardPatientStatusTagsRendering.test.js
+++ b/tests/dashboardPatientStatusTagsRendering.test.js
@@ -32,6 +32,7 @@ function createElement(tagName) {
     },
     addEventListener() {},
     setAttribute() {},
+    classList: { add() {}, remove() {}, toggle() {} },
     get childElementCount() {
       return this.children.length;
     }
@@ -126,6 +127,18 @@ function createContext() {
 
   assert.ok(pendingTag.className.includes('tag-report-pending'), '未作成 should use pending class');
   assert.ok(doneTag.className.includes('tag-report-done'), '作成済 should use done class');
+})();
+
+(function testOverviewListDoesNotRenderCountText() {
+  const { context } = createContext();
+  const list = context.renderOverviewList_([
+    { patientId: '1', name: '患者A', count: 3, subText: '補足' }
+  ], '対象なし');
+
+  const title = list.children[0].children[0];
+  const titleTexts = title.children.map((child) => child.textContent);
+
+  assert.deepStrictEqual(titleTexts, ['患者A'], '患者名のみ表示し件数は表示しない');
 })();
 
 console.log('dashboard patient status tags rendering tests passed');


### PR DESCRIPTION
### Motivation
- The dashboard showed a redundant per-patient count badge (`［n件］`) next to patient names in overview lists which should be removed while preserving the underlying API `count` fields.

### Description
- Removed the count span creation and `item.count` display from `renderOverviewList_` in `src/dashboard.html` so overview rows show only patient names.
- Kept server/API payload shape intact (the `count` properties are still produced and available but not rendered in the UI).
- Added a unit test in `tests/dashboardPatientStatusTagsRendering.test.js` that asserts `renderOverviewList_` renders only the patient name and not the count text.
- Extended the test DOM element stub to include `classList` methods so `bindPatientRow_` works in the test environment.

### Testing
- Ran `node tests/dashboardPatientStatusTagsRendering.test.js` and it passed.
- Ran `node tests/dashboardTodayVisits.test.js` and it passed.
- Ran `node tests/dashboardNavigationLinks.test.js` and it passed.
- Attempted a browser-driven validation (Playwright) that opens `src/dashboard.html` and renders the overview, but the script failed because `dashboardState` was not defined on the served page, so no screenshot artifact was produced (this does not affect the unit test coverage).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69913c6241088321888260c902892ed8)