### PR TITLE
Limit consent eligibility evaluation to visible/matched dashboard patients

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -190,10 +190,14 @@ function getDashboardData(options) {
 
       patientMasterIds.forEach(pid => {
         const info = patientMaster[pid] || {};
+        const inVisibleScope = visiblePatientIds.has(pid);
+        const shouldEvaluateConsent = inVisibleScope || matchedPatientIds.has(pid);
+
+        if (!shouldEvaluateConsent) return;
+
         const consentExpiryResolved = resolveConsentExpiry_(info);
         const consentExpiryDate = parseConsentDate_(consentExpiryResolved.value);
         const consentAcquired = dashboardIsConsentAcquired_(info.raw);
-        const inVisibleScope = visiblePatientIds.has(pid);
         const hasConsentExpiry = consentExpiryResolved.value != null && String(consentExpiryResolved.value).trim() !== '';
 
         if (hasConsentExpiry && !consentExpiryDate) parseFailedCount += 1;

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -543,6 +543,54 @@ function testStaffConsentScopeMetricsAreLogged() {
   assert.ok(logEntries.some(entry => entry.label === 'buildOverviewFromConsent_:scope'), 'buildOverviewFromConsent_:scope ログが出力される');
 }
 
+function testStaffConsentEligibilityEvaluatesOnlyVisibleOrMatchedPatients() {
+  const logEntries = [];
+  const ctx = createContext();
+  ctx.dashboardLogContext_ = (label, details) => {
+    logEntries.push({ label, details: String(details || '') });
+  };
+
+  const result = ctx.getDashboardData({
+    user: 'staff@example.com',
+    now: new Date('2025-02-20T00:00:00Z'),
+    patientInfo: {
+      patients: {
+        '001': { name: '患者A', raw: { '同意年月日': '2024-09-16' } },
+        '002': { name: '患者B', raw: { '同意年月日': '2024-09-16' } },
+        '003': { name: '患者C', raw: { '同意年月日': '2024-09-16' } }
+      },
+      warnings: []
+    },
+    notes: { notes: {}, warnings: [] },
+    aiReports: { reports: {}, warnings: [] },
+    invoices: { invoices: {}, warnings: [] },
+    treatmentLogs: {
+      logs: [
+        { patientId: '001', timestamp: new Date('2025-02-10T09:00:00Z'), staffKeys: { email: 'staff@example.com', name: '', staffId: '' } },
+        { patientId: '002', timestamp: new Date('2024-12-01T09:00:00Z'), staffKeys: { email: 'staff@example.com', name: '', staffId: '' } }
+      ],
+      warnings: []
+    },
+    responsible: { responsible: {}, warnings: [] },
+    unpaidAlerts: { alerts: [], warnings: [] },
+    visitsResult: { visits: [], warnings: [] }
+  });
+
+  assert.strictEqual(result.meta.error, undefined);
+
+  const eligibilityLogs = logEntries
+    .filter(entry => entry.label === 'getDashboardData:consentEligibilityPatient')
+    .map(entry => JSON.parse(entry.details).pid)
+    .sort();
+  assert.deepStrictEqual(eligibilityLogs, ['001', '002'], '可視範囲または一致患者のみ同意評価ログに含まれる');
+
+  const consentDebugLogs = logEntries
+    .filter(entry => entry.label === 'consent-eligible-debug')
+    .map(entry => JSON.parse(entry.details).pid)
+    .sort();
+  assert.deepStrictEqual(consentDebugLogs, ['001', '002'], '可視範囲外かつ一致しない患者は同意デバッグログを出力しない');
+}
+
 function testVisitSummaryWhenTodayIsZeroUsesLatestPastDayCount() {
   const ctx = createContext({
     Utilities: {
@@ -997,6 +1045,7 @@ function testWarningsAreDedupedAndSetupFlagged() {
   testConsentDateParseFailureCanBeDebugLogged();
   testStaffMatchingUsesEmailNameAndStaffIdWithLogs();
   testStaffConsentScopeMetricsAreLogged();
+  testStaffConsentEligibilityEvaluatesOnlyVisibleOrMatchedPatients();
   testVisitSummaryWhenTodayIsZeroUsesLatestPastDayCount();
   testVisitSummaryWhenTodayHasTwoUsesTodayCountForBoth();
   testVisitSummaryWhenNoDataReturnsZeroCounts();


### PR DESCRIPTION
### Motivation
- Reduce unnecessary work and noisy debug logs by skipping consent evaluation for patients outside the staff-visible scope and not matched to the staff user. 
- Keep business logic identical while improving dashboard performance when computing consent-related metrics.

### Description
- Gate the consent eligibility loop in `getDashboardData` so it only processes a patient when `inVisibleScope === true` OR the patient id exists in `matchedPatientIds`, by adding a `shouldEvaluateConsent` check and early `return` for other patients in `src/dashboard/api/getDashboardData.js`.
- This prevents calling `resolveConsentExpiry_`, `parseConsentDate_`, and emitting per-patient consent debug logs for out-of-scope, unmatched patients while preserving the existing consent rules and thresholds.
- Added a regression test `testStaffConsentEligibilityEvaluatesOnlyVisibleOrMatchedPatients` in `tests/dashboardGetDashboardData.test.js` that asserts consent eligibility/debug logs are emitted only for visible-or-matched patients and not for an out-of-scope unmatched patient.

### Testing
- Ran the dashboard test suite with `node tests/dashboardGetDashboardData.test.js`, and the suite completed successfully (`dashboardGetDashboardData tests passed`).
- The new regression test verifies that only patients in `visiblePatientIds` or `matchedPatientIds` produce `getDashboardData:consentEligibilityPatient` and `consent-eligible-debug` logs.
- Existing tests remain green and no behavioral changes to the dashboard output were introduced; only execution scope was restricted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992a8712ed48321a4ed6bf98feb86a1)