### PR TITLE
reportタグ消失と時刻依存の同意日数判定を修正

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -520,7 +520,6 @@ function buildDashboardPatientStatusTags_(patient, params, maybeNow) {
   const consentExpiryDate = parseConsentDate_(consentExpiryResolved.value);
   const raw = patient && patient.raw ? patient.raw : null;
   const consentAcquired = dashboardIsConsentAcquired_(raw);
-  const daysRemaining = consentExpiryDate ? dashboardDaysBetween_(targetNow, consentExpiryDate, true) : null;
 
   if (shouldDebugConsent_() && consentExpiryResolved.value != null && !consentExpiryDate) {
     dashboardLogContext_('consent-date-parse-failed', JSON.stringify({
@@ -531,23 +530,17 @@ function buildDashboardPatientStatusTags_(patient, params, maybeNow) {
     }));
   }
 
-  if (!consentAcquired && consentExpiryDate) {
-    if (daysRemaining > 30) {
-      return tags;
-    }
-    let label = '📄 要対応';
-    let priority = 'low';
-    if (daysRemaining < 0) {
-      label = '⚠ 期限超過';
-      priority = 'high';
-    } else if (daysRemaining <= 14) {
-      label = '⏳ 期限迫る';
-      priority = 'medium';
-    } else if (daysRemaining <= 30) {
-      label = '📄 要対応';
-      priority = 'low';
-    }
-    tags.push({ type: 'consent', label, priority });
+  const consentStatus = !consentAcquired
+    ? evaluateConsentStatus_(consentExpiryDate, targetNow)
+    : null;
+
+  if (consentStatus) {
+    const labelMap = {
+      expired: '⚠ 期限超過',
+      warning: '⏳ 期限迫る',
+      normal: '📄 要対応'
+    };
+    tags.push({ type: 'consent', label: labelMap[consentStatus.type] || '📄 要対応', priority: consentStatus.priority });
   }
 
   const reportDate = dashboardParseTimestamp_(aiReportAt);
@@ -566,6 +559,22 @@ function dashboardDaysBetween_(from, to, futurePositive) {
   const diff = end.getTime() - start.getTime();
   const days = Math.floor(diff / (24 * 60 * 60 * 1000));
   return futurePositive ? days : Math.abs(days);
+}
+
+function evaluateConsentStatus_(consentExpiryDate, today) {
+  const expiry = parseConsentDate_(consentExpiryDate);
+  if (!expiry) return null;
+  const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const expiryStart = new Date(expiry.getFullYear(), expiry.getMonth(), expiry.getDate());
+  const diffDays = dashboardDaysBetween_(todayStart, expiryStart, true);
+  if (diffDays > 30) return null;
+  if (diffDays < 0) {
+    return { type: 'expired', days: diffDays, priority: 'high' };
+  }
+  if (diffDays <= 14) {
+    return { type: 'warning', days: diffDays, priority: 'medium' };
+  }
+  return { type: 'normal', days: diffDays, priority: 'low' };
 }
 
 function normalizeDashboardNote_(note, patientId) {
@@ -780,17 +789,13 @@ function buildOverviewFromConsent_(patientInfo, scope, patientNameMap, now) {
     }
     if (consentAcquired || !consentExpiryDate) return;
 
-    const todayStart = new Date(targetNow.getFullYear(), targetNow.getMonth(), targetNow.getDate());
-    const expiryStart = new Date(consentExpiryDate.getFullYear(), consentExpiryDate.getMonth(), consentExpiryDate.getDate());
-    const diffDays = Math.floor((expiryStart.getTime() - todayStart.getTime()) / (24 * 60 * 60 * 1000));
-    if (diffDays > 30) return;
-    let label = `同意期限（残${diffDays}日）`;
-    if (diffDays < 0) {
-      label = `⚠ 同意期限超過（${Math.abs(diffDays)}日超過）`;
-    } else if (diffDays <= 14) {
-      label = `⏳ 同意期限迫る（残${diffDays}日）`;
-    } else if (diffDays <= 30) {
-      label = `同意期限（残${diffDays}日）`;
+    const consentStatus = evaluateConsentStatus_(consentExpiryDate, targetNow);
+    if (!consentStatus) return;
+    let label = `同意期限（残${consentStatus.days}日）`;
+    if (consentStatus.type === 'expired') {
+      label = `⚠ 同意期限超過（${Math.abs(consentStatus.days)}日超過）`;
+    } else if (consentStatus.type === 'warning') {
+      label = `⏳ 同意期限迫る（残${consentStatus.days}日）`;
     }
     const name = info.name || patientNameMap[pid] || '';
     items.push({

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -166,7 +166,9 @@ function testPatientStatusTagsGeneration() {
 
   assert.deepStrictEqual(patientsById['004'], [], '4. 同意取得確認ありは両タグを非表示にする');
 
-  assert.deepStrictEqual(patientsById['005'], [], '5. 同意期限30日超はタグを表示しない');
+  assert.deepStrictEqual(patientsById['005'], [
+    { type: 'report', label: '未作成' }
+  ], '5. 同意期限30日超はconsent非表示だがreportは表示する');
 
   assert.deepStrictEqual(patientsById['006'], [
     { type: 'consent', label: '📄 要対応', priority: 'low' },
@@ -222,6 +224,67 @@ function testConsentOverviewMatchesPatientStatusTags() {
   assert.deepStrictEqual((patientsById['003'] || []).filter(tag => tag.type === 'consent'), [], 'Case3: 同意取得確認済');
   assert.deepStrictEqual((patientsById['004'] || []).filter(tag => tag.type === 'consent'), [], 'Case4: 期限未登録');
   assert.deepStrictEqual((patientsById['005'] || []).filter(tag => tag.type === 'consent'), [{ type: 'consent', label: '📄 要対応', priority: 'low' }], 'Case5: 期限内・未取得');
+}
+
+
+function testEvaluateConsentStatusBoundaries() {
+  const ctx = createContext();
+  const today = new Date('2025-02-01T00:00:00Z');
+
+  const expired = JSON.parse(JSON.stringify(ctx.evaluateConsentStatus_(new Date('2025-01-31T00:00:00Z'), today)));
+  assert.deepStrictEqual(expired, { type: 'expired', days: -1, priority: 'high' }, 'expired: 期限超過は high');
+
+  const warning = JSON.parse(JSON.stringify(ctx.evaluateConsentStatus_(new Date('2025-02-15T00:00:00Z'), today)));
+  assert.deepStrictEqual(warning, { type: 'warning', days: 14, priority: 'medium' }, 'warning: 14日以内は medium');
+
+  const normal = JSON.parse(JSON.stringify(ctx.evaluateConsentStatus_(new Date('2025-02-16T00:00:00Z'), today)));
+  assert.deepStrictEqual(normal, { type: 'normal', days: 15, priority: 'low' }, 'normal: 15〜30日は low');
+
+  const hiddenOver30 = ctx.evaluateConsentStatus_(new Date('2025-03-04T00:00:00Z'), today);
+  assert.strictEqual(hiddenOver30, null, '30日超は非表示');
+
+  const hiddenNoDate = ctx.evaluateConsentStatus_(null, today);
+  assert.strictEqual(hiddenNoDate, null, '同意年月日なしは非表示');
+}
+
+
+function testConsentOver30DaysStillShowsReportTag() {
+  const ctx = createContext();
+  const result = ctx.getDashboardData({
+    user: { email: 'user@example.com', role: 'admin' },
+    now: new Date('2025-02-01T00:00:00Z'),
+    patientInfo: {
+      patients: {
+        '001': { name: '同意期限30日超', raw: { '同意年月日': '2024-09-16' } }
+      },
+      warnings: []
+    },
+    notes: { notes: {}, warnings: [] },
+    aiReports: { reports: {}, warnings: [] },
+    invoices: { invoices: {}, warnings: [] },
+    treatmentLogs: { logs: [], warnings: [] },
+    responsible: { responsible: {}, warnings: [] },
+    unpaidAlerts: { alerts: [], warnings: [] },
+    tasksResult: { tasks: [], warnings: [] },
+    visitsResult: { visits: [], warnings: [] }
+  });
+
+  const tags = JSON.parse(JSON.stringify(result.patients[0].statusTags));
+  assert.deepStrictEqual(tags.filter(tag => tag.type === 'consent'), [], '30日超はconsentタグ非表示');
+  assert.deepStrictEqual(tags.filter(tag => tag.type === 'report'), [{ type: 'report', label: '未作成' }], '30日超でもreportタグは表示');
+}
+
+function testEvaluateConsentStatusIsTimeIndependentForSameDate() {
+  const ctx = createContext();
+
+  const onDeadline = JSON.parse(JSON.stringify(ctx.evaluateConsentStatus_(new Date('2025-02-01T00:00:00Z'), new Date('2025-02-01T12:34:56Z'))));
+  assert.deepStrictEqual(onDeadline, { type: 'warning', days: 0, priority: 'medium' }, '期限当日(diffDays=0)はwarning');
+
+  const dayBeforeLateNight = JSON.parse(JSON.stringify(ctx.evaluateConsentStatus_(new Date('2025-02-01T00:00:00Z'), new Date('2025-01-31T23:59:00Z'))));
+  assert.deepStrictEqual(dayBeforeLateNight, { type: 'warning', days: 1, priority: 'medium' }, '期限前日23:59はwarning');
+
+  const sameDayAfterMidnight = JSON.parse(JSON.stringify(ctx.evaluateConsentStatus_(new Date('2025-02-01T00:00:00Z'), new Date('2025-02-01T00:01:00Z'))));
+  assert.deepStrictEqual(sameDayAfterMidnight, { type: 'warning', days: 0, priority: 'medium' }, '期限当日00:01はwarning（時刻非依存）');
 }
 
 function testConsentAcquiredJudgmentHandlesFalseyStringsConsistently() {
@@ -926,6 +989,9 @@ function testWarningsAreDedupedAndSetupFlagged() {
   testAggregatesDashboardData();
   testPatientStatusTagsGeneration();
   testConsentOverviewMatchesPatientStatusTags();
+  testEvaluateConsentStatusBoundaries();
+  testConsentOver30DaysStillShowsReportTag();
+  testEvaluateConsentStatusIsTimeIndependentForSameDate();
   testConsentAcquiredJudgmentHandlesFalseyStringsConsistently();
   testConsentDateParsingFormatsAndResolverPriority();
   testConsentDateParseFailureCanBeDebugLogged();


### PR DESCRIPTION
### Motivation
- `evaluateConsentStatus_` 導入後に、同意期限が30日超で `consentStatus === null` のケースで report タグまで早期に消えてしまう不具合を修正するため。 
- 同意期限の残日数算出が時刻に依存して境界判定が不安定になる問題を解消するため。 

### Description
- `buildDashboardPatientStatusTags_` の早期 `return`（`else if (consentExpiryDate) { return tags; }`）を削除し、`consentStatus` が `null` の場合でも report タグ生成処理まで評価するように変更しました。 
- `evaluateConsentStatus_` 内で `today` と `expiry` を日付単位に丸め（`todayStart` / `expiryStart`）、その上で `dashboardDaysBetween_` を使って差分（日数）を計算するように変更しました。 
- `buildDashboardPatientStatusTags_` と `buildOverviewFromConsent_` の表示ロジックは `evaluateConsentStatus_` の戻り値（`null` または `{ type, days, priority }`）を参照するように統一しました。 
- 関連テストを更新および追加し、期待挙動（30日超で consent 非表示だが report は表示、時刻非依存の境界判定など）を検証するコードを追加しました（変更ファイル: `src/dashboard/api/getDashboardData.js`, `tests/dashboardGetDashboardData.test.js`）。

### Testing
- `node tests/dashboardGetDashboardData.test.js` を実行し、全テストが成功しました。 
- `node tests/dashboardPatientStatusTagsRendering.test.js` を実行し、全テストが成功しました.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992a02611008321bc853403953d32f4)