### PR TITLE
上段3ブロックを2026-02-10設計へ完全準拠

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -288,45 +288,13 @@ function renderConsentSummary() {
 function renderVisitSummary() {
   const container = document.getElementById('visitSummary');
   if (!container) return;
-  container.innerHTML = '';
   const overview = dashboardState.data && dashboardState.data.overview ? dashboardState.data.overview : {};
-  const data = overview && overview.visitSummary ? overview.visitSummary : { todayCount: 0, recentOneDayCount: 0 };
-
-  const header = document.createElement('div');
-  header.className = 'summary-header';
-  const title = document.createElement('h3');
-  title.textContent = '③施術実績';
-  header.appendChild(title);
-  container.appendChild(header);
-
-  const metrics = document.createElement('div');
-  metrics.className = 'overview-metrics';
-
-  const todayRow = document.createElement('div');
-  todayRow.className = 'overview-metric';
-  const todayLabel = document.createElement('span');
-  todayLabel.className = 'overview-metric-label';
-  todayLabel.textContent = '今日';
-  const todayValue = document.createElement('span');
-  todayValue.className = 'overview-metric-value';
-  todayValue.textContent = `${data.todayCount || 0}件`;
-  todayRow.appendChild(todayLabel);
-  todayRow.appendChild(todayValue);
-  metrics.appendChild(todayRow);
-
-  const lastRow = document.createElement('div');
-  lastRow.className = 'overview-metric';
-  const lastLabel = document.createElement('span');
-  lastLabel.className = 'overview-metric-label';
-  lastLabel.textContent = '直近1日施術';
-  const lastValue = document.createElement('span');
-  lastValue.className = 'overview-metric-value';
-  lastValue.textContent = `${data.recentOneDayCount || 0}件`;
-  lastRow.appendChild(lastLabel);
-  lastRow.appendChild(lastValue);
-  metrics.appendChild(lastRow);
-
-  container.appendChild(metrics);
+  const data = overview && overview.visitSummary ? overview.visitSummary : { items: [] };
+  renderOverviewCard_(container, {
+    title: '③実績',
+    items: data.items || [],
+    emptyText: '対象者なし'
+  });
 }
 
 function renderUnpaidAlerts() {
@@ -790,19 +758,6 @@ function showNavigationError_(message) {
   if (!message) return;
   dashboardState.error = message;
   renderError();
-}
-function formatTaskLabel(type) {
-  switch(type) {
-    case 'consentExpired': return '同意書期限切れ';
-    case 'consentWarning': return '同意書期限間近';
-    case 'handoverDelayed':
-      // 一時対応: Issue #1449
-      // 表示上は非表示にするが、タスクデータ自体は保持して将来の再有効化に備える。
-      return DASHBOARD_SUPPRESS_HANDOVER_REMINDER_UI ? '' : '報告書作成ヒント未入力';
-    case 'aiReportDelayed': return '医師報告書遅延';
-    case 'invoiceUnconfirmed': return '請求書確認待ち';
-    default: return 'タスク';
-  }
 }
 function formatCurrency(amount) {
   const num = Number(amount) || 0;

--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -185,15 +185,7 @@ function getDashboardData(options) {
       : { alerts: [], warnings: [] })));
     logContext('getDashboardData:loadUnpaidAlerts', `alerts=${(unpaidAlertsResult && unpaidAlertsResult.alerts ? unpaidAlertsResult.alerts.length : 0)} warnings=${(unpaidAlertsResult && unpaidAlertsResult.warnings ? unpaidAlertsResult.warnings.length : 0)} setupIncomplete=${!!(unpaidAlertsResult && unpaidAlertsResult.setupIncomplete)}`);
 
-    const tasksResult = measureStep('getTasks', () => (opts.tasksResult || (typeof getTasks === 'function' ? getTasks({
-      patientInfo,
-      notes,
-      aiReports,
-      invoiceConfirmations: opts.invoiceConfirmations,
-      visiblePatientIds,
-      now: opts.now
-    }) : { tasks: [], warnings: [] })));
-    logContext('getDashboardData:getTasks', `tasks=${(tasksResult && tasksResult.tasks ? tasksResult.tasks.length : 0)} warnings=${(tasksResult && tasksResult.warnings ? tasksResult.warnings.length : 0)} setupIncomplete=${!!(tasksResult && tasksResult.setupIncomplete)}`);
+    const tasksResult = { tasks: [], warnings: [] };
 
     const visitsResult = measureStep('getTodayVisits', () => (opts.visitsResult || (typeof getTodayVisits === 'function' ? getTodayVisits({
       treatmentLogs,
@@ -222,7 +214,6 @@ function getDashboardData(options) {
       treatmentLogs,
       responsible,
       unpaidAlertsResult,
-      tasksResult,
       visitsResult
     ]);
 
@@ -230,7 +221,6 @@ function getDashboardData(options) {
     logContext('getDashboardData:setupIncomplete', `result=${meta.setupIncomplete} warnings=${warningState.warnings.length}`);
 
     const overview = buildDashboardOverview_({
-      tasks: tasksResult && tasksResult.tasks ? tasksResult.tasks : [],
       visits: visitsResult && visitsResult.visits ? visitsResult.visits : [],
       patients,
       patientInfo,
@@ -241,10 +231,10 @@ function getDashboardData(options) {
       now: opts.now,
       allowedPatientIds: visiblePatientIds
     });
-    const invoiceUnconfirmed = overview && overview.invoiceUnconfirmed ? overview.invoiceUnconfirmed : { count: 0, items: [] };
-    logContext('getDashboardData:overviewInvoiceUnconfirmed', `count=${Number(invoiceUnconfirmed.count) || 0} items.length=${Array.isArray(invoiceUnconfirmed.items) ? invoiceUnconfirmed.items.length : 0}`);
+    const invoiceUnconfirmed = overview && overview.invoiceUnconfirmed ? overview.invoiceUnconfirmed : { items: [] };
+    logContext('getDashboardData:overviewInvoiceUnconfirmed', `items.length=${Array.isArray(invoiceUnconfirmed.items) ? invoiceUnconfirmed.items.length : 0}`);
     return {
-      tasks: tasksResult && tasksResult.tasks ? tasksResult.tasks : [],
+      tasks: [],
       todayVisits: visitsResult && visitsResult.visits ? visitsResult.visits : [],
       patients,
       unpaidAlerts: unpaidAlertsResult && unpaidAlertsResult.alerts ? unpaidAlertsResult.alerts : [],
@@ -270,7 +260,6 @@ function getDashboardData(options) {
       'staffMatch処理',
       'assignResponsible',
       'loadUnpaidAlerts',
-      'getTasks',
       'getTodayVisits',
       'buildPatients'
     ];
@@ -463,7 +452,6 @@ function normalizeDashboardNote_(note, patientId) {
 
 function buildDashboardOverview_(params) {
   const payload = params || {};
-  const tasks = Array.isArray(payload.tasks) ? payload.tasks : [];
   const patients = Array.isArray(payload.patients) ? payload.patients : [];
   const patientInfo = payload.patientInfo && payload.patientInfo.patients ? payload.patientInfo.patients : {};
   const invoices = payload.invoices || {};
@@ -490,7 +478,6 @@ function buildDashboardOverview_(params) {
   });
 
   const invoiceUnconfirmed = buildOverviewFromInvoiceUnconfirmed_(
-    tasks,
     invoices,
     treatmentLogs,
     payload.notes,
@@ -501,7 +488,7 @@ function buildDashboardOverview_(params) {
     patientInfo
   );
   const consentRelated = buildOverviewFromConsent_(patientInfo, scope, patientNameMap, now);
-  const visitSummary = buildOverviewFromTreatmentProgress_(treatmentLogs, user, now, tz);
+  const visitSummary = buildOverviewFromTreatmentProgress_(treatmentLogs, user, now, tz, patientNameMap, scope, patientInfo);
   return {
     invoiceUnconfirmed,
     consentRelated,
@@ -509,7 +496,7 @@ function buildDashboardOverview_(params) {
   };
 }
 
-function buildOverviewFromInvoiceUnconfirmed_(tasks, invoices, treatmentLogs, notes, scope, patientNameMap, now, tz, patientInfo) {
+function buildOverviewFromInvoiceUnconfirmed_(invoices, treatmentLogs, notes, scope, patientNameMap, now, tz, patientInfo) {
   const items = [];
   const allowedPatientIds = scope ? scope.patientIds : null;
   const applyFilter = scope ? scope.applyFilter : false;
@@ -576,7 +563,6 @@ function buildOverviewFromInvoiceUnconfirmed_(tasks, invoices, treatmentLogs, no
     items.push({
       patientId: pid,
       name: patientNameMap[pid] || '',
-      count: 1,
       subText: `受渡未確認（対象月: ${previousMonthKey}）`
     });
   });
@@ -585,7 +571,7 @@ function buildOverviewFromInvoiceUnconfirmed_(tasks, invoices, treatmentLogs, no
   logBillingDebug(`pendingPatients count=${items.length}`, `sample=${JSON.stringify(pendingSample)}`);
 
   items.sort((a, b) => (a.name || '').localeCompare(b.name || '', 'ja'));
-  return { count: items.length, items };
+  return { items };
 }
 
 function isDashboardMedicalAssistancePatient_(patientInfo, patientId) {
@@ -650,19 +636,22 @@ function buildOverviewFromConsent_(patientInfo, scope, patientNameMap, now) {
     const consentAcquired = resolvePatientRawValue_(info.raw, ['同意書取得確認']);
     if (consentAcquired || !consentExpiryDate) return;
 
-    const daysUntil = dashboardDaysBetween_(targetNow, consentExpiryDate, true);
-    const label = daysUntil <= 0 ? '期限超過' : '要対応';
+    const todayStart = new Date(targetNow.getFullYear(), targetNow.getMonth(), targetNow.getDate());
+    const expiryStart = new Date(consentExpiryDate.getFullYear(), consentExpiryDate.getMonth(), consentExpiryDate.getDate());
+    const diffDays = Math.floor((expiryStart.getTime() - todayStart.getTime()) / (24 * 60 * 60 * 1000));
+    const label = diffDays >= 0
+      ? `要対応（残${diffDays}日）`
+      : `期限超過（${Math.abs(diffDays)}日超過）`;
     const name = info.name || patientNameMap[pid] || '';
     items.push({
       patientId: pid,
       name,
-      count: 1,
       subText: label
     });
   });
 
   items.sort((a, b) => (a.name || '').localeCompare(b.name || '', 'ja'));
-  return { count: items.length, items };
+  return { items };
 }
 
 function resolvePatientRawValue_(raw, candidates) {
@@ -678,29 +667,64 @@ function resolvePatientRawValue_(raw, candidates) {
   return '';
 }
 
-function buildOverviewFromTreatmentProgress_(treatmentLogs, user, now, tz) {
+function buildOverviewFromTreatmentProgress_(treatmentLogs, user, now, tz, patientNameMap, scope, patientInfo) {
   const targetNow = dashboardCoerceDate_(now) || new Date();
   const todayKey = dashboardFormatDate_(targetNow, tz, 'yyyy-MM-dd');
   const normalizedUser = dashboardNormalizeEmail_(user || '');
+  const allowedPatientIds = scope && scope.patientIds ? scope.patientIds : null;
+  const applyFilter = !!(scope && scope.applyFilter);
+  const patientStates = {};
+
+  Object.keys(patientInfo || {}).forEach(pid => {
+    if (!pid || (applyFilter && allowedPatientIds && !allowedPatientIds.has(pid))) return;
+    patientStates[pid] = {
+      patientId: pid,
+      name: patientNameMap && patientNameMap[pid] ? patientNameMap[pid] : ((patientInfo[pid] && patientInfo[pid].name) || ''),
+      hasTodayTreatment: false,
+      lastOwnTreatmentDate: ''
+    };
+  });
+
   const filtered = (treatmentLogs || []).filter(entry => {
     if (!normalizedUser) return true;
     const entryEmail = dashboardNormalizeEmail_(entry && entry.createdByEmail ? entry.createdByEmail : '');
     return entryEmail && entryEmail === normalizedUser;
   });
 
-  const countsByDate = {};
   filtered.forEach(entry => {
+    const pid = dashboardNormalizePatientId_(entry && entry.patientId);
+    if (!pid) return;
+    if (applyFilter && allowedPatientIds && !allowedPatientIds.has(pid)) return;
     const key = entry && entry.dateKey ? String(entry.dateKey).trim() : '';
     if (!key) return;
-    countsByDate[key] = (countsByDate[key] || 0) + 1;
+    if (!patientStates[pid]) {
+      patientStates[pid] = {
+        patientId: pid,
+        name: patientNameMap && patientNameMap[pid] ? patientNameMap[pid] : '',
+        hasTodayTreatment: false,
+        lastOwnTreatmentDate: ''
+      };
+    }
+    if (key === todayKey) patientStates[pid].hasTodayTreatment = true;
+    if (!patientStates[pid].lastOwnTreatmentDate || key > patientStates[pid].lastOwnTreatmentDate) {
+      patientStates[pid].lastOwnTreatmentDate = key;
+    }
   });
 
-  const todayCount = countsByDate[todayKey] || 0;
-  const dateKeys = Object.keys(countsByDate).sort();
-  const latestDateKey = dateKeys.length ? dateKeys[dateKeys.length - 1] : '';
-  const recentOneDayCount = latestDateKey ? (countsByDate[latestDateKey] || 0) : 0;
+  const items = Object.keys(patientStates)
+    .map(pid => {
+      const state = patientStates[pid];
+      const todayText = state.hasTodayTreatment ? '今日施術あり' : '今日施術なし';
+      const lastDate = state.lastOwnTreatmentDate || '--';
+      return {
+        patientId: state.patientId,
+        name: state.name || state.patientId,
+        subText: `${todayText} / 直近本人施術日: ${lastDate}`
+      };
+    })
+    .sort((a, b) => (a.name || '').localeCompare(b.name || '', 'ja'));
 
-  return { todayCount, recentOneDayCount };
+  return { items };
 }
 
 function collectDashboardWarnings_(results) {

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -72,7 +72,7 @@ function testAggregatesDashboardData() {
 
   assert.strictEqual(result.meta.user, 'user@example.com');
   assert.ok(result.meta.generatedAt, 'generatedAt should be present');
-  assert.deepStrictEqual(result.tasks, tasksResult.tasks);
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(result.tasks)), []);
   assert.deepStrictEqual(result.todayVisits, visitsResult.visits);
   assert.strictEqual(result.patients.length, 1);
   const normalizedPatient = JSON.parse(JSON.stringify(result.patients[0]));
@@ -100,7 +100,7 @@ function testAggregatesDashboardData() {
   assert.strictEqual(result.unpaidAlerts.length, 1, '未回収アラートが伝搬する');
   assert.strictEqual(result.unpaidAlerts[0].patientId, '001');
   const warnings = JSON.parse(JSON.stringify(result.warnings)).sort();
-  assert.deepStrictEqual(warnings, ['a1', 'i1', 'n1', 'p1', 'r1', 't1', 'task', 'u1', 'visit'].sort());
+  assert.deepStrictEqual(warnings, ['a1', 'i1', 'n1', 'p1', 'r1', 't1', 'u1', 'visit'].sort());
 }
 
 
@@ -195,8 +195,8 @@ function testConsentOverviewMatchesPatientStatusTags() {
 
   const overviewItems = JSON.parse(JSON.stringify(result.overview.consentRelated.items));
   assert.deepStrictEqual(overviewItems, [
-    { patientId: '002', name: '期限超過未取得', count: 1, subText: '期限超過' },
-    { patientId: '001', name: '期限内未取得', count: 1, subText: '要対応' }
+    { patientId: '002', name: '期限超過未取得', subText: '期限超過（12日超過）' },
+    { patientId: '001', name: '期限内未取得', subText: '要対応（残19日）' }
   ], '上段同意ブロックは consentExpiry + 同意書取得確認の判定だけで表示する');
 
   const patientsById = {};
@@ -269,7 +269,7 @@ function testStaffMatchingUsesEmailNameAndStaffIdWithLogs() {
 }
 
 
-function testVisitSummaryUsesCountsForTodayAndRecentOneDay() {
+function testVisitSummaryUsesPerPatientRows() {
   const ctx = createContext({
     Utilities: {
       formatDate: (date, _tz, fmt) => {
@@ -280,29 +280,27 @@ function testVisitSummaryUsesCountsForTodayAndRecentOneDay() {
   });
 
   const logs = [
-    { dateKey: '2025-02-01', createdByEmail: 'user@example.com' },
-    { dateKey: '2025-01-31', createdByEmail: 'user@example.com' },
-    { dateKey: '2025-01-31', createdByEmail: 'user@example.com' },
-    { dateKey: '2025-01-30', createdByEmail: 'other@example.com' }
+    { patientId: '001', dateKey: '2025-02-01', createdByEmail: 'user@example.com' },
+    { patientId: '001', dateKey: '2025-01-31', createdByEmail: 'user@example.com' },
+    { patientId: '002', dateKey: '2025-01-31', createdByEmail: 'user@example.com' },
+    { patientId: '002', dateKey: '2025-01-30', createdByEmail: 'other@example.com' }
   ];
 
-  const resultToday = ctx.buildOverviewFromTreatmentProgress_(
+  const result = ctx.buildOverviewFromTreatmentProgress_(
     logs,
     'user@example.com',
     new Date('2025-02-01T00:00:00Z'),
-    'Asia/Tokyo'
+    'Asia/Tokyo',
+    { '001': '患者A', '002': '患者B', '003': '患者C' },
+    { patientIds: new Set(['001', '002', '003']), applyFilter: true },
+    { '001': { name: '患者A' }, '002': { name: '患者B' }, '003': { name: '患者C' } }
   );
-  assert.strictEqual(resultToday.todayCount, 1, '今日の件数を返す');
-  assert.strictEqual(resultToday.recentOneDayCount, 1, '直近1日施術は最新日の件数を返す');
 
-  const resultNoToday = ctx.buildOverviewFromTreatmentProgress_(
-    logs,
-    'user@example.com',
-    new Date('2025-02-02T00:00:00Z'),
-    'Asia/Tokyo'
-  );
-  assert.strictEqual(resultNoToday.todayCount, 0, '今日が0件の場合は0件を返す');
-  assert.strictEqual(resultNoToday.recentOneDayCount, 1, '今日0件の場合は過去で最も新しい施術日の件数を返す');
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(result.items)), [
+    { patientId: '001', name: '患者A', subText: '今日施術あり / 直近本人施術日: 2025-02-01' },
+    { patientId: '002', name: '患者B', subText: '今日施術なし / 直近本人施術日: 2025-01-31' },
+    { patientId: '003', name: '患者C', subText: '今日施術なし / 直近本人施術日: --' }
+  ]);
 }
 
 
@@ -319,7 +317,6 @@ function testInvoiceUnconfirmedUsesPositiveConfirmationEvidence() {
   });
 
   const result = ctx.buildOverviewFromInvoiceUnconfirmed_(
-    [],
     {},
     [
       { patientId: '001', dateKey: '2025-01-10', searchText: '前月施術あり' },
@@ -335,7 +332,7 @@ function testInvoiceUnconfirmedUsesPositiveConfirmationEvidence() {
     'Asia/Tokyo'
   );
 
-  assert.strictEqual(result.count, 1, '前月施術があり証跡がない患者のみ未対応になる');
+  assert.strictEqual(result.items.length, 1, '前月施術があり証跡がない患者のみ未対応になる');
   assert.strictEqual(result.items[0].patientId, '002');
 }
 
@@ -370,7 +367,7 @@ function testInvoiceUnconfirmedIgnoresDisplayTargetFilter() {
     visitsResult: { visits: [], warnings: [] }
   });
 
-  assert.strictEqual(result.overview.invoiceUnconfirmed.count, 1, 'displayTarget が空でも①請求の対象を保持する');
+  assert.strictEqual(result.overview.invoiceUnconfirmed.items.length, 1, 'displayTarget が空でも①請求の対象を保持する');
   assert.strictEqual(result.overview.invoiceUnconfirmed.items[0].patientId, '001');
 }
 
@@ -413,7 +410,7 @@ function testInvoiceUnconfirmedShouldDetectPatientWithOnlyPreviousMonthTreatment
     visitsResult: { visits: [], warnings: [] }
   });
 
-  assert.strictEqual(result.overview.invoiceUnconfirmed.count, 1, '前月のみ施術ログがある患者を未確認として検出する');
+  assert.strictEqual(result.overview.invoiceUnconfirmed.items.length, 1, '前月のみ施術ログがある患者を未確認として検出する');
   assert.strictEqual(result.overview.invoiceUnconfirmed.items[0].patientId, '001');
 }
 
@@ -460,7 +457,7 @@ function testInvoiceUnconfirmedExcludesMedicalAssistancePatient() {
     visitsResult: { visits: [], warnings: [] }
   });
 
-  assert.strictEqual(result.overview.invoiceUnconfirmed.count, 0, '医療助成患者は請求未確認対象から除外する');
+  assert.strictEqual(result.overview.invoiceUnconfirmed.items.length, 0, '医療助成患者は請求未確認対象から除外する');
 }
 
 
@@ -512,10 +509,10 @@ function testVisibleScopeForAdminShowsAllPatients() {
   });
 
   assert.strictEqual(result.patients.length, 2, '管理者は全患者表示する');
-  assert.strictEqual(result.tasks.length, 2, '管理者はタスク全件表示する');
+  assert.strictEqual(result.tasks.length, 0, '上段3ブロックは tasks 非依存とする');
   assert.strictEqual(result.todayVisits.length, 2, '管理者は訪問全件表示する');
   assert.strictEqual(result.unpaidAlerts.length, 2, '管理者は未回収アラート全件表示する');
-  assert.strictEqual(result.overview.invoiceUnconfirmed.count, 2, '管理者は請求未確認を全患者分表示する');
+  assert.strictEqual(result.overview.invoiceUnconfirmed.items.length, 2, '管理者は請求未確認を全患者分表示する');
 }
 
 function testVisibleScopeForStaffWithin50DaysShowsMatchedPatientsOnly() {
@@ -566,7 +563,7 @@ function testVisibleScopeForStaffWithin50DaysShowsMatchedPatientsOnly() {
   });
 
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result.patients.map(p => p.patientId))), ['001'], 'スタッフは50日以内に記録した患者のみ表示する');
-  assert.deepStrictEqual(JSON.parse(JSON.stringify(result.tasks.map(t => t.patientId))), ['001']);
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(result.tasks.map(t => t.patientId))), []);
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result.todayVisits.map(v => v.patientId))), ['001']);
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result.unpaidAlerts.map(a => a.patientId))), ['001']);
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result.overview.invoiceUnconfirmed.items.map(item => item.patientId))), ['001'], 'スタッフは請求未確認も担当患者のみ表示する');
@@ -681,7 +678,7 @@ function testWarningsAreDedupedAndSetupFlagged() {
   testPatientStatusTagsGeneration();
   testConsentOverviewMatchesPatientStatusTags();
   testStaffMatchingUsesEmailNameAndStaffIdWithLogs();
-  testVisitSummaryUsesCountsForTodayAndRecentOneDay();
+  testVisitSummaryUsesPerPatientRows();
   testInvoiceUnconfirmedUsesPositiveConfirmationEvidence();
   testInvoiceUnconfirmedIgnoresDisplayTargetFilter();
   testInvoiceUnconfirmedShouldDetectPatientWithOnlyPreviousMonthTreatment();


### PR DESCRIPTION
### Motivation
- ダッシュボード上段の「①請求 / ②同意 / ③実績」を2026-02-10設計に合わせ、表示を「1患者1行（患者名 + 状態サブテキスト1行）」に統一するための修正です。
- 既存の `tasks` 依存や `count` / `priority` / KPI 表示・分析情報を除去して、要件どおりの簡潔な一覧と判定ロジックに整理します。

### Description
- サーバー側: `src/dashboard/api/getDashboardData.js` を変更し、`getTasks` 依存を除去して上段ブロックは `items` 中心で返却するように再構成しました（`tasks` は常に空配列として返却）。
- ①請求: `buildOverviewFromInvoiceUnconfirmed_` を `items` のみ返す形に変更し、各行は `患者名` + `受渡未確認（対象月: YYYY-MM）` の簡潔なサブテキストのみ出力するように整理しました。
- ②同意: `buildOverviewFromConsent_` を `consentExpiry + 同意書取得確認` 判定に統一し、表示文言を `要対応（残◯日）` / `期限超過（◯日超過）` に更新、期限未登録や同意取得確認済は非表示にしました。
- ③実績: `buildOverviewFromTreatmentProgress_` を患者毎1行の出力に変更し、サブテキストに `今日施術あり/なし` と `直近本人施術日` を1行で返すようにしました。フロント側 `src/dashboard.html` の `renderVisitSummary` を一覧カード描画に差し替え、タイトルを `③実績` に変更しました。
- フロント: 未使用だった `formatTaskLabel` を削除し、上段カード描画を `renderOverviewCard_` ベースへ統一しました。
- テスト: `tests/dashboardGetDashboardData.test.js` を修正して新しい返り値フォーマットと言動を検証するよう更新しました。
- 変更ファイル: `src/dashboard/api/getDashboardData.js`, `src/dashboard.html`, `tests/dashboardGetDashboardData.test.js`.

### Testing
- 実行した自動テスト: `node tests/dashboardGetDashboardData.test.js` — 成功。 
- 補助テスト: `node tests/dashboardPatientStatusTagsRendering.test.js` — 成功. 
- オプション/回帰: `node tests/dashboardGetDashboardDataOptions.test.js` — 成功. 
- パフォーマンス回帰: `node tests/dashboardCachingPerf.test.js` — 成功.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69914bd4e2148321917312062c11925f)