### PR TITLE
③実績ブロックを件数サマリー表示へ戻す

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -289,12 +289,26 @@ function renderVisitSummary() {
   const container = document.getElementById('visitSummary');
   if (!container) return;
   const overview = dashboardState.data && dashboardState.data.overview ? dashboardState.data.overview : {};
-  const data = overview && overview.visitSummary ? overview.visitSummary : { items: [] };
-  renderOverviewCard_(container, {
-    title: '③実績',
-    items: data.items || [],
-    emptyText: '対象者なし'
-  });
+  const data = overview && overview.visitSummary ? overview.visitSummary : { todayCount: 0, latestDayCount: 0 };
+  const todayCount = Number(data.todayCount || 0);
+  const latestDayCount = Number(data.latestDayCount || 0);
+
+  container.innerHTML = '';
+
+  const header = document.createElement('div');
+  header.className = 'summary-header';
+  const title = document.createElement('h3');
+  title.textContent = '③実績';
+  header.appendChild(title);
+  container.appendChild(header);
+
+  const metrics = document.createElement('div');
+  metrics.className = 'overview-metrics';
+
+  metrics.appendChild(renderOverviewMetric_('今日', `${todayCount}件`));
+  metrics.appendChild(renderOverviewMetric_('直近1日施術', `${latestDayCount}件`));
+
+  container.appendChild(metrics);
 }
 
 function renderUnpaidAlerts() {
@@ -602,6 +616,23 @@ function renderOverviewCard_(container, options) {
 
   const items = Array.isArray(opts.items) ? opts.items : [];
   container.appendChild(renderOverviewList_(items, opts.emptyText || '対象はありません'));
+}
+
+function renderOverviewMetric_(label, value) {
+  const row = document.createElement('div');
+  row.className = 'overview-metric';
+
+  const labelEl = document.createElement('div');
+  labelEl.className = 'overview-metric-label';
+  labelEl.textContent = label || '';
+  row.appendChild(labelEl);
+
+  const valueEl = document.createElement('div');
+  valueEl.className = 'overview-metric-value';
+  valueEl.textContent = value || '0件';
+  row.appendChild(valueEl);
+
+  return row;
 }
 
 function renderOverviewList_(items, emptyText) {

--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -488,7 +488,7 @@ function buildDashboardOverview_(params) {
     patientInfo
   );
   const consentRelated = buildOverviewFromConsent_(patientInfo, scope, patientNameMap, now);
-  const visitSummary = buildOverviewFromTreatmentProgress_(treatmentLogs, user, now, tz, patientNameMap, scope, patientInfo);
+  const visitSummary = buildOverviewFromTreatmentProgress_(payload.visits, now, tz);
   return {
     invoiceUnconfirmed,
     consentRelated,
@@ -667,64 +667,28 @@ function resolvePatientRawValue_(raw, candidates) {
   return '';
 }
 
-function buildOverviewFromTreatmentProgress_(treatmentLogs, user, now, tz, patientNameMap, scope, patientInfo) {
+function buildOverviewFromTreatmentProgress_(visits, now, tz) {
   const targetNow = dashboardCoerceDate_(now) || new Date();
   const todayKey = dashboardFormatDate_(targetNow, tz, 'yyyy-MM-dd');
-  const normalizedUser = dashboardNormalizeEmail_(user || '');
-  const allowedPatientIds = scope && scope.patientIds ? scope.patientIds : null;
-  const applyFilter = !!(scope && scope.applyFilter);
-  const patientStates = {};
+  const normalizedVisits = Array.isArray(visits) ? visits : [];
+  const countByDate = {};
 
-  Object.keys(patientInfo || {}).forEach(pid => {
-    if (!pid || (applyFilter && allowedPatientIds && !allowedPatientIds.has(pid))) return;
-    patientStates[pid] = {
-      patientId: pid,
-      name: patientNameMap && patientNameMap[pid] ? patientNameMap[pid] : ((patientInfo[pid] && patientInfo[pid].name) || ''),
-      hasTodayTreatment: false,
-      lastOwnTreatmentDate: ''
-    };
+  normalizedVisits.forEach(visit => {
+    const dateKey = visit && visit.dateKey ? String(visit.dateKey).trim() : '';
+    if (!dateKey) return;
+    countByDate[dateKey] = (countByDate[dateKey] || 0) + 1;
   });
 
-  const filtered = (treatmentLogs || []).filter(entry => {
-    if (!normalizedUser) return true;
-    const entryEmail = dashboardNormalizeEmail_(entry && entry.createdByEmail ? entry.createdByEmail : '');
-    return entryEmail && entryEmail === normalizedUser;
-  });
+  const todayCount = countByDate[todayKey] || 0;
+  const latestPastDate = Object.keys(countByDate)
+    .filter(dateKey => dateKey < todayKey)
+    .sort((a, b) => b.localeCompare(a))[0] || '';
+  const latestDayCount = todayCount > 0 ? todayCount : (latestPastDate ? countByDate[latestPastDate] || 0 : 0);
 
-  filtered.forEach(entry => {
-    const pid = dashboardNormalizePatientId_(entry && entry.patientId);
-    if (!pid) return;
-    if (applyFilter && allowedPatientIds && !allowedPatientIds.has(pid)) return;
-    const key = entry && entry.dateKey ? String(entry.dateKey).trim() : '';
-    if (!key) return;
-    if (!patientStates[pid]) {
-      patientStates[pid] = {
-        patientId: pid,
-        name: patientNameMap && patientNameMap[pid] ? patientNameMap[pid] : '',
-        hasTodayTreatment: false,
-        lastOwnTreatmentDate: ''
-      };
-    }
-    if (key === todayKey) patientStates[pid].hasTodayTreatment = true;
-    if (!patientStates[pid].lastOwnTreatmentDate || key > patientStates[pid].lastOwnTreatmentDate) {
-      patientStates[pid].lastOwnTreatmentDate = key;
-    }
-  });
-
-  const items = Object.keys(patientStates)
-    .map(pid => {
-      const state = patientStates[pid];
-      const todayText = state.hasTodayTreatment ? '今日施術あり' : '今日施術なし';
-      const lastDate = state.lastOwnTreatmentDate || '--';
-      return {
-        patientId: state.patientId,
-        name: state.name || state.patientId,
-        subText: `${todayText} / 直近本人施術日: ${lastDate}`
-      };
-    })
-    .sort((a, b) => (a.name || '').localeCompare(b.name || '', 'ja'));
-
-  return { items };
+  return {
+    todayCount,
+    latestDayCount
+  };
 }
 
 function collectDashboardWarnings_(results) {

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -269,7 +269,7 @@ function testStaffMatchingUsesEmailNameAndStaffIdWithLogs() {
 }
 
 
-function testVisitSummaryUsesPerPatientRows() {
+function testVisitSummaryWhenTodayIsZeroUsesLatestPastDayCount() {
   const ctx = createContext({
     Utilities: {
       formatDate: (date, _tz, fmt) => {
@@ -279,28 +279,66 @@ function testVisitSummaryUsesPerPatientRows() {
     }
   });
 
-  const logs = [
-    { patientId: '001', dateKey: '2025-02-01', createdByEmail: 'user@example.com' },
-    { patientId: '001', dateKey: '2025-01-31', createdByEmail: 'user@example.com' },
-    { patientId: '002', dateKey: '2025-01-31', createdByEmail: 'user@example.com' },
-    { patientId: '002', dateKey: '2025-01-30', createdByEmail: 'other@example.com' }
-  ];
-
   const result = ctx.buildOverviewFromTreatmentProgress_(
-    logs,
-    'user@example.com',
+    [
+      { patientId: '001', dateKey: '2025-01-31', time: '09:00' }
+    ],
     new Date('2025-02-01T00:00:00Z'),
-    'Asia/Tokyo',
-    { '001': '患者A', '002': '患者B', '003': '患者C' },
-    { patientIds: new Set(['001', '002', '003']), applyFilter: true },
-    { '001': { name: '患者A' }, '002': { name: '患者B' }, '003': { name: '患者C' } }
+    'Asia/Tokyo'
   );
 
-  assert.deepStrictEqual(JSON.parse(JSON.stringify(result.items)), [
-    { patientId: '001', name: '患者A', subText: '今日施術あり / 直近本人施術日: 2025-02-01' },
-    { patientId: '002', name: '患者B', subText: '今日施術なし / 直近本人施術日: 2025-01-31' },
-    { patientId: '003', name: '患者C', subText: '今日施術なし / 直近本人施術日: --' }
-  ]);
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(result)), {
+    todayCount: 0,
+    latestDayCount: 1
+  });
+}
+
+function testVisitSummaryWhenTodayHasTwoUsesTodayCountForBoth() {
+  const ctx = createContext({
+    Utilities: {
+      formatDate: (date, _tz, fmt) => {
+        if (fmt === 'yyyy-MM-dd') return new Date(date).toISOString().slice(0, 10);
+        return new Date(date).toISOString();
+      }
+    }
+  });
+
+  const result = ctx.buildOverviewFromTreatmentProgress_(
+    [
+      { patientId: '001', dateKey: '2025-02-01', time: '09:00' },
+      { patientId: '002', dateKey: '2025-02-01', time: '10:00' },
+      { patientId: '003', dateKey: '2025-01-31', time: '11:00' }
+    ],
+    new Date('2025-02-01T00:00:00Z'),
+    'Asia/Tokyo'
+  );
+
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(result)), {
+    todayCount: 2,
+    latestDayCount: 2
+  });
+}
+
+function testVisitSummaryWhenNoDataReturnsZeroCounts() {
+  const ctx = createContext({
+    Utilities: {
+      formatDate: (date, _tz, fmt) => {
+        if (fmt === 'yyyy-MM-dd') return new Date(date).toISOString().slice(0, 10);
+        return new Date(date).toISOString();
+      }
+    }
+  });
+
+  const result = ctx.buildOverviewFromTreatmentProgress_(
+    [],
+    new Date('2025-02-01T00:00:00Z'),
+    'Asia/Tokyo'
+  );
+
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(result)), {
+    todayCount: 0,
+    latestDayCount: 0
+  });
 }
 
 
@@ -678,7 +716,9 @@ function testWarningsAreDedupedAndSetupFlagged() {
   testPatientStatusTagsGeneration();
   testConsentOverviewMatchesPatientStatusTags();
   testStaffMatchingUsesEmailNameAndStaffIdWithLogs();
-  testVisitSummaryUsesPerPatientRows();
+  testVisitSummaryWhenTodayIsZeroUsesLatestPastDayCount();
+  testVisitSummaryWhenTodayHasTwoUsesTodayCountForBoth();
+  testVisitSummaryWhenNoDataReturnsZeroCounts();
   testInvoiceUnconfirmedUsesPositiveConfirmationEvidence();
   testInvoiceUnconfirmedIgnoresDisplayTargetFilter();
   testInvoiceUnconfirmedShouldDetectPatientWithOnlyPreviousMonthTreatment();


### PR DESCRIPTION
### Motivation
- 既存の患者単位リスト表示（⑤五十音ソート・患者ごとのサブテキスト）から、Issue の要件どおり `今日` と `直近1日施術` の件数サマリー表示へ戻すための変更。 

### Description
- `src/dashboard/api/getDashboardData.js` の `buildOverviewFromTreatmentProgress_` を患者一覧生成から件数集計ロジックへ置換し、`todayCount` と `latestDayCount` を返すようにした。 
- `buildDashboardOverview_` では `treatmentLogs` ベースではなく `payload.visits`（`getTodayVisits` の結果）を使って `visitSummary` を生成するように変更した。 
- `src/dashboard.html` の `renderVisitSummary()` を患者行リスト表示からメトリクス表示へ差し替え、`今日 ◯件` と `直近1日施術 ◯件` を描画するようにし、メトリクス行を作る `renderOverviewMetric_()` を追加した。 
- 関連テスト `tests/dashboardGetDashboardData.test.js` を更新し、要件に合わせて「今日0件＋直近1日1件」「今日2件」「データ0件」のケースを追加・検証するようにした。 

### Testing
- 自動テストとして `node tests/dashboardGetDashboardData.test.js` を実行し、全テストが成功して `dashboardGetDashboardData tests passed` を確認した。 
- 変更対象ファイルは `src/dashboard/api/getDashboardData.js`、`src/dashboard.html`、および `tests/dashboardGetDashboardData.test.js` であることを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69914fa078188321922d8e3803e9e014)