### PR TITLE
和暦入力に対応した同意期限計算の修正

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -6893,9 +6893,9 @@ function parseDateFlexible_(v) {
   if (!raw) return null;
 
   // 和暦（正式）
-  const era = raw.match(/(令和|平成|昭和)\s*(\d+)[\/\-.年](\d{1,2})[\/\-.月](\d{1,2})/);
+  const era = raw.match(/(令和|平成|昭和)\s*(元|\d+)[\/\-.年](\d{1,2})[\/\-.月](\d{1,2})/);
   if (era) {
-    const eraName = era[1], y = Number(era[2]), m = Number(era[3]), d = Number(era[4]);
+    const eraName = era[1], y = era[2] === '元' ? 1 : Number(era[2]), m = Number(era[3]), d = Number(era[4]);
     const base = eraName === '令和' ? 2018 : eraName === '平成' ? 1988 : 1925; // R1=2019, H1=1989, S1=1926
     return new Date(base + y, m - 1, d);
   }
@@ -6918,8 +6918,8 @@ function parseDateFlexible_(v) {
 }
 
 function calculateConsentExpiry_(dateRaw) {
-  const d = new Date(dateRaw);
-  if (isNaN(d.getTime())) return '';
+  const d = parseDateFlexible_(dateRaw);
+  if (!(d instanceof Date) || isNaN(d.getTime())) return '';
 
   const day = d.getDate();
   const monthsToAdd = day <= 15 ? 5 : 6;

--- a/tests/calculateConsentExpiry.test.js
+++ b/tests/calculateConsentExpiry.test.js
@@ -26,7 +26,9 @@ sandbox.Utilities = {
     { input: '2024-01-10', expected: '2024-06-30' },
     { input: '2024-01-20', expected: '2024-07-31' },
     { input: '2024-03-31', expected: '2024-09-30' },
-    { input: '2024-08-16', expected: '2025-02-28' }
+    { input: '2024-08-16', expected: '2025-02-28' },
+    { input: '令和7年6月26日', expected: '2025-12-31' },
+    { input: '令和7年1月10日', expected: '2025-06-30' }
   ];
 
   cases.forEach(({ input, expected }) => {


### PR DESCRIPTION
### Motivation
- `calculateConsentExpiry_` が `new Date(dateRaw)` を直接使っていたため、和暦表記（例: `令和7年6月26日`）を正しく解釈できなかった。 
- 和暦（特に `元` 年表記）を扱えるようにして、同意期限算出の互換性を高める必要があった。

### Description
- `calculateConsentExpiry_` を `parseDateFlexible_` 経由で日付を解釈するよう変更し、無効な入力は空文字を返すチェックを `if (!(d instanceof Date) || isNaN(d.getTime())) return ''` に置き換えた。 
- `parseDateFlexible_` の和暦正式表記の正規表現を拡張し、`元` を年 `1` として解釈するように対応した（`(令和|平成|昭和)\s*(元|\d+)...` として処理）。 
- 同意期限計算ロジック（1〜15日: +5ヶ月月末、16日〜: +6ヶ月月末）と返却フォーマット `yyyy-MM-dd` は従来通り維持している。 
- `tests/calculateConsentExpiry.test.js` に和暦ケース（`令和7年6月26日` → `2025-12-31`、`令和7年1月10日` → `2025-06-30`）を追加した。 

### Testing
- 実行: `node tests/calculateConsentExpiry.test.js` — テストは全件通過しました。 
- 実行: `node tests/getPatientHeaderMonthlySummary.test.js` — テストは全件通過しました。 
- 実行: `node tests/dashboardGetDashboardData.test.js` — テストは全件通過しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992b739ceb48321ac1e30fa331f48d8)