### PR TITLE
Add staff-only diagnostics to investigate consent visibility scope

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -180,6 +180,36 @@ function getDashboardData(options) {
     });
     const visiblePatientIds = isAdmin ? null : responsiblePatientIds;
 
+    if (!isAdmin) {
+      const patientMasterIds = Object.keys(patientMaster || {});
+      let consentEligiblePatients = 0;
+      let consentEligibleButOutOfScope = 0;
+
+      patientMasterIds.forEach(pid => {
+        const info = patientMaster[pid] || {};
+        const consentExpiryDate = parseConsentDate_(resolveConsentExpiry_(info).value);
+        if (!consentExpiryDate) return;
+        if (dashboardIsConsentAcquired_(info.raw)) return;
+        consentEligiblePatients += 1;
+        if (!visiblePatientIds.has(pid)) consentEligibleButOutOfScope += 1;
+      });
+
+      logContext('getDashboardData:consentScopeMetrics', JSON.stringify({
+        totalPatients: patientMasterIds.length,
+        consentEligiblePatients,
+        visiblePatientIdsSize: visiblePatientIds.size,
+        consentEligibleButOutOfScope
+      }));
+      logContext(
+        'getDashboardData:consentMissingByRecentLog',
+        `staffOnly consent期限あり&同意取得確認なし&直近50日ログなし=${consentEligibleButOutOfScope}`
+      );
+      logContext(
+        'getDashboardData:visibleScopeRoutes',
+        'overview.consentRelated=buildDashboardOverview_ -> buildOverviewFromConsent_(allowedPatientIds=visiblePatientIds), patients/statusTags=buildDashboardPatients_(allowedPatientIds=visiblePatientIds) -> buildDashboardPatientStatusTags_'
+      );
+    }
+
     const unpaidAlertsResult = measureStep('loadUnpaidAlerts', () => (opts.unpaidAlerts || (typeof loadUnpaidAlerts === 'function'
       ? loadUnpaidAlerts({ patientInfo, now: opts.now, cache: opts.cache, dashboardSpreadsheet, visiblePatientIds })
       : { alerts: [], warnings: [] })));
@@ -370,10 +400,14 @@ function buildDashboardPatients_(patientInfo, sources, allowedPatientIds) {
   const now = dashboardCoerceDate_(sources && sources.now) || new Date();
 
   const seen = new Set();
+  let filteredByScope = 0;
   const addPatient = (pid, payload) => {
     const patientId = dashboardNormalizePatientId_(pid);
     if (!patientId || seen.has(patientId)) return;
-    if (allowedPatientIds && !allowedPatientIds.has(patientId)) return;
+    if (allowedPatientIds && !allowedPatientIds.has(patientId)) {
+      filteredByScope += 1;
+      return;
+    }
     if (!Object.prototype.hasOwnProperty.call(basePatients, patientId)) return;
     seen.add(patientId);
 
@@ -398,6 +432,15 @@ function buildDashboardPatients_(patientInfo, sources, allowedPatientIds) {
   };
 
   Object.keys(basePatients).forEach(pid => addPatient(pid, basePatients[pid]));
+
+  if (typeof dashboardLogContext_ === 'function') {
+    dashboardLogContext_('buildDashboardPatients_:scope', JSON.stringify({
+      applyFilter: !!allowedPatientIds,
+      basePatients: Object.keys(basePatients).length,
+      filteredByScope,
+      resultPatients: patients.length
+    }));
+  }
 
   return patients;
 }
@@ -636,9 +679,14 @@ function buildOverviewFromConsent_(patientInfo, scope, patientNameMap, now) {
   const allowedPatientIds = scope ? scope.patientIds : null;
   const applyFilter = scope ? scope.applyFilter : false;
   const targetNow = dashboardCoerceDate_(now) || new Date();
+  let filteredByScope = 0;
 
   Object.keys(patientInfo || {}).forEach(pid => {
-    if (!pid || (applyFilter && allowedPatientIds && !allowedPatientIds.has(pid))) return;
+    if (!pid) return;
+    if (applyFilter && allowedPatientIds && !allowedPatientIds.has(pid)) {
+      filteredByScope += 1;
+      return;
+    }
     const info = patientInfo[pid] || {};
     const consentExpiryResolved = resolveConsentExpiry_(info);
     const consentExpiryDate = parseConsentDate_(consentExpiryResolved.value);
@@ -668,6 +716,14 @@ function buildOverviewFromConsent_(patientInfo, scope, patientNameMap, now) {
   });
 
   items.sort((a, b) => (a.name || '').localeCompare(b.name || '', 'ja'));
+  if (typeof dashboardLogContext_ === 'function') {
+    dashboardLogContext_('buildOverviewFromConsent_:scope', JSON.stringify({
+      applyFilter,
+      totalPatients: Object.keys(patientInfo || {}).length,
+      filteredByScope,
+      resultItems: items.length
+    }));
+  }
   return { items };
 }
 

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -411,6 +411,62 @@ function testStaffMatchingUsesEmailNameAndStaffIdWithLogs() {
 }
 
 
+
+function testStaffConsentScopeMetricsAreLogged() {
+  const logEntries = [];
+  const ctx = createContext();
+  ctx.dashboardLogContext_ = (label, details) => {
+    logEntries.push({ label, details: String(details || '') });
+  };
+
+  const result = ctx.getDashboardData({
+    user: 'staff@example.com',
+    now: new Date('2025-02-20T00:00:00Z'),
+    patientInfo: {
+      patients: {
+        '001': { name: '患者A', consentExpiry: '2025-03-01', raw: {} },
+        '002': { name: '患者B', consentExpiry: '2025-03-05', raw: {} },
+        '003': { name: '患者C', consentExpiry: '2025-03-08', raw: { '同意書取得確認': '済' } },
+        '004': { name: '患者D', raw: {} }
+      },
+      warnings: []
+    },
+    notes: { notes: {}, warnings: [] },
+    aiReports: { reports: {}, warnings: [] },
+    invoices: { invoices: {}, warnings: [] },
+    treatmentLogs: {
+      logs: [
+        { patientId: '001', timestamp: new Date('2025-02-10T09:00:00Z'), staffKeys: { email: 'staff@example.com', name: '', staffId: '' } },
+        { patientId: '002', timestamp: new Date('2024-12-01T09:00:00Z'), staffKeys: { email: 'staff@example.com', name: '', staffId: '' } }
+      ],
+      warnings: []
+    },
+    responsible: { responsible: {}, warnings: [] },
+    unpaidAlerts: { alerts: [], warnings: [] },
+    visitsResult: { visits: [], warnings: [] }
+  });
+
+  assert.strictEqual(result.meta.error, undefined);
+
+  const scopeMetricsLog = logEntries.find(entry => entry.label === 'getDashboardData:consentScopeMetrics');
+  assert.ok(scopeMetricsLog, 'consentScopeMetrics ログが出力される');
+  const metrics = JSON.parse(scopeMetricsLog.details);
+  assert.deepStrictEqual(metrics, {
+    totalPatients: 4,
+    consentEligiblePatients: 2,
+    visiblePatientIdsSize: 1,
+    consentEligibleButOutOfScope: 1
+  });
+
+  const missingByRecentLog = logEntries.find(entry => entry.label === 'getDashboardData:consentMissingByRecentLog');
+  assert.ok(missingByRecentLog, 'consentMissingByRecentLog ログが出力される');
+  assert.ok(missingByRecentLog.details.indexOf('=1') >= 0, '直近50日ログなし件数がログに含まれる');
+
+  assert.ok(logEntries.some(entry => entry.label === 'getDashboardData:visibleScopeRoutes'), 'visibleScopeRoutes ログが出力される');
+  assert.ok(logEntries.some(entry => entry.label === 'buildDashboardPatients_:scope'), 'buildDashboardPatients_:scope ログが出力される');
+  assert.ok(logEntries.some(entry => entry.label === 'buildOverviewFromConsent_:scope'), 'buildOverviewFromConsent_:scope ログが出力される');
+}
+
 function testVisitSummaryWhenTodayIsZeroUsesLatestPastDayCount() {
   const ctx = createContext({
     Utilities: {
@@ -861,6 +917,7 @@ function testWarningsAreDedupedAndSetupFlagged() {
   testConsentDateParsingFormatsAndResolverPriority();
   testConsentDateParseFailureCanBeDebugLogged();
   testStaffMatchingUsesEmailNameAndStaffIdWithLogs();
+  testStaffConsentScopeMetricsAreLogged();
   testVisitSummaryWhenTodayIsZeroUsesLatestPastDayCount();
   testVisitSummaryWhenTodayHasTwoUsesTodayCountForBoth();
   testVisitSummaryWhenNoDataReturnsZeroCounts();


### PR DESCRIPTION
### Motivation
- Investigate Issue #1614 by measuring whether `visiblePatientIds` (50-day treatment-log scope for staff) causes consent items to be omitted from the dashboard instead of data issues. 
- Provide runtime observability without changing business logic so the root cause (scope vs data) can be determined safely.

### Description
- Add staff-only metrics inside `getDashboardData` to log `totalPatients`, `consentEligiblePatients`, `visiblePatientIdsSize`, and `consentEligibleButOutOfScope` under the label `getDashboardData:consentScopeMetrics`. 
- Emit a human-readable summary `getDashboardData:consentMissingByRecentLog` and a route documentation entry `getDashboardData:visibleScopeRoutes` indicating where `visiblePatientIds` is applied. 
- Add scope diagnostics to the two code paths that are affected by `visiblePatientIds`: `buildDashboardPatients_` (logs `buildDashboardPatients_:scope`) and `buildOverviewFromConsent_` (logs `buildOverviewFromConsent_:scope`), each including whether filtering was applied, counts filtered, and result counts. 
- Add an investigation unit test `testStaffConsentScopeMetricsAreLogged` to `tests/dashboardGetDashboardData.test.js` which asserts emitted metrics and scope logs for a representative staff scenario.

### Testing
- Ran the test suite entry point with `node tests/dashboardGetDashboardData.test.js`, which executed the new test and existing tests and printed `dashboardGetDashboardData tests passed`. 
- All automated tests completed successfully (no failures) in the local run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991919bca908321b36aad491f4c70e8)