### PR TITLE
Improve consent column detection and logging

### DIFF
--- a/docs/consent-expiry-investigation.md
+++ b/docs/consent-expiry-investigation.md
@@ -1,0 +1,43 @@
+# Consent Expiry Data-Layer Investigation
+
+## 1) resolveConsentExpiry_ 実装確認
+- 参照キー（優先順）
+  1. `info.consentExpiry`
+  2. `raw['同意期限']`
+  3. `raw['同意有効期限']`
+  4. `raw['同意期限日']`
+- `raw['consentExpiry']` は参照していない。
+- `patientInfo` の `patients[pid]` オブジェクトを受け取り、`patient.raw` を読む。
+- `null` 扱い条件:
+  - 値が `null/undefined`
+  - 文字列かつ trim 後に空文字
+
+## 2) loadPatientInfo のカラムマッピング確認
+- ヘッダは `getDisplayValues()` で取得。
+- 同意期限列の候補: `['同意期限', '同意書期限', '同意有効期限', '同意期限日']`。
+- マッチ方式:
+  - ヘッダは trim + lowercase で正規化
+  - 候補側も trim + lowercase で正規化
+  - 完全一致比較
+- index は 1-origin（見つからない場合は 0）。
+- `raw` オブジェクト生成:
+  - 全ヘッダを走査し、`raw[String(header).trim()] = row[idx]` を格納。
+
+## 3) 実シート構造確認
+- ローカルリポジトリ環境では Google Apps Script 実行コンテキスト・実スプレッドシートへの接続がないため未実施。
+
+## 4) PID単体検証
+- 実シートデータにアクセスできないため未実施。
+
+## 5) parseConsentDate_ の挙動
+- 受理フォーマット:
+  - `Date` オブジェクト（有効日付）
+  - `yyyy-M-d` / `yyyy-MM-dd`
+  - `yyyy/M/d` / `yyyy/MM/dd`
+  - `yyyy年M月d日`
+  - ISO日時（例: `2025-02-01T00:00:00Z`）
+- `null` になる主な条件:
+  - `null/undefined`
+  - 空文字
+  - 上記いずれのフォーマットにも一致しない
+  - 数値として不正な日付（例: 2025-02-30）

--- a/src/Code.js
+++ b/src/Code.js
@@ -6942,13 +6942,17 @@ function rebuildAllConsentExpiry_() {
     throw new Error('必要な列が見つかりません');
   }
 
+  let updatedCount = 0;
   for (let i = 1; i < values.length; i++) {
     const consentDateRaw = values[i][colConsentDate];
     if (!consentDateRaw) continue;
 
     const expiry = calculateConsentExpiry_(consentDateRaw);
     sheet.getRange(i + 1, colExpiry + 1).setValue(expiry);
+    updatedCount += 1;
   }
+
+  Logger.log('[consent-rebuild] updatedCount=' + updatedCount);
 }
 
 function calcConsentExpiry_(consentVal) {

--- a/src/dashboard/data/loadPatientInfo.js
+++ b/src/dashboard/data/loadPatientInfo.js
@@ -55,7 +55,14 @@ function loadPatientInfoUncached_(options) {
   const colPid = dashboardResolveColumn_(headers, ['患者ID', 'patientId', 'ID', 'id', '施術録番号'], 1);
   logContext('loadPatientInfo:patientIdColumn', `index=${colPid}`);
   const colName = dashboardResolveColumn_(headers, ['氏名', '名前', '患者名'], 2);
-  const colConsent = dashboardResolveColumn_(headers, ['同意期限', '同意書期限', '同意有効期限', '同意期限日'], 0);
+  const consentExpiryColumnIndex = dashboardResolveColumn_(headers, ['同意期限', '同意書期限', '同意有効期限', '同意期限日'], 0);
+  if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+    Logger.log('[consent-header-debug] ' + JSON.stringify(headers));
+    Logger.log('[consent-column-index] ' + consentExpiryColumnIndex);
+  }
+  if (consentExpiryColumnIndex === 0) {
+    throw new Error('同意期限列が検出できません。ヘッダ不一致の可能性があります。');
+  }
 
   const values = sheet.getRange(2, 1, lastRow - 1, lastCol).getValues();
   const displayValues = sheet.getRange(2, 1, lastRow - 1, lastCol).getDisplayValues();
@@ -74,8 +81,8 @@ function loadPatientInfoUncached_(options) {
       patientIdSamples.push(patientId);
     }
     const name = String(rowDisplay[colName - 1] || row[colName - 1] || '').trim();
-    const consentExpiry = colConsent
-      ? String(rowDisplay[colConsent - 1] || row[colConsent - 1] || '').trim()
+    const consentExpiry = consentExpiryColumnIndex
+      ? String(rowDisplay[consentExpiryColumnIndex - 1] || row[consentExpiryColumnIndex - 1] || '').trim()
       : '';
 
     if (!patientId) {

--- a/src/dashboard/utils/sheetUtils.js
+++ b/src/dashboard/utils/sheetUtils.js
@@ -273,12 +273,18 @@ function dashboardResolvePatientIdFromName_(name, nameToId) {
 }
 
 function dashboardResolveColumn_(headers, candidates, fallbackIndex) {
+  const normalize = s => String(s)
+    .trim()
+    .toLowerCase()
+    .replace(/\s/g, '')
+    .replace(/[　]/g, '');
+
   if (Array.isArray(candidates)) {
-    const normalizedHeaders = (headers || []).map(h => String(h || '').trim().toLowerCase());
+    const normalizedHeaders = (headers || []).map(h => normalize(h || ''));
     for (let i = 0; i < normalizedHeaders.length; i++) {
       const header = normalizedHeaders[i];
       if (!header) continue;
-      if (candidates.some(c => header === String(c || '').trim().toLowerCase())) {
+      if (candidates.some(c => header === normalize(c || ''))) {
         return i + 1;
       }
     }


### PR DESCRIPTION
### Motivation
- Improve reliability of detecting the consent-expiry column in the patient master so missing/ambiguous headers are diagnosed quickly.
- Make header matching more robust to whitespace and full-width space variations to reduce false negatives when resolving columns.
- Surface actionable debug information and counts during consent rebuild operations to aid investigation of missing `consentExpiry` values.

### Description
- Strengthen `dashboardResolveColumn_` normalization to compare headers and candidates after `trim`, `toLowerCase`, removing ASCII whitespace and full-width spaces via `replace(/\s/g, '')` and `replace(/[　]/g, '')` so matches ignore spacing differences. (`src/dashboard/utils/sheetUtils.js`)
- Add debug logging right after resolving the consent column in `loadPatientInfoUncached_`, logging full `headers` as `[consent-header-debug]` and the resolved index as `[consent-column-index]`, and throw immediately when the resolved index is `0` with message `同意期限列が検出できません。ヘッダ不一致の可能性があります。`. Also switch consent value reads to use the resolved `consentExpiryColumnIndex`. (`src/dashboard/data/loadPatientInfo.js`)
- Add an `updatedCount` increment and final log `Logger.log('[consent-rebuild] updatedCount=' + updatedCount);` to `rebuildAllConsentExpiry_` so rebuild runs report how many rows were updated. (`src/Code.js`)
- Preserve existing consent calculation, dashboard recalculation, and UI logic; changes are limited to detection/normalization and logging only.

### Testing
- Ran `node tests/dashboardGetDashboardData.test.js` and it completed successfully (dashboard-focused test passed).
- Ran `node tests/dashboardGetDashboardDataOptions.test.js` and `node tests/dashboardCachingPerf.test.js` and both completed successfully.
- Attempted a full test sweep but an unrelated existing failure was observed in `tests/aggregateBillingFromBankFlags.test.js`, so the entire suite did not fully pass; the failure is not related to these consent-detection changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991b4d4ebe88321a7ddbbea9f044689)