### PR TITLE
Add diagnostic logs for consent eligibility in dashboard

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -184,21 +184,50 @@ function getDashboardData(options) {
       const patientMasterIds = Object.keys(patientMaster || {});
       let consentEligiblePatients = 0;
       let consentEligibleButOutOfScope = 0;
+      let parseFailedCount = 0;
+      let consentAcquiredExcludedCount = 0;
+      let scopeExcludedCount = 0;
 
       patientMasterIds.forEach(pid => {
         const info = patientMaster[pid] || {};
-        const consentExpiryDate = parseConsentDate_(resolveConsentExpiry_(info).value);
+        const consentExpiryResolved = resolveConsentExpiry_(info);
+        const consentExpiryDate = parseConsentDate_(consentExpiryResolved.value);
+        const consentAcquired = dashboardIsConsentAcquired_(info.raw);
+        const inVisibleScope = visiblePatientIds.has(pid);
+        const hasConsentExpiry = consentExpiryResolved.value != null && String(consentExpiryResolved.value).trim() !== '';
+
+        if (hasConsentExpiry && !consentExpiryDate) parseFailedCount += 1;
+        if (consentAcquired) consentAcquiredExcludedCount += 1;
+        if (!inVisibleScope) scopeExcludedCount += 1;
+
+        logContext('getDashboardData:consentEligibilityPatient', JSON.stringify({
+          pid,
+          hasConsentExpiry,
+          parsedConsentExpiry: consentExpiryDate ? consentExpiryDate.toISOString() : null,
+          consentAcquired,
+          inVisibleScope
+        }));
+
         if (!consentExpiryDate) return;
-        if (dashboardIsConsentAcquired_(info.raw)) return;
+        if (consentAcquired) return;
         consentEligiblePatients += 1;
-        if (!visiblePatientIds.has(pid)) consentEligibleButOutOfScope += 1;
+        if (!inVisibleScope) consentEligibleButOutOfScope += 1;
       });
 
+      logContext('getDashboardData:consentEligibleFormula', 'consentEligiblePatients = count(pid where parseConsentDate_(resolveConsentExpiry_(patient).value) != null && dashboardIsConsentAcquired_(patient.raw) === false)');
       logContext('getDashboardData:consentScopeMetrics', JSON.stringify({
         totalPatients: patientMasterIds.length,
         consentEligiblePatients,
         visiblePatientIdsSize: visiblePatientIds.size,
-        consentEligibleButOutOfScope
+        consentEligibleButOutOfScope,
+        parseFailedCount,
+        consentAcquiredExcludedCount,
+        scopeExcludedCount
+      }));
+      logContext('getDashboardData:visibleVsEligible', JSON.stringify({
+        visiblePatientIdsSize: visiblePatientIds.size,
+        consentEligiblePatients,
+        diff: visiblePatientIds.size - consentEligiblePatients
       }));
       logContext(
         'getDashboardData:consentMissingByRecentLog',
@@ -741,36 +770,82 @@ function resolveConsentExpiry_(patient) {
     const entry = candidates[i];
     if (entry.value == null) continue;
     if (typeof entry.value === 'string' && !entry.value.trim()) continue;
+    if (typeof dashboardLogContext_ === 'function') {
+      dashboardLogContext_('resolveConsentExpiry_:result', JSON.stringify({
+        source: entry.source,
+        resolvedValue: entry.value
+      }));
+    }
     return { value: entry.value, source: entry.source };
+  }
+
+  if (typeof dashboardLogContext_ === 'function') {
+    dashboardLogContext_('resolveConsentExpiry_:result', JSON.stringify({
+      source: '',
+      resolvedValue: null
+    }));
   }
 
   return { value: null, source: '' };
 }
 
 function parseConsentDate_(value) {
+  const logParseResult = result => {
+    if (typeof dashboardLogContext_ !== 'function') return;
+    dashboardLogContext_('parseConsentDate_:result', JSON.stringify({
+      input: value,
+      result: result ? result.toISOString() : null
+    }));
+  };
+
   if (value instanceof Date) {
-    return Number.isNaN(value.getTime()) ? null : value;
+    const parsedDate = Number.isNaN(value.getTime()) ? null : value;
+    logParseResult(parsedDate);
+    return parsedDate;
   }
-  if (value == null) return null;
+  if (value == null) {
+    logParseResult(null);
+    return null;
+  }
 
   const str = String(value).trim();
-  if (!str) return null;
+  if (!str) {
+    logParseResult(null);
+    return null;
+  }
 
   const ymdHyphen = str.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
-  if (ymdHyphen) return createDateFromYmd_(ymdHyphen[1], ymdHyphen[2], ymdHyphen[3]);
+  if (ymdHyphen) {
+    const parsedDate = createDateFromYmd_(ymdHyphen[1], ymdHyphen[2], ymdHyphen[3]);
+    logParseResult(parsedDate);
+    return parsedDate;
+  }
 
   const ymdSlash = str.match(/^(\d{4})\/(\d{1,2})\/(\d{1,2})$/);
-  if (ymdSlash) return createDateFromYmd_(ymdSlash[1], ymdSlash[2], ymdSlash[3]);
+  if (ymdSlash) {
+    const parsedDate = createDateFromYmd_(ymdSlash[1], ymdSlash[2], ymdSlash[3]);
+    logParseResult(parsedDate);
+    return parsedDate;
+  }
 
   const ymdJapanese = str.match(/^(\d{4})年(\d{1,2})月(\d{1,2})日$/);
-  if (ymdJapanese) return createDateFromYmd_(ymdJapanese[1], ymdJapanese[2], ymdJapanese[3]);
+  if (ymdJapanese) {
+    const parsedDate = createDateFromYmd_(ymdJapanese[1], ymdJapanese[2], ymdJapanese[3]);
+    logParseResult(parsedDate);
+    return parsedDate;
+  }
 
   const isoPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})?$/;
   if (isoPattern.test(str)) {
     const timestamp = Date.parse(str);
-    if (Number.isFinite(timestamp)) return new Date(timestamp);
+    if (Number.isFinite(timestamp)) {
+      const parsedDate = new Date(timestamp);
+      logParseResult(parsedDate);
+      return parsedDate;
+    }
   }
 
+  logParseResult(null);
   return null;
 }
 

--- a/src/dashboard/data/loadPatientInfo.js
+++ b/src/dashboard/data/loadPatientInfo.js
@@ -60,6 +60,9 @@ function loadPatientInfoUncached_(options) {
   const values = sheet.getRange(2, 1, lastRow - 1, lastCol).getValues();
   const displayValues = sheet.getRange(2, 1, lastRow - 1, lastCol).getDisplayValues();
   const patientIdSamples = [];
+  const consentExpirySamples = [];
+  const rawConsentDateSamples = [];
+  let consentExpiryCount = 0;
 
   for (let i = 0; i < values.length; i++) {
     const row = values[i] || [];
@@ -97,6 +100,17 @@ function loadPatientInfoUncached_(options) {
       raw[key] = row[idx];
     });
 
+    if (consentExpiry) {
+      consentExpiryCount += 1;
+      if (consentExpirySamples.length < 3) {
+        consentExpirySamples.push({ patientId, consentExpiry });
+      }
+    }
+    const rawConsentDate = raw['同意年月日'];
+    if (rawConsentDate != null && String(rawConsentDate).trim() && rawConsentDateSamples.length < 3) {
+      rawConsentDateSamples.push({ patientId, rawConsentDate });
+    }
+
     patients[patientId] = {
       patientId,
       name,
@@ -106,6 +120,9 @@ function loadPatientInfoUncached_(options) {
   }
 
   logContext('loadPatientInfo:patientIdSamples', JSON.stringify(patientIdSamples));
+  logContext('loadPatientInfo:consentExpiryCount', String(consentExpiryCount));
+  logContext('loadPatientInfo:consentExpirySamples', JSON.stringify(consentExpirySamples));
+  logContext('loadPatientInfo:rawConsentDateSamples', JSON.stringify(rawConsentDateSamples));
   const patientMapSize = Object.keys(patients).length;
   logContext('loadPatientInfo:patientMapSize', `size=${patientMapSize}`);
   if (patientMapSize === 0) {


### PR DESCRIPTION
### Motivation
- Instrument dashboard consent filtering to determine why `consentEligiblePatients` can be 0 for staff users by collecting runtime evidence for all candidate failure modes. 
- Provide per-patient and aggregate diagnostics for `resolveConsentExpiry_` and `parseConsentDate_` so the root cause can be asserted from logs rather than guessed. 

### Description
- Added `loadPatientInfo` diagnostics to log `consentExpiry` presence: `consentExpiryCount`, up to 3 `consentExpiry` samples, and up to 3 `raw['同意年月日']` samples to help verify values read from the sheet (`src/dashboard/data/loadPatientInfo.js`).
- In `getDashboardData` staff path added per-patient JSON logs containing `pid`, `hasConsentExpiry`, `parsedConsentExpiry`, `consentAcquired`, and `inVisibleScope`, and introduced aggregate counters `parseFailedCount`, `consentAcquiredExcludedCount`, and `scopeExcludedCount` plus a `visibleVsEligible` delta and an explicit `consentEligibleFormula` log (`src/dashboard/api/getDashboardData.js`).
- Added `resolveConsentExpiry_` logging of `source` and `resolvedValue` for every resolution decision, and added `parseConsentDate_` logging which records the original `input` and parse `result` as an ISO string or `null` for failures (`src/dashboard/api/getDashboardData.js`).

### Testing
- Ran a JavaScript syntax check on the modified files with Node using `node -e "const fs=require('fs');['src/dashboard/data/loadPatientInfo.js','src/dashboard/api/getDashboardData.js'].forEach(f=>{new Function(fs.readFileSync(f,'utf8'));});console.log('syntax ok');"` which completed successfully.
- Changes were committed after validation and are instrumentation-only to be validated further against Apps Script runtime logs in production or test deployments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69919bdd55008321a9e5cc3d32879b30)