### PR TITLE
③実績0件不具合修正: getTodayVisitsでdateKeyを必須化

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -195,7 +195,6 @@ function getDashboardData(options) {
       now: opts.now
     }) : { visits: [], warnings: [] })));
     logContext('getDashboardData:getTodayVisits', `visits=${(visitsResult && visitsResult.visits ? visitsResult.visits.length : 0)} warnings=${(visitsResult && visitsResult.warnings ? visitsResult.warnings.length : 0)} setupIncomplete=${!!(visitsResult && visitsResult.setupIncomplete)}`);
-
     const patients = measureStep('buildPatients', () => buildDashboardPatients_(patientInfo, {
       notes,
       aiReports,
@@ -678,6 +677,7 @@ function buildOverviewFromTreatmentProgress_(visits, now, tz) {
     if (!dateKey) return;
     countByDate[dateKey] = (countByDate[dateKey] || 0) + 1;
   });
+
 
   const todayCount = countByDate[todayKey] || 0;
   const latestPastDate = Object.keys(countByDate)

--- a/src/dashboard/api/getTodayVisits.js
+++ b/src/dashboard/api/getTodayVisits.js
@@ -37,7 +37,7 @@ function getTodayVisits(options) {
     if (!entry || !entry.timestamp) return;
     const ts = dashboardCoerceDate_(entry.timestamp);
     if (!ts) return;
-    const dateKey = entry.dateKey || dashboardFormatDate_(ts, tz, 'yyyy-MM-dd');
+    const dateKey = String(entry.dateKey || '').trim() || dashboardFormatDate_(ts, tz, 'yyyy-MM-dd');
 
     const patientId = dashboardNormalizePatientId_(entry.patientId);
     const master = patientId && Object.prototype.hasOwnProperty.call(patientInfo, patientId)
@@ -53,12 +53,12 @@ function getTodayVisits(options) {
     normalizedVisits.push({ patientId, patientName, time, dateKey, noteStatus });
   });
 
-  const latestPastDate = normalizedVisits
+  const latestPastDayKey = normalizedVisits
     .filter(visit => visit.dateKey < todayKey)
     .map(visit => visit.dateKey)
     .sort((a, b) => b.localeCompare(a))[0] || '';
 
-  const visits = normalizedVisits.filter(visit => visit.dateKey === todayKey || (latestPastDate && visit.dateKey === latestPastDate));
+  const visits = normalizedVisits.filter(visit => visit.dateKey === todayKey || (latestPastDayKey && visit.dateKey === latestPastDayKey));
 
   visits.sort((a, b) => {
     if (a.dateKey === b.dateKey) return a.time.localeCompare(b.time);
@@ -67,6 +67,7 @@ function getTodayVisits(options) {
 
   return { visits, warnings, setupIncomplete };
 }
+
 
 function resolveHandoverStatus_(dateKey, patientId, notes, tz) {
   const note = notes && patientId ? notes[patientId] : null;

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -52,7 +52,7 @@ function testAggregatesDashboardData() {
   const treatmentLogs = { logs: [{ patientId: '001', timestamp: new Date('2025-02-01T09:00:00Z'), dateKey: '2025-02-01', createdByEmail: 'user@example.com', staffKeys: { email: 'user@example.com', name: '', staffId: '' } }], warnings: ['t1'] };
   const responsible = { responsible: { '001': 'staff@example.com' }, warnings: ['r1'] };
   const tasksResult = { tasks: [{ type: 'consentWarning', patientId: '001' }], warnings: ['task'] };
-  const visitsResult = { visits: [{ patientId: '001', time: '10:00' }], warnings: ['visit'] };
+  const visitsResult = { visits: [{ patientId: '001', dateKey: '2025-02-01', time: '10:00' }], warnings: ['visit'] };
   const unpaidAlerts = { alerts: [{ patientId: '001', patientName: '山田太郎', consecutiveMonths: 3, totalAmount: 15000, months: [], followUp: { phone: false, visit: false } }], warnings: ['u1'] };
 
   const ctx = createContext();

--- a/tests/dashboardTodayVisits.test.js
+++ b/tests/dashboardTodayVisits.test.js
@@ -208,6 +208,24 @@ function runVisits(context, now, logs, patientInfo, extraOptions) {
   assert.deepStrictEqual(keys, ['2025-02-10', '2025-02-13'], '有給明けでも過去は最新1日だけ');
 })();
 
+
+(function testMissingDateKeyIsDerivedFromTimestamp() {
+  const context = createApiContext();
+  const visits = runVisits(
+    context,
+    '2025-02-01T10:00:00Z',
+    [
+      { timestamp: new Date('2025-02-01T09:30:00Z'), patientId: 'P001' },
+      { timestamp: new Date('2025-01-31T23:00:00Z'), patientId: 'P002' }
+    ],
+    { P001: { name: '田中 花子' }, P002: { name: '山田 太郎' } }
+  );
+
+  assert.strictEqual(visits.length, 2, 'dateKey未設定でもtimestampから補完して2日分を返す');
+  const keys = JSON.parse(JSON.stringify(visits.map(v => v.dateKey)));
+  assert.deepStrictEqual(keys, ['2025-01-31', '2025-02-01']);
+})();
+
 (function testTodayOnly() {
   const context = createApiContext();
   const visits = runVisits(


### PR DESCRIPTION
### Motivation
- Visits lacking `dateKey` caused the visit-summary grouping to skip entries, producing 0 counts for "今日"/"直近1日"; the fix ensures `dateKey` is always present on returned visits.
- The change strictly keeps return shapes and does not alter downstream `tasks` logic or summary algorithms.

### Description
- Normalize `dateKey` in `getTodayVisits`: if `entry.dateKey` is missing/empty, derive `yyyy-MM-dd` from `entry.timestamp` and use the trimmed existing value when present, guaranteeing returned visits include `{ patientId, dateKey, ... }` (`src/dashboard/api/getTodayVisits.js`).
- Remove previously added debug/log blocks that were only for investigation (`getDashboardData:visitsPayload`, `getTodayVisits:debug`, `visitSummary:*`) to avoid leaving exploratory logs in production (`src/dashboard/api/getDashboardData.js`, `src/dashboard/api/getTodayVisits.js`).
- Update test fixtures to match the normalized shape by adding `dateKey` to a visits fixture used by `getDashboardData` tests (`tests/dashboardGetDashboardData.test.js`).
- Add a unit test verifying missing `dateKey` is derived from `timestamp` so such visits are counted correctly (`tests/dashboardTodayVisits.test.js`).

### Testing
- Ran `node tests/dashboardTodayVisits.test.js` and it passed (includes new case for missing `dateKey`).
- Ran `node tests/dashboardGetDashboardData.test.js` and it passed (fixture adjusted to include `dateKey`).
- Attempted full test-suite run but it stopped on an unrelated, preexisting failing test `tests/aggregateBillingFromBankFlags.test.js`; this failure is outside the scope of these changes and unchanged by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699154b0c89c8321aeca8141c0f205a8)