### PR TITLE
Add consent expiry calculation and rebuild helper; add unit tests

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -6916,6 +6916,41 @@ function parseDateFlexible_(v) {
   const d = new Date(raw);
   return isNaN(d.getTime()) ? null : d;
 }
+
+function calculateConsentExpiry_(dateRaw) {
+  const d = new Date(dateRaw);
+  if (isNaN(d)) return '';
+
+  const day = d.getDate();
+  const monthsToAdd = day <= 15 ? 5 : 6;
+
+  const target = new Date(d);
+  target.setMonth(target.getMonth() + monthsToAdd + 1, 0);
+
+  return Utilities.formatDate(target, Session.getScriptTimeZone(), 'yyyy-MM-dd');
+}
+
+function rebuildAllConsentExpiry_() {
+  const sheet = SpreadsheetApp.getActive().getSheetByName('患者情報');
+  const values = sheet.getDataRange().getValues();
+  const headers = values[0];
+
+  const colConsentDate = headers.indexOf('同意年月日');
+  const colExpiry = headers.indexOf('同意期限');
+
+  if (colConsentDate === -1 || colExpiry === -1) {
+    throw new Error('必要な列が見つかりません');
+  }
+
+  for (let i = 1; i < values.length; i++) {
+    const consentDateRaw = values[i][colConsentDate];
+    if (!consentDateRaw) continue;
+
+    const expiry = calculateConsentExpiry_(consentDateRaw);
+    sheet.getRange(i + 1, colExpiry + 1).setValue(expiry);
+  }
+}
+
 function calcConsentExpiry_(consentVal) {
   const d = parseDateFlexible_(consentVal);
   if (!d) return '';

--- a/tests/calculateConsentExpiry.test.js
+++ b/tests/calculateConsentExpiry.test.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const code = fs.readFileSync(path.join(__dirname, '../src/Code.js'), 'utf8');
+const sandbox = { console };
+vm.createContext(sandbox);
+vm.runInContext(code, sandbox);
+
+sandbox.Session = {
+  getScriptTimeZone: () => 'Asia/Tokyo'
+};
+
+sandbox.Utilities = {
+  formatDate: date => {
+    const yyyy = date.getFullYear();
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const dd = String(date.getDate()).padStart(2, '0');
+    return `${yyyy}-${mm}-${dd}`;
+  }
+};
+
+(function testConsentDateDay1To15AddsFiveMonthsAndRoundsToMonthEnd() {
+  const result = sandbox.calculateConsentExpiry_('2025-01-15');
+  assert.strictEqual(result, '2025-06-30');
+})();
+
+(function testConsentDateDay16OrLaterAddsSixMonthsAndRoundsToMonthEnd() {
+  const result = sandbox.calculateConsentExpiry_('2025-01-16');
+  assert.strictEqual(result, '2025-07-31');
+})();
+
+(function testInvalidDateReturnsEmptyString() {
+  const result = sandbox.calculateConsentExpiry_('invalid-date');
+  assert.strictEqual(result, '');
+})();
+
+console.log('calculateConsentExpiry tests passed');


### PR DESCRIPTION
### Motivation
- Provide a way to compute and persist `consentExpiry` (同意期限) derived from `同意年月日` on the patient sheet so stored expiry values can be backfilled without changing dashboard-side logic.

### Description
- Added `calculateConsentExpiry_(dateRaw)` which returns `yyyy-MM-dd` with month-end rounding using the rule: day 1–15 → +5 months month-end, day 16+ → +6 months month-end.
- Added `rebuildAllConsentExpiry_()` which reads the `患者情報` sheet, locates `同意年月日` and `同意期限` columns, computes expiry per row and writes it back, and throws if required columns are missing.
- Left existing dashboard calculation logic (`calcConsentExpiry_` and dashboard code) unchanged.
- Added unit tests `tests/calculateConsentExpiry.test.js` covering the 1–15 day case, 16+ day case, and invalid date case.

### Testing
- Ran `node tests/calculateConsentExpiry.test.js` and the test suite passed.
- Ran `node tests/getPatientHeaderMonthlySummary.test.js` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699199c955fc8321bc15493133af0d61)