### PR TITLE
Stop dashboard-side consent expiry recalculation fallback

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -794,7 +794,6 @@ function buildOverviewFromConsent_(patientInfo, scope, patientNameMap, now) {
 function resolveConsentExpiry_(patient) {
   const info = patient && typeof patient === 'object' ? patient : {};
   const raw = info.raw && typeof info.raw === 'object' ? info.raw : null;
-  const rawConsentDate = resolvePatientRawValue_(raw, ['同意年月日', '同意日', '同意開始日', '同意開始']);
   const candidates = [
     { source: 'info.consentExpiry', value: info.consentExpiry },
     { source: "raw['同意期限']", value: raw ? raw['同意期限'] : null },
@@ -815,33 +814,10 @@ function resolveConsentExpiry_(patient) {
     return { value: entry.value, source: entry.source };
   }
 
-  if (rawConsentDate != null && String(rawConsentDate).trim()) {
-    const parsedConsentDate = parseConsentDate_(rawConsentDate);
-    const calculatedExpiryDate = parsedConsentDate ? addYearsToDate_(parsedConsentDate, 1) : null;
-    const daysRemaining = calculatedExpiryDate
-      ? dashboardDaysBetween_(dashboardTodayAtTimeZone_(new Date(), 'Asia/Tokyo'), calculatedExpiryDate, true)
-      : null;
-    if (typeof dashboardLogContext_ === 'function') {
-      dashboardLogContext_('resolveConsentExpiry_:consentDateFallback', JSON.stringify({
-        rawConsentDate,
-        parsedConsentDate: parsedConsentDate ? parsedConsentDate.toISOString() : null,
-        calculatedExpiryDate: calculatedExpiryDate ? calculatedExpiryDate.toISOString() : null,
-        daysRemaining
-      }));
-    }
-    if (calculatedExpiryDate) {
-      return {
-        value: dashboardFormatDate_(calculatedExpiryDate, 'Asia/Tokyo', 'yyyy-MM-dd') || calculatedExpiryDate,
-        source: "raw['同意年月日']+1year"
-      };
-    }
-  }
-
   if (typeof dashboardLogContext_ === 'function') {
     dashboardLogContext_('resolveConsentExpiry_:result', JSON.stringify({
       source: '',
-      resolvedValue: null,
-      rawConsentDate: rawConsentDate || null
+      resolvedValue: null
     }));
   }
 
@@ -894,20 +870,6 @@ function parseConsentDate_(value) {
     return parsedDate;
   }
 
-  const eraJapanese = str.match(/^(令和|平成)\s*(元|\d{1,2})年\s*(\d{1,2})月\s*(\d{1,2})日$/);
-  if (eraJapanese) {
-    const eraName = eraJapanese[1];
-    const eraYearRaw = eraJapanese[2];
-    const monthRaw = eraJapanese[3];
-    const dayRaw = eraJapanese[4];
-    const eraYear = eraYearRaw === '元' ? 1 : Number(eraYearRaw);
-    const eraBase = eraName === '令和' ? 2018 : 1988;
-    const year = Number.isFinite(eraYear) ? eraBase + eraYear : NaN;
-    const parsedDate = createDateFromYmd_(year, monthRaw, dayRaw);
-    logParseResult(parsedDate);
-    return parsedDate;
-  }
-
   const isoPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})?$/;
   if (isoPattern.test(str)) {
     const timestamp = Date.parse(str);
@@ -920,24 +882,6 @@ function parseConsentDate_(value) {
 
   logParseResult(null);
   return null;
-}
-
-function addYearsToDate_(date, years) {
-  const base = dashboardCoerceDate_(date);
-  const count = Number(years);
-  if (!base || !Number.isFinite(count)) return null;
-  const next = new Date(base.getFullYear() + count, base.getMonth(), base.getDate());
-  if (Number.isNaN(next.getTime())) return null;
-  return next;
-}
-
-function dashboardTodayAtTimeZone_(now, tz) {
-  const targetNow = dashboardCoerceDate_(now) || new Date();
-  const dayKey = dashboardFormatDate_(targetNow, tz || 'Asia/Tokyo', 'yyyy-MM-dd');
-  if (typeof dayKey !== 'string') return new Date(targetNow.getFullYear(), targetNow.getMonth(), targetNow.getDate());
-  const m = dayKey.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  if (!m) return new Date(targetNow.getFullYear(), targetNow.getMonth(), targetNow.getDate());
-  return createDateFromYmd_(m[1], m[2], m[3]) || new Date(targetNow.getFullYear(), targetNow.getMonth(), targetNow.getDate());
 }
 
 function createDateFromYmd_(yearRaw, monthRaw, dayRaw) {

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -285,9 +285,10 @@ function testConsentDateParsingFormatsAndResolverPriority() {
       '同意年月日': '令和7年6月26日'
     }
   });
-  const normalizedResolvedFromConsentDate = JSON.parse(JSON.stringify(resolvedFromConsentDate));
-  assert.strictEqual(normalizedResolvedFromConsentDate.source, "raw['同意年月日']+1year", '同意期限が無い場合は同意年月日フォールバックを記録する');
-  assert.ok(String(normalizedResolvedFromConsentDate.value).indexOf('2026-06-26') === 0, '同意年月日の +1年を同意期限として扱う');
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(resolvedFromConsentDate)), {
+    value: null,
+    source: ''
+  }, '同意年月日のみでは同意期限を再計算しない');
 
   const result = ctx.getDashboardData({
     user: { email: 'user@example.com', role: 'admin' },
@@ -304,7 +305,7 @@ function testConsentDateParsingFormatsAndResolverPriority() {
         '008': { name: 'H-raw-valid', consentExpiry: '', raw: { '同意有効期限': '2025/02/26' } },
         '009': { name: 'I-raw-date', raw: { '同意期限日': '2025年2月27日' } },
         '010': { name: 'J-acquired', raw: { '同意期限': '2025-02-28', '同意書取得確認': '済' } },
-        '011': { name: 'K-era-consent-date', raw: { '同意年月日': '令和7年1月15日' } }
+        '011': { name: 'K-consent-date-only', raw: { '同意年月日': '令和7年1月15日' } }
       },
       warnings: []
     },
@@ -319,17 +320,18 @@ function testConsentDateParsingFormatsAndResolverPriority() {
   });
 
   const overviewIds = JSON.parse(JSON.stringify(result.overview.consentRelated.items)).map(item => item.patientId);
-  assert.deepStrictEqual(overviewIds, ['001', '002', '003', '004', '005', '007', '008', '009', '011'], '対応フォーマット + raw列解決 + 同意年月日和暦フォールバックのみ表示され、不正値と取得済みは除外される');
+  assert.deepStrictEqual(overviewIds, ['001', '002', '003', '004', '005', '007', '008', '009'], '同意期限がある患者のみ表示され、同意年月日のみでは表示しない');
 
   const patientsById = {};
   result.patients.forEach(entry => {
     patientsById[entry.patientId] = JSON.parse(JSON.stringify(entry.statusTags));
   });
-  ['001', '002', '003', '004', '005', '007', '008', '009', '011'].forEach(patientId => {
+  ['001', '002', '003', '004', '005', '007', '008', '009'].forEach(patientId => {
     assert.deepStrictEqual((patientsById[patientId] || []).filter(tag => tag.type === 'consent'), [{ type: 'consent', label: '要対応' }], `同意タグが表示される: ${patientId}`);
   });
   assert.deepStrictEqual((patientsById['006'] || []).filter(tag => tag.type === 'consent'), [], '不正文字列は同意タグの表示対象外');
   assert.deepStrictEqual((patientsById['010'] || []).filter(tag => tag.type === 'consent'), [], '取得済み判定は従来通り同意タグ非表示');
+  assert.deepStrictEqual((patientsById['011'] || []).filter(tag => tag.type === 'consent'), [], '同意年月日のみでは同意タグを表示しない');
 }
 
 function testConsentDateParseFailureCanBeDebugLogged() {


### PR DESCRIPTION
### Motivation
- Centralize consent expiry calculation in `Code.js` and remove any dashboard-side recomputation and era/month-end heuristics so the dashboard treats missing `consentExpiry` as genuinely absent.

### Description
- Removed the `raw['同意年月日']` fallback and +1 year recalculation from `resolveConsentExpiry_` in `src/dashboard/api/getDashboardData.js` so the function returns `null` when no explicit expiry is present.
- Deleted the era-based parsing branch from `parseConsentDate_` and removed helper functions used only for consent-date->expiry recalculation (`addYearsToDate_`, `dashboardTodayAtTimeZone_`) so dashboard code no longer interprets Japanese-era dates for expiry computation.
- Cleaned up related logging to stop reporting a consent-date fallback source and left the `getDashboardData` consent-eligibility formula unchanged (`parseConsentDate_(resolveConsentExpiry_(...).value) != null && !dashboardIsConsentAcquired_(...)`).
- Updated `tests/dashboardGetDashboardData.test.js` to assert that: a patient with an explicit consent expiry is shown, a patient without an expiry is not shown, and a patient with only `同意年月日` is not recalculated/displayed.

### Testing
- Ran the dashboard consent tests with `node tests/dashboardGetDashboardData.test.js` and they passed.
- Verified the modified tests assert the three targeted behaviors (expiry present, expiry absent, consent-date-only not recalculated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991a8880458832199d9a7a27c7f3ed1)