### PR TITLE
同意ブロック判定をconsentExpiry/consentAcquired基準に統一

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -500,7 +500,7 @@ function buildDashboardOverview_(params) {
     tz,
     patientInfo
   );
-  const consentRelated = buildOverviewFromConsent_(tasks, patientInfo, scope, patientNameMap, now, tz);
+  const consentRelated = buildOverviewFromConsent_(patientInfo, scope, patientNameMap, now);
   const visitSummary = buildOverviewFromTreatmentProgress_(treatmentLogs, user, now, tz);
   return {
     invoiceUnconfirmed,
@@ -636,58 +636,28 @@ function buildDashboardInvoiceSearchText_(entry) {
     .join('\n');
 }
 
-function buildOverviewFromConsent_(tasks, patientInfo, scope, patientNameMap, now, tz) {
+function buildOverviewFromConsent_(patientInfo, scope, patientNameMap, now) {
   const items = [];
-  const issuesByPatient = {};
   const allowedPatientIds = scope ? scope.patientIds : null;
   const applyFilter = scope ? scope.applyFilter : false;
-
-  (tasks || []).forEach(task => {
-    const pid = task && task.patientId ? String(task.patientId).trim() : '';
-    if (!pid || (applyFilter && allowedPatientIds && !allowedPatientIds.has(pid))) return;
-    const type = task && task.type ? String(task.type) : '';
-    if (type !== 'consentExpired' && type !== 'consentWarning') return;
-    const detail = task.detail ? String(task.detail) : '';
-    const label = type === 'consentExpired' ? '期限切れ' : '期限間近';
-    const message = detail ? `${label}: ${detail}` : label;
-    if (!issuesByPatient[pid]) issuesByPatient[pid] = [];
-    issuesByPatient[pid].push(message);
-  });
+  const targetNow = dashboardCoerceDate_(now) || new Date();
 
   Object.keys(patientInfo || {}).forEach(pid => {
     if (!pid || (applyFilter && allowedPatientIds && !allowedPatientIds.has(pid))) return;
     const info = patientInfo[pid] || {};
-    const consentHandout = resolvePatientRawValue_(info.raw, [
-      '配布', '配布欄', '配布状況', '配布日', '配布（同意書）', '同意書受渡', '同意書受け渡し', '同意書受渡日'
-    ]);
-    const consentDate = resolvePatientRawValue_(info.raw, [
-      '同意年月日', '同意日', '同意開始日', '同意開始'
-    ]);
-    const visitPlanDate = resolvePatientRawValue_(info.raw, [
-      '通院予定日', '通院日', '来院日', '通院予定', '来院予定'
-    ]);
+    const consentExpiry = info.consentExpiry || (info.raw && (info.raw['同意期限'] || info.raw['同意有効期限']));
+    const consentExpiryDate = dashboardParseTimestamp_(consentExpiry);
+    const consentAcquired = resolvePatientRawValue_(info.raw, ['同意書取得確認']);
+    if (consentAcquired || !consentExpiryDate) return;
 
-    if (consentHandout && !consentDate) {
-      if (!issuesByPatient[pid]) issuesByPatient[pid] = [];
-      issuesByPatient[pid].push('同意未取得');
-    }
-    if (consentHandout && !visitPlanDate) {
-      if (!issuesByPatient[pid]) issuesByPatient[pid] = [];
-      issuesByPatient[pid].push('通院日未定');
-    }
-  });
-
-  Object.keys(issuesByPatient).forEach(pid => {
-    const reasons = issuesByPatient[pid] || [];
-    if (!reasons.length) return;
-    const info = patientInfo[pid] || {};
+    const daysUntil = dashboardDaysBetween_(targetNow, consentExpiryDate, true);
+    const label = daysUntil <= 0 ? '期限超過' : '要対応';
     const name = info.name || patientNameMap[pid] || '';
-    const subText = reasons.join(' / ');
     items.push({
       patientId: pid,
       name,
-      count: Math.max(1, reasons.length),
-      subText
+      count: 1,
+      subText: label
     });
   });
 

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -163,6 +163,53 @@ function testPatientStatusTagsGeneration() {
   ], '5. 同意日更新後は新期限で要対応を再表示する');
 }
 
+function testConsentOverviewMatchesPatientStatusTags() {
+  const ctx = createContext();
+  const result = ctx.getDashboardData({
+    user: { email: 'user@example.com', role: 'admin' },
+    now: new Date('2025-02-01T00:00:00Z'),
+    patientInfo: {
+      patients: {
+        '001': { name: '期限内未取得', consentExpiry: '2025-02-20', raw: {} },
+        '002': { name: '期限超過未取得', consentExpiry: '2025-01-20', raw: {} },
+        '003': { name: '同意取得確認済', consentExpiry: '2025-02-20', raw: { '同意書取得確認': '済' } },
+        '004': { name: '期限未登録', raw: {} }
+      },
+      warnings: []
+    },
+    notes: { notes: {}, warnings: [] },
+    aiReports: { reports: {}, warnings: [] },
+    invoices: { invoices: {}, warnings: [] },
+    treatmentLogs: { logs: [], warnings: [] },
+    responsible: { responsible: {}, warnings: [] },
+    unpaidAlerts: { alerts: [], warnings: [] },
+    tasksResult: {
+      tasks: [
+        { patientId: '003', type: 'consentExpired', detail: 'legacy' },
+        { patientId: '004', type: 'consentWarning', detail: 'legacy' }
+      ],
+      warnings: []
+    },
+    visitsResult: { visits: [], warnings: [] }
+  });
+
+  const overviewItems = JSON.parse(JSON.stringify(result.overview.consentRelated.items));
+  assert.deepStrictEqual(overviewItems, [
+    { patientId: '002', name: '期限超過未取得', count: 1, subText: '期限超過' },
+    { patientId: '001', name: '期限内未取得', count: 1, subText: '要対応' }
+  ], '上段同意ブロックは consentExpiry + 同意書取得確認の判定だけで表示する');
+
+  const patientsById = {};
+  result.patients.forEach(entry => {
+    patientsById[entry.patientId] = JSON.parse(JSON.stringify(entry.statusTags));
+  });
+
+  assert.deepStrictEqual(patientsById['001'].filter(tag => tag.type === 'consent'), [{ type: 'consent', label: '要対応' }], 'Case1: 期限内・未取得');
+  assert.deepStrictEqual(patientsById['002'].filter(tag => tag.type === 'consent'), [{ type: 'consent', label: '期限超過' }], 'Case2: 期限超過・未取得');
+  assert.deepStrictEqual((patientsById['003'] || []).filter(tag => tag.type === 'consent'), [], 'Case3: 同意取得確認済');
+  assert.deepStrictEqual((patientsById['004'] || []).filter(tag => tag.type === 'consent'), [], 'Case4: 期限未登録');
+}
+
 function testStaffMatchingUsesEmailNameAndStaffIdWithLogs() {
   const logEntries = [];
   const ctx = createContext();
@@ -632,6 +679,7 @@ function testWarningsAreDedupedAndSetupFlagged() {
 (function run() {
   testAggregatesDashboardData();
   testPatientStatusTagsGeneration();
+  testConsentOverviewMatchesPatientStatusTags();
   testStaffMatchingUsesEmailNameAndStaffIdWithLogs();
   testVisitSummaryUsesCountsForTodayAndRecentOneDay();
   testInvoiceUnconfirmedUsesPositiveConfirmationEvidence();


### PR DESCRIPTION
### Motivation
- 上段の同意ブロック(`buildOverviewFromConsent_`)が `tasks` と配布/通院日ロジックに依存し、下段の `statusTags` 判定(`consentExpiry` + `同意書取得確認`)と母集団が一致していなかったため、判定軸を一本化する必要があった。

### Description
- `buildOverviewFromConsent_` を `tasks` 非依存に書き換え、直接 `patientInfo` を走査して判定するように変更した（呼び出し側も引数を `patientInfo, scope, patientNameMap, now` に更新）。
- 古い `consentExpired` / `consentWarning` タスク依存部分、`consentHandout` / `visitPlanDate` 等の配布・通院日ロジック、および handout 未取得/通院日未定の判定を削除した。
- 新ロジックは `consentAcquired` があればスキップ、`consentExpiry` が未登録ならスキップ、期限超過は `期限超過`、それ以外は `要対応` を `subText` にして患者単位で `count: 1` のアイテムを返す仕様にした。結果は名前順でソートして `{ count: items.length, items }` を返す。
- `buildDashboardPatientStatusTags_` は変更せず現行ロジック（`consentExpiry` + `同意書取得確認` に基づく `consent` タグ付与）を維持しているため、上段と下段の判定基準が一致するようになった。
- 変更ファイル: `src/dashboard/api/getDashboardData.js`、テスト追加: `tests/dashboardGetDashboardData.test.js`（上段/下段の整合性を検証するテストを追加）。

### Testing
- 実行した自動テスト: `node tests/dashboardGetDashboardData.test.js`.
- 結果: テストスイートは成功し `dashboardGetDashboardData tests passed` を出力した（追加したケースを含む）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991447a77988321aa4fdebec43dcd38)