### PR TITLE
Support Japanese-era consent dates in consent expiry resolution

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -831,7 +831,8 @@ function resolveConsentExpiry_(patient) {
   const consentDateRaw = raw ? raw['同意年月日'] : null;
 
   if (consentDateRaw != null && String(consentDateRaw).trim()) {
-    const expiryDate = calculateConsentExpiryDateFromConsentDate_(consentDateRaw);
+    const normalizedConsentDate = parseJapaneseEraDate_(consentDateRaw) || consentDateRaw;
+    const expiryDate = calculateConsentExpiryDateFromConsentDate_(normalizedConsentDate);
     if (expiryDate) {
       if (typeof dashboardLogContext_ === 'function') {
         dashboardLogContext_('resolveConsentExpiry_:result', JSON.stringify({
@@ -857,6 +858,37 @@ function calculateConsentExpiryDateFromConsentDate_(consentDateRaw) {
   if (typeof calculateConsentExpiry_ !== 'function') return null;
   const calculated = calculateConsentExpiry_(consentDateRaw);
   return parseConsentDate_(calculated);
+}
+
+function parseJapaneseEraDate_(value) {
+  if (value == null) return null;
+
+  const str = String(value).trim();
+  if (!str) return null;
+
+  const matched = str.match(/^(令和|平成)\s*(元|\d{1,2})年\s*(\d{1,2})月\s*(\d{1,2})日$/);
+  if (!matched) return null;
+
+  const era = matched[1];
+  const eraYearRaw = matched[2];
+  const month = Number(matched[3]);
+  const day = Number(matched[4]);
+  const eraYear = eraYearRaw === '元' ? 1 : Number(eraYearRaw);
+
+  if (!Number.isInteger(eraYear) || eraYear < 1) return null;
+
+  const westernYear = era === '令和'
+    ? 2018 + eraYear
+    : 1988 + eraYear;
+
+  const parsed = createDateFromYmd_(westernYear, month, day);
+  if (!parsed) return null;
+
+  return [
+    String(westernYear).padStart(4, '0'),
+    String(month).padStart(2, '0'),
+    String(day).padStart(2, '0')
+  ].join('-');
 }
 
 function parseConsentDate_(value) {

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -339,6 +339,31 @@ function testConsentAcquiredJudgmentHandlesFalseyStringsConsistently() {
 }
 
 
+
+function testParseJapaneseEraDateAndResolveConsentExpiry() {
+  const ctx = createContext();
+
+  assert.strictEqual(ctx.parseJapaneseEraDate_('令和7年6月26日'), '2025-06-26', '令和を西暦に変換する');
+  assert.strictEqual(ctx.parseJapaneseEraDate_('令和元年5月1日'), '2019-05-01', '令和元年を1年として扱う');
+  assert.strictEqual(ctx.parseJapaneseEraDate_('平成30年4月10日'), '2018-04-10', '平成年号を西暦に変換する');
+  assert.strictEqual(ctx.parseJapaneseEraDate_('不正文字列'), null, '不正文字列は null を返す');
+
+  const reiwaResolved = JSON.parse(JSON.stringify(ctx.resolveConsentExpiry_({
+    raw: { '同意年月日': '令和7年6月26日' }
+  })));
+  assert.strictEqual(reiwaResolved.value, '2025-12-31T00:00:00.000Z', '令和7年6月26日は月末期限を算出できる');
+
+  const heiseiResolved = JSON.parse(JSON.stringify(ctx.resolveConsentExpiry_({
+    raw: { '同意年月日': '平成30年4月10日' }
+  })));
+  assert.strictEqual(heiseiResolved.value, '2018-09-30T00:00:00.000Z', '平成30年4月10日を変換して期限算出できる');
+
+  const invalidResolved = JSON.parse(JSON.stringify(ctx.resolveConsentExpiry_({
+    raw: { '同意年月日': '不正文字列' }
+  })));
+  assert.strictEqual(invalidResolved.value, null, '不正文字列は同意期限を解決しない');
+}
+
 function testConsentDateParsingFormatsAndResolverPriority() {
   const ctx = createContext();
   const now = new Date('2025-02-01T00:00:00Z');
@@ -1042,6 +1067,7 @@ function testWarningsAreDedupedAndSetupFlagged() {
   testEvaluateConsentStatusIsTimeIndependentForSameDate();
   testConsentAcquiredJudgmentHandlesFalseyStringsConsistently();
   testConsentDateParsingFormatsAndResolverPriority();
+  testParseJapaneseEraDateAndResolveConsentExpiry();
   testConsentDateParseFailureCanBeDebugLogged();
   testStaffMatchingUsesEmailNameAndStaffIdWithLogs();
   testStaffConsentScopeMetricsAreLogged();


### PR DESCRIPTION
### Motivation
- `resolveConsentExpiry_` previously relied on `calculateConsentExpiry_` with raw date strings and `new Date(...)`, so Japanese-era (和暦) inputs like "令和7年6月26日" were treated as invalid and produced null results.
- Add preprocessing to interpret common 和暦 formats (令和/平成, including `元年`) and convert them to ISO `yyyy-MM-dd` so existing expiry calculation can be reused unchanged.

### Description
- Updated `resolveConsentExpiry_` to normalize `raw['同意年月日']` by running it through `parseJapaneseEraDate_` and passing the converted value to the existing expiry calculation when parsing succeeds via `const normalizedConsentDate = parseJapaneseEraDate_(consentDateRaw) || consentDateRaw;`.
- Implemented new helper `parseJapaneseEraDate_` that accepts formats like `令和7年6月26日`, `令和元年5月1日`, and `平成30年4月10日`, converts `令和`→`2018 + 年数` and `平成`→`1988 + 年数` (treating `元年` as year 1), validates the date via `createDateFromYmd_`, and returns `yyyy-MM-dd` on success.
- Kept the existing expiry logic (`calculateConsentExpiry_` and `parseConsentDate_`) unchanged and only added the era parsing as a preprocessing step.
- Added a new test `testParseJapaneseEraDateAndResolveConsentExpiry` to `tests/dashboardGetDashboardData.test.js` that verifies Reiwa/Heisei conversion, `元年` handling, invalid input behavior, and that `resolveConsentExpiry_` integrates with the converter.

### Testing
- Ran `node tests/dashboardGetDashboardData.test.js` and the full test run completed successfully with output `dashboardGetDashboardData tests passed`.
- Ran `node tests/calculateConsentExpiry.test.js` and it passed with `calculateConsentExpiry tests passed`.
- Attempted `npm test -- tests/dashboardGetDashboardData.test.js` but it failed due to missing `package.json` in the environment, which is an unrelated environment constraint.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992ae4799fc832199b4d94dc027c48d)