### PR TITLE
Resolve and strictly parse consent expiry; add tests

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -378,10 +378,11 @@ function buildDashboardPatients_(patientInfo, sources, allowedPatientIds) {
     seen.add(patientId);
 
     const base = payload || {};
+    const consentExpiryResolved = resolveConsentExpiry_(base);
     const entry = {
       patientId,
       name: base.name || base.patientName || '',
-      consentExpiry: base.consentExpiry || (base.raw && (base.raw['同意期限'] || base.raw['同意有効期限'])) || '',
+      consentExpiry: consentExpiryResolved.value == null ? '' : consentExpiryResolved.value,
       responsible: Object.prototype.hasOwnProperty.call(responsible, patientId) ? responsible[patientId] : null,
       invoiceUrl: Object.prototype.hasOwnProperty.call(invoices, patientId) ? invoices[patientId] : null,
       aiReportAt: Object.prototype.hasOwnProperty.call(aiReports, patientId) ? aiReports[patientId] : null,
@@ -408,11 +409,20 @@ function buildDashboardPatientStatusTags_(patient, params, maybeNow) {
     : { aiReportAt: params, now: maybeNow };
   const targetNow = dashboardCoerceDate_(options.now) || new Date();
   const aiReportAt = options.aiReportAt;
-  const consentExpiry = patient && (patient.consentExpiry || (patient.raw && (patient.raw['同意期限'] || patient.raw['同意有効期限'])));
-  const consentExpiryDate = dashboardParseTimestamp_(consentExpiry);
+  const consentExpiryResolved = resolveConsentExpiry_(patient);
+  const consentExpiryDate = parseConsentDate_(consentExpiryResolved.value);
   const raw = patient && patient.raw ? patient.raw : null;
   const consentAcquired = dashboardIsConsentAcquired_(raw);
   const consentExpired = consentExpiryDate && dashboardDaysBetween_(targetNow, consentExpiryDate, true) <= 0;
+
+  if (shouldDebugConsent_() && consentExpiryResolved.value != null && !consentExpiryDate) {
+    dashboardLogContext_('consent-date-parse-failed', JSON.stringify({
+      phase: 'tag',
+      patientId: patient && patient.patientId ? patient.patientId : '',
+      source: consentExpiryResolved.source,
+      raw: consentExpiryResolved.value
+    }));
+  }
 
   if (!consentAcquired && consentExpiryDate) {
     tags.push({ type: 'consent', label: consentExpired ? '期限超過' : '要対応' });
@@ -630,9 +640,17 @@ function buildOverviewFromConsent_(patientInfo, scope, patientNameMap, now) {
   Object.keys(patientInfo || {}).forEach(pid => {
     if (!pid || (applyFilter && allowedPatientIds && !allowedPatientIds.has(pid))) return;
     const info = patientInfo[pid] || {};
-    const consentExpiry = info.consentExpiry || (info.raw && (info.raw['同意期限'] || info.raw['同意有効期限']));
-    const consentExpiryDate = dashboardParseTimestamp_(consentExpiry);
+    const consentExpiryResolved = resolveConsentExpiry_(info);
+    const consentExpiryDate = parseConsentDate_(consentExpiryResolved.value);
     const consentAcquired = dashboardIsConsentAcquired_(info.raw);
+    if (shouldDebugConsent_() && consentExpiryResolved.value != null && !consentExpiryDate) {
+      dashboardLogContext_('consent-date-parse-failed', JSON.stringify({
+        phase: 'overview',
+        patientId: pid,
+        source: consentExpiryResolved.source,
+        raw: consentExpiryResolved.value
+      }));
+    }
     if (consentAcquired || !consentExpiryDate) return;
 
     const todayStart = new Date(targetNow.getFullYear(), targetNow.getMonth(), targetNow.getDate());
@@ -651,6 +669,71 @@ function buildOverviewFromConsent_(patientInfo, scope, patientNameMap, now) {
 
   items.sort((a, b) => (a.name || '').localeCompare(b.name || '', 'ja'));
   return { items };
+}
+
+function resolveConsentExpiry_(patient) {
+  const info = patient && typeof patient === 'object' ? patient : {};
+  const raw = info.raw && typeof info.raw === 'object' ? info.raw : null;
+  const candidates = [
+    { source: 'info.consentExpiry', value: info.consentExpiry },
+    { source: "raw['同意期限']", value: raw ? raw['同意期限'] : null },
+    { source: "raw['同意有効期限']", value: raw ? raw['同意有効期限'] : null },
+    { source: "raw['同意期限日']", value: raw ? raw['同意期限日'] : null }
+  ];
+
+  for (let i = 0; i < candidates.length; i++) {
+    const entry = candidates[i];
+    if (entry.value == null) continue;
+    if (typeof entry.value === 'string' && !entry.value.trim()) continue;
+    return { value: entry.value, source: entry.source };
+  }
+
+  return { value: null, source: '' };
+}
+
+function parseConsentDate_(value) {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  if (value == null) return null;
+
+  const str = String(value).trim();
+  if (!str) return null;
+
+  const ymdHyphen = str.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
+  if (ymdHyphen) return createDateFromYmd_(ymdHyphen[1], ymdHyphen[2], ymdHyphen[3]);
+
+  const ymdSlash = str.match(/^(\d{4})\/(\d{1,2})\/(\d{1,2})$/);
+  if (ymdSlash) return createDateFromYmd_(ymdSlash[1], ymdSlash[2], ymdSlash[3]);
+
+  const ymdJapanese = str.match(/^(\d{4})年(\d{1,2})月(\d{1,2})日$/);
+  if (ymdJapanese) return createDateFromYmd_(ymdJapanese[1], ymdJapanese[2], ymdJapanese[3]);
+
+  const isoPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})?$/;
+  if (isoPattern.test(str)) {
+    const timestamp = Date.parse(str);
+    if (Number.isFinite(timestamp)) return new Date(timestamp);
+  }
+
+  return null;
+}
+
+function createDateFromYmd_(yearRaw, monthRaw, dayRaw) {
+  const year = Number(yearRaw);
+  const month = Number(monthRaw);
+  const day = Number(dayRaw);
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return null;
+
+  const date = new Date(year, month - 1, day);
+  if (Number.isNaN(date.getTime())) return null;
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) return null;
+  return date;
+}
+
+function shouldDebugConsent_() {
+  if (typeof DASHBOARD_DEBUG_CONSENT !== 'undefined') return !!DASHBOARD_DEBUG_CONSENT;
+  if (typeof DEBUG_MODE !== 'undefined') return !!DEBUG_MODE;
+  return false;
 }
 
 function resolvePatientRawValue_(raw, candidates) {

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -261,6 +261,97 @@ function testConsentAcquiredJudgmentHandlesFalseyStringsConsistently() {
   });
 }
 
+
+function testConsentDateParsingFormatsAndResolverPriority() {
+  const ctx = createContext();
+  const now = new Date('2025-02-01T00:00:00Z');
+
+  const resolved = ctx.resolveConsentExpiry_({
+    consentExpiry: '   ',
+    raw: {
+      '同意期限': '2025-03-01',
+      '同意有効期限': '2025-03-02',
+      '同意期限日': '2025-03-03'
+    }
+  });
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(resolved)), {
+    value: '2025-03-01',
+    source: "raw['同意期限']"
+  }, '空文字の consentExpiry は無視して raw[同意期限] を優先する');
+
+  const result = ctx.getDashboardData({
+    user: { email: 'user@example.com', role: 'admin' },
+    now,
+    patientInfo: {
+      patients: {
+        '001': { name: 'A-hyphen', consentExpiry: '2025-02-20', raw: {} },
+        '002': { name: 'B-slash', consentExpiry: '2025/02/21', raw: {} },
+        '003': { name: 'C-japanese', consentExpiry: '2025年2月22日', raw: {} },
+        '004': { name: 'D-iso', consentExpiry: '2025-02-23T00:00:00Z', raw: {} },
+        '005': { name: 'E-date', consentExpiry: new Date('2025-02-24T00:00:00Z'), raw: {} },
+        '006': { name: 'F-invalid', consentExpiry: '2025-99-99', raw: {} },
+        '007': { name: 'G-raw-consent', consentExpiry: '   ', raw: { '同意期限': '2025-02-25' } },
+        '008': { name: 'H-raw-valid', consentExpiry: '', raw: { '同意有効期限': '2025/02/26' } },
+        '009': { name: 'I-raw-date', raw: { '同意期限日': '2025年2月27日' } },
+        '010': { name: 'J-acquired', raw: { '同意期限': '2025-02-28', '同意書取得確認': '済' } }
+      },
+      warnings: []
+    },
+    notes: { notes: {}, warnings: [] },
+    aiReports: { reports: {}, warnings: [] },
+    invoices: { invoices: {}, warnings: [] },
+    treatmentLogs: { logs: [], warnings: [] },
+    responsible: { responsible: {}, warnings: [] },
+    unpaidAlerts: { alerts: [], warnings: [] },
+    tasksResult: { tasks: [], warnings: [] },
+    visitsResult: { visits: [], warnings: [] }
+  });
+
+  const overviewIds = JSON.parse(JSON.stringify(result.overview.consentRelated.items)).map(item => item.patientId);
+  assert.deepStrictEqual(overviewIds, ['001', '002', '003', '004', '005', '007', '008', '009'], '対応フォーマット + raw列解決のみ表示され、不正値と取得済みは除外される');
+
+  const patientsById = {};
+  result.patients.forEach(entry => {
+    patientsById[entry.patientId] = JSON.parse(JSON.stringify(entry.statusTags));
+  });
+  ['001', '002', '003', '004', '005', '007', '008', '009'].forEach(patientId => {
+    assert.deepStrictEqual((patientsById[patientId] || []).filter(tag => tag.type === 'consent'), [{ type: 'consent', label: '要対応' }], `同意タグが表示される: ${patientId}`);
+  });
+  assert.deepStrictEqual((patientsById['006'] || []).filter(tag => tag.type === 'consent'), [], '不正文字列は同意タグの表示対象外');
+  assert.deepStrictEqual((patientsById['010'] || []).filter(tag => tag.type === 'consent'), [], '取得済み判定は従来通り同意タグ非表示');
+}
+
+function testConsentDateParseFailureCanBeDebugLogged() {
+  const logs = [];
+  const ctx = createContext({ DASHBOARD_DEBUG_CONSENT: true });
+  ctx.dashboardLogContext_ = (label, details) => {
+    logs.push({ label, details: String(details || '') });
+  };
+
+  ctx.getDashboardData({
+    user: { email: 'user@example.com', role: 'admin' },
+    now: new Date('2025-02-01T00:00:00Z'),
+    patientInfo: {
+      patients: {
+        '001': { name: 'invalid-overview', consentExpiry: 'invalid-date', raw: {} }
+      },
+      warnings: []
+    },
+    notes: { notes: {}, warnings: [] },
+    aiReports: { reports: {}, warnings: [] },
+    invoices: { invoices: {}, warnings: [] },
+    treatmentLogs: { logs: [], warnings: [] },
+    responsible: { responsible: {}, warnings: [] },
+    unpaidAlerts: { alerts: [], warnings: [] },
+    tasksResult: { tasks: [], warnings: [] },
+    visitsResult: { visits: [], warnings: [] }
+  });
+
+  const parseFailureLogs = logs.filter(entry => entry.label === 'consent-date-parse-failed');
+  assert.ok(parseFailureLogs.length >= 1, 'debug flag 有効時に parse 失敗ログを出力する');
+  assert.ok(parseFailureLogs.some(entry => entry.details.indexOf('invalid-date') >= 0), '失敗した元値をログに含む');
+}
+
 function testStaffMatchingUsesEmailNameAndStaffIdWithLogs() {
   const logEntries = [];
   const ctx = createContext();
@@ -767,6 +858,8 @@ function testWarningsAreDedupedAndSetupFlagged() {
   testPatientStatusTagsGeneration();
   testConsentOverviewMatchesPatientStatusTags();
   testConsentAcquiredJudgmentHandlesFalseyStringsConsistently();
+  testConsentDateParsingFormatsAndResolverPriority();
+  testConsentDateParseFailureCanBeDebugLogged();
   testStaffMatchingUsesEmailNameAndStaffIdWithLogs();
   testVisitSummaryWhenTodayIsZeroUsesLatestPastDayCount();
   testVisitSummaryWhenTodayHasTwoUsesTodayCountForBoth();


### PR DESCRIPTION
### Motivation
- 同意期限列の解決と日付パースが `new Date(str)` 任せで失敗時に静かに除外され、同意期限があるのに表示されないケースが発生していたため、列解決の優先度を明確化し日付パースを厳密化しました。

### Description
- 追加した `resolveConsentExpiry_(patient)` は優先順で `info.consentExpiry` → `raw['同意期限']` → `raw['同意有効期限']` → `raw['同意期限日']` を解決し、解決元を示す `source` と `value` を返します。
- 追加した `parseConsentDate_(value)` は `YYYY-MM-DD` / `YYYY/MM/DD` / `YYYY年M月D日` / ISO 文字列 / `Date` オブジェクトに明示対応し、`new Date(str)` 丸投げを避けて失敗時は `null` を返す実装です（補助に `createDateFromYmd_` を追加）。
- `buildOverviewFromConsent_` / `buildDashboardPatientStatusTags_` / `buildDashboardPatients_` を `resolveConsentExpiry_` + `parseConsentDate_` を使うよう置換し、パース失敗時はデバッグフラグで `consent-date-parse-failed` ログを出すようにしました（フラグは `DASHBOARD_DEBUG_CONSENT` または `DEBUG_MODE` を参照）。
- 既存の同意取得判定ロジック (`dashboardIsConsentAcquired_`) との互換性は維持しています。

### Testing
- `tests/dashboardGetDashboardData.test.js` に `testConsentDateParsingFormatsAndResolverPriority` と `testConsentDateParseFailureCanBeDebugLogged` を追加し、対応フォーマットの判定・不正文字列の除外・列解決優先度・デバッグログ出力を検証するようにしました. 
- 実行: `node tests/dashboardGetDashboardData.test.js` を実行し全テストが通過しました（出力: `dashboardGetDashboardData tests passed`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69918fe89ff0832190c67bb680166126)