### PR TITLE
Add consent eligibility condition breakdown debug logs

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -208,6 +208,28 @@ function getDashboardData(options) {
           inVisibleScope
         }));
 
+        const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+        const parsedConsentExpiry = consentExpiryDate
+          ? new Date(consentExpiryDate.getFullYear(), consentExpiryDate.getMonth(), consentExpiryDate.getDate())
+          : null;
+        const diffMs = parsedConsentExpiry ? parsedConsentExpiry.getTime() - today.getTime() : null;
+        const diffDays = diffMs == null ? null : Math.floor(diffMs / (1000 * 60 * 60 * 24));
+        const threshold = null;
+        const finalCondition = Boolean(consentExpiryDate) && !consentAcquired;
+        Logger.log('[consent-eligible-debug] ' + JSON.stringify({
+          pid,
+          hasConsentExpiry,
+          parsedConsentExpiry: parsedConsentExpiry ? parsedConsentExpiry.toISOString() : null,
+          consentAcquired,
+          inVisibleScope,
+          todayISO: today.toISOString(),
+          expiryISO: parsedConsentExpiry ? parsedConsentExpiry.toISOString() : null,
+          diffMs,
+          diffDays,
+          threshold,
+          finalCondition
+        }));
+
         if (!consentExpiryDate) return;
         if (consentAcquired) return;
         consentEligiblePatients += 1;


### PR DESCRIPTION
### Motivation
- Investigate why `consentEligiblePatients` is zero even when some patients have `consentExpiry` by exposing the per-patient boolean evaluation that gates the increment.

### Description
- Inserted a per-patient debug log immediately before the block that increments `consentEligiblePatients` in `src/dashboard/api/getDashboardData.js` so each patient emits a detailed state dump. 
- The log uses `Logger.log('[consent-eligible-debug] ' + JSON.stringify(...))` and includes the requested fields: `pid`, `hasConsentExpiry`, `parsedConsentExpiry`, `consentAcquired`, `inVisibleScope`, `todayISO`, `expiryISO`, `diffMs`, `diffDays`, `threshold`, and `finalCondition`.
- Computed `today`, `parsedConsentExpiry`, `diffMs`, and `diffDays` locally for clarity and set `finalCondition` to the exact boolean being tested (`Boolean(consentExpiryDate) && !consentAcquired`) without changing the eligibility logic.
- Left all existing control flow and business logic untouched (the `if (!consentExpiryDate) return; if (consentAcquired) return; consentEligiblePatients += 1;` sequence remains the same).

### Testing
- Parsed the modified file with Node via `node -e "const fs=require('fs'); new Function(fs.readFileSync('src/dashboard/api/getDashboardData.js','utf8')); console.log('ok')"` and it completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991a11d60ac8321abb18903e08c6284)