### PR TITLE
Support Reiwa date parsing and unify consent date parsing/logging

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -6892,26 +6892,37 @@ function parseDateFlexible_(v) {
   const raw = String(v).trim();
   if (!raw) return null;
 
+  const createValidDate = function(year, month, day) {
+    const y = Number(year);
+    const m = Number(month);
+    const d = Number(day);
+    if (!Number.isInteger(y) || !Number.isInteger(m) || !Number.isInteger(d)) return null;
+    const dt = new Date(y, m - 1, d);
+    if (isNaN(dt.getTime())) return null;
+    if (dt.getFullYear() !== y || dt.getMonth() !== m - 1 || dt.getDate() !== d) return null;
+    return dt;
+  };
+
   // 和暦（正式）
   const era = raw.match(/(令和|平成|昭和)\s*(元|\d+)[\/\-.年](\d{1,2})[\/\-.月](\d{1,2})/);
   if (era) {
     const eraName = era[1], y = era[2] === '元' ? 1 : Number(era[2]), m = Number(era[3]), d = Number(era[4]);
     const base = eraName === '令和' ? 2018 : eraName === '平成' ? 1988 : 1925; // R1=2019, H1=1989, S1=1926
-    return new Date(base + y, m - 1, d);
+    return createValidDate(base + y, m, d);
   }
   // 和暦（略号 R/H/S）
   const eraShort = raw.match(/([RrHhSs])\s*(\d+)[\/\-.年](\d{1,2})[\/\-.月](\d{1,2})/);
   if (eraShort) {
     const ch = eraShort[1].toUpperCase(), y = Number(eraShort[2]), m = Number(eraShort[3]), d = Number(eraShort[4]);
     const base = ch === 'R' ? 2018 : ch === 'H' ? 1988 : 1925;
-    return new Date(base + y, m - 1, d);
+    return createValidDate(base + y, m, d);
   }
   // 西暦
   const m1 = raw.match(/(\d{4})[\/\-.年](\d{1,2})[\/\-.月](\d{1,2})/);
-  if (m1) return new Date(Number(m1[1]), Number(m1[2]) - 1, Number(m1[3]));
+  if (m1) return createValidDate(m1[1], m1[2], m1[3]);
   // yyyymmdd
   const n = raw.replace(/\D/g,'');
-  if (n.length === 8) return new Date(Number(n.slice(0,4)), Number(n.slice(4,6))-1, Number(n.slice(6,8)));
+  if (n.length === 8) return createValidDate(n.slice(0,4), n.slice(4,6), n.slice(6,8));
 
   const d = new Date(raw);
   return isNaN(d.getTime()) ? null : d;
@@ -6919,7 +6930,13 @@ function parseDateFlexible_(v) {
 
 function calculateConsentExpiry_(dateRaw) {
   const d = parseDateFlexible_(dateRaw);
-  if (!(d instanceof Date) || isNaN(d.getTime())) return '';
+  if (!(d instanceof Date) || isNaN(d.getTime())) {
+    const raw = dateRaw == null ? '' : String(dateRaw).trim();
+    if (raw && typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+      Logger.log('[consent-date-parse-failed] ' + JSON.stringify({ raw: raw }));
+    }
+    return '';
+  }
 
   const day = d.getDate();
   const monthsToAdd = day <= 15 ? 5 : 6;

--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -831,8 +831,7 @@ function resolveConsentExpiry_(patient) {
   const consentDateRaw = raw ? raw['同意年月日'] : null;
 
   if (consentDateRaw != null && String(consentDateRaw).trim()) {
-    const normalizedConsentDate = parseJapaneseEraDate_(consentDateRaw) || consentDateRaw;
-    const expiryDate = calculateConsentExpiryDateFromConsentDate_(normalizedConsentDate);
+    const expiryDate = calculateConsentExpiryDateFromConsentDate_(consentDateRaw);
     if (expiryDate) {
       if (typeof dashboardLogContext_ === 'function') {
         dashboardLogContext_('resolveConsentExpiry_:result', JSON.stringify({
@@ -855,9 +854,82 @@ function resolveConsentExpiry_(patient) {
 }
 
 function calculateConsentExpiryDateFromConsentDate_(consentDateRaw) {
-  if (typeof calculateConsentExpiry_ !== 'function') return null;
-  const calculated = calculateConsentExpiry_(consentDateRaw);
-  return parseConsentDate_(calculated);
+  const parsedConsentDate = parseDateFlexible_(consentDateRaw);
+  if (!parsedConsentDate) return null;
+
+  if (typeof calculateConsentExpiry_ === 'function') {
+    const calculated = calculateConsentExpiry_(parsedConsentDate);
+    return parseConsentDate_(calculated);
+  }
+
+  const monthsToAdd = parsedConsentDate.getDate() <= 15 ? 5 : 6;
+  const target = new Date(parsedConsentDate);
+  target.setMonth(target.getMonth() + monthsToAdd + 1, 0);
+  return target;
+}
+
+function parseDateFlexible_(value) {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  if (value == null) return null;
+
+  const raw = String(value).trim();
+  if (!raw) return null;
+
+  const japaneseEra = raw.match(/^(令和|平成|昭和)\s*(元|\d{1,2})(?:年|\/)\s*(\d{1,2})(?:月|\/)\s*(\d{1,2})(?:日)?$/);
+  if (japaneseEra) {
+    const era = japaneseEra[1];
+    const eraYear = japaneseEra[2] === '元' ? 1 : Number(japaneseEra[2]);
+    const yearBase = era === '令和' ? 2018 : era === '平成' ? 1988 : 1925;
+    const parsed = createDateFromYmd_(yearBase + eraYear, japaneseEra[3], japaneseEra[4]);
+    if (parsed) return parsed;
+    logConsentDateParseFailed_(raw);
+    return null;
+  }
+
+  const ymdHyphen = raw.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
+  if (ymdHyphen) {
+    const parsed = createDateFromYmd_(ymdHyphen[1], ymdHyphen[2], ymdHyphen[3]);
+    if (parsed) return parsed;
+    logConsentDateParseFailed_(raw);
+    return null;
+  }
+
+  const ymdSlash = raw.match(/^(\d{4})\/(\d{1,2})\/(\d{1,2})$/);
+  if (ymdSlash) {
+    const parsed = createDateFromYmd_(ymdSlash[1], ymdSlash[2], ymdSlash[3]);
+    if (parsed) return parsed;
+    logConsentDateParseFailed_(raw);
+    return null;
+  }
+
+  const ymdJapanese = raw.match(/^(\d{4})年\s*(\d{1,2})月\s*(\d{1,2})日$/);
+  if (ymdJapanese) {
+    const parsed = createDateFromYmd_(ymdJapanese[1], ymdJapanese[2], ymdJapanese[3]);
+    if (parsed) return parsed;
+    logConsentDateParseFailed_(raw);
+    return null;
+  }
+
+  const iso = Date.parse(raw);
+  if (Number.isFinite(iso)) {
+    return new Date(iso);
+  }
+
+  logConsentDateParseFailed_(raw);
+  return null;
+}
+
+function logConsentDateParseFailed_(raw) {
+  const message = `[consent-date-parse-failed] ${JSON.stringify({ raw: String(raw) })}`;
+  if (typeof dashboardLogContext_ === 'function') {
+    dashboardLogContext_('consent-date-parse-failed', message);
+    return;
+  }
+  if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+    Logger.log(message);
+  }
 }
 
 function parseJapaneseEraDate_(value) {

--- a/tests/calculateConsentExpiry.test.js
+++ b/tests/calculateConsentExpiry.test.js
@@ -27,7 +27,10 @@ sandbox.Utilities = {
     { input: '2024-01-20', expected: '2024-07-31' },
     { input: '2024-03-31', expected: '2024-09-30' },
     { input: '2024-08-16', expected: '2025-02-28' },
+    { input: '2026/06/26', expected: '2026-12-31' },
+    { input: '2026-06-26', expected: '2026-12-31' },
     { input: '令和7年6月26日', expected: '2025-12-31' },
+    { input: '令和7/6/26', expected: '2025-12-31' },
     { input: '令和7年1月10日', expected: '2025-06-30' }
   ];
 

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -353,6 +353,11 @@ function testParseJapaneseEraDateAndResolveConsentExpiry() {
   })));
   assert.strictEqual(reiwaResolved.value, '2025-12-31T00:00:00.000Z', '令和7年6月26日は月末期限を算出できる');
 
+  const reiwaSlashResolved = JSON.parse(JSON.stringify(ctx.resolveConsentExpiry_({
+    raw: { '同意年月日': '令和7/6/26' }
+  })));
+  assert.strictEqual(reiwaSlashResolved.value, '2025-12-31T00:00:00.000Z', '令和7/6/26 も月末期限を算出できる');
+
   const heiseiResolved = JSON.parse(JSON.stringify(ctx.resolveConsentExpiry_({
     raw: { '同意年月日': '平成30年4月10日' }
   })));
@@ -410,17 +415,16 @@ function testConsentDateParsingFormatsAndResolverPriority() {
   });
 
   const overviewIds = JSON.parse(JSON.stringify(result.overview.consentRelated.items)).map(item => item.patientId);
-  assert.deepStrictEqual(overviewIds, ['001', '002', '004', '005'], 'calculateConsentExpiry_ で解釈可能な同意年月日の患者のみ表示される');
+  assert.deepStrictEqual(overviewIds, ['001', '002', '003', '004', '005'], '和暦を含む解釈可能な同意年月日の患者のみ表示される');
 
   const patientsById = {};
   result.patients.forEach(entry => {
     patientsById[entry.patientId] = JSON.parse(JSON.stringify(entry.statusTags));
   });
-  ['001', '002', '004', '005'].forEach(patientId => {
+  ['001', '002', '003', '004', '005'].forEach(patientId => {
     assert.deepStrictEqual((patientsById[patientId] || []).filter(tag => tag.type === 'consent'), [{ type: 'consent', label: '📄 要対応', priority: 'low' }], `同意タグが表示される: ${patientId}`);
   });
-  assert.deepStrictEqual((patientsById['003'] || []).filter(tag => tag.type === 'consent'), [], 'calculateConsentExpiry_ で解釈できない形式は同意タグを表示しない');
-  assert.deepStrictEqual((patientsById['006'] || []).filter(tag => tag.type === 'consent'), [], '不正文字列は同意タグの表示対象外');
+    assert.deepStrictEqual((patientsById['006'] || []).filter(tag => tag.type === 'consent'), [], '不正文字列は同意タグの表示対象外');
   assert.deepStrictEqual((patientsById['007'] || []).filter(tag => tag.type === 'consent'), [], '取得済み判定は従来通り同意タグ非表示');
   assert.deepStrictEqual((patientsById['008'] || []).filter(tag => tag.type === 'consent'), [], '同意年月日なしでは同意タグを表示しない');
 }
@@ -452,7 +456,8 @@ function testConsentDateParseFailureCanBeDebugLogged() {
   });
 
   const parseFailureLogs = logs.filter(entry => entry.label === 'consent-date-parse-failed');
-  assert.deepStrictEqual(parseFailureLogs, [], '同意年月日が不正でも同意期限未解決扱いとして parse 失敗ログは出さない');
+  assert.ok(parseFailureLogs.length >= 1, '同意年月日の形式不正時は parse 失敗ログを出す');
+  assert.ok(parseFailureLogs.some(entry => entry.details.includes('\"raw\":\"invalid-date\"')), 'parse 失敗ログに入力値を含める');
 }
 
 function testStaffMatchingUsesEmailNameAndStaffIdWithLogs() {


### PR DESCRIPTION
### Motivation
- `resolveConsentExpiry_` was failing to interpret Japanese-era inputs (e.g. `令和7年6月26日`, `令和7/6/26`) so consent expiry resolution returned `null` and consent-related UI filtered out patients incorrectly.
- Add era parsing (Reiwa slash form included) while preserving existing ISO/Gregorian parsing and not breaking legacy logic.

### Description
- Introduced a shared `parseDateFlexible_` used by the dashboard flow (`src/dashboard/api/getDashboardData.js`) to normalize inputs before expiry calculation and replaced ad-hoc normalization in `resolveConsentExpiry_` with a single path through `parseDateFlexible_` and `calculateConsentExpiryDateFromConsentDate_`.
- Reworked core parsing in `src/Code.js` to use a stricter `createValidDate` helper and have `calculateConsentExpiry_` call `parseDateFlexible_` so Japanese-era forms (including `令和◯年◯月◯日` and `令和◯/◯/◯`) are handled; ISO and existing formats remain supported.
- Added unified parse-failure logging `logConsentDateParseFailed_` which emits logs in the required format `[consent-date-parse-failed] {"raw":"..."}` (prefers `dashboardLogContext_`, falls back to `Logger.log`).
- Updated tests to cover the new formats and behaviors in `tests/calculateConsentExpiry.test.js` and `tests/dashboardGetDashboardData.test.js` and adjusted assertions expecting Japanese-era parsing to succeed.

### Testing
- Ran `node tests/calculateConsentExpiry.test.js` and the test suite passed (`calculateConsentExpiry tests passed`).
- Ran `node tests/dashboardGetDashboardData.test.js` and the test suite passed (`dashboardGetDashboardData tests passed`).
- Attempted `npm test -- --runInBand ...` which failed due to missing `package.json` in the environment, but the direct `node` test runs above validated the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992ba2f6e9083218b34fc6aff1c0ae6)