### PR TITLE
Centralize dashboard role logic and fix visibility to role + responsible email only

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -1,57 +1,14 @@
 const DEBUG_CONSENT_PID = '513';
 
-const DASHBOARD_ROLES = {
-  ADMIN: 'admin',
-  STAFF: 'staff'
-};
+const PATIENT_RESPONSIBLE_COLUMN_CANDIDATES = ['担当者', '担当メール', '担当者メール', 'メール', 'email', 'mail', 'responsibleEmail'];
 
-const ADMIN_EMAILS = new Set([
-  'belltree@belltree1102.com'
-]);
-
-
-const PATIENT_RESPONSIBLE_COLUMN_CANDIDATES = [
-  '担当者',
-  '担当',
-  '担当者名',
-  '担当メール',
-  '担当者メール',
-  'メール',
-  'email',
-  'mail',
-  'responsible',
-  'responsibleName',
-  'responsibleEmail',
-  '施術者',
-  'スタッフ',
-  'スタッフ名',
-  '担当者ID',
-  'スタッフID',
-  'staffId',
-  'staffid'
-];
-
-function getPatientResponsibleKeys_(patientRaw) {
+function resolveResponsibleColumn_(patientRaw) {
   const raw = patientRaw && typeof patientRaw === 'object' ? patientRaw : {};
-  const keys = new Set();
-  PATIENT_RESPONSIBLE_COLUMN_CANDIDATES.forEach(columnName => {
-    if (!Object.prototype.hasOwnProperty.call(raw, columnName)) return;
-    const normalized = dashboardNormalizeStaffKey_(raw[columnName]);
-    if (!normalized) return;
-    keys.add(normalized);
-  });
-  return keys;
-}
-
-function getUserRole_(normalizedUser) {
-  if (ADMIN_EMAILS.has(normalizedUser)) {
-    return DASHBOARD_ROLES.ADMIN;
+  for (let i = 0; i < PATIENT_RESPONSIBLE_COLUMN_CANDIDATES.length; i += 1) {
+    const columnName = PATIENT_RESPONSIBLE_COLUMN_CANDIDATES[i];
+    if (Object.prototype.hasOwnProperty.call(raw, columnName)) return columnName;
   }
-  return DASHBOARD_ROLES.STAFF;
-}
-
-function isAdminUser_(normalizedUser) {
-  return getUserRole_(normalizedUser) === DASHBOARD_ROLES.ADMIN;
+  return '';
 }
 
 /**
@@ -108,9 +65,10 @@ function getDashboardData(options) {
   const user = opts.user && typeof opts.user === 'object' ? opts.user : null;
   const userIdentity = user && user.email ? user.email : meta.user;
   meta.user = userIdentity || '';
-  const normalizedUser = dashboardNormalizeEmail_(userIdentity || '');
-  const role = getUserRole_(normalizedUser);
-  const isAdmin = isAdminUser_(normalizedUser);
+  const userEmail = userIdentity || '';
+  const normalizedUser = dashboardNormalizeEmail_(userEmail);
+  const role = getUserRole_(userEmail);
+  const isAdmin = role === 'admin';
   logContext('getDashboardData:start', `user=${userIdentity || 'unknown'} normalizedUser=${normalizedUser || 'unknown'} isAdmin=${isAdmin ? 'true' : 'false'} mock=${opts.mock ? 'true' : 'false'}`);
 
   try {
@@ -157,68 +115,7 @@ function getDashboardData(options) {
         treatmentLogCount: totalTreatmentLogs
       }));
     }
-    const normalizedUserName = dashboardNormalizeStaffKey_(userIdentity || '');
-    const normalizedUserId = dashboardNormalizeStaffKey_(userIdentity || '');
-    const staffMatchResult = measureStep('staffMatch処理', () => {
-      const staffMatchedLogs = [];
-      const matchStats = { email: 0, name: 0, staffId: 0, none: 0 };
-      const matchSamples = [];
-      (treatmentLogs && Array.isArray(treatmentLogs.logs) ? treatmentLogs.logs : []).forEach(entry => {
-        const staffKeys = entry && entry.staffKeys ? entry.staffKeys : {};
-        const emailKey = dashboardNormalizeStaffKey_(staffKeys.email || (entry && entry.createdByEmail ? entry.createdByEmail : ''));
-        const nameKey = dashboardNormalizeStaffKey_(staffKeys.name || (entry && entry.staffName ? entry.staffName : ''));
-        const staffIdKey = dashboardNormalizeStaffKey_(staffKeys.staffId || (entry && entry.staffId ? entry.staffId : ''));
-
-        let strategy = 'none';
-        if (normalizedUser && emailKey && emailKey === normalizedUser) {
-          strategy = 'email';
-        } else if (normalizedUserName && nameKey && nameKey === normalizedUserName) {
-          strategy = 'name';
-        } else if (normalizedUserId && staffIdKey && staffIdKey === normalizedUserId) {
-          strategy = 'staffId';
-        }
-
-        if (strategy !== 'none') {
-          const matchedEntry = Object.assign({}, entry, { staffMatchStrategy: strategy });
-          staffMatchedLogs.push(matchedEntry);
-        }
-        matchStats[strategy] += 1;
-        if (matchSamples.length < 20 && strategy !== 'none') {
-          matchSamples.push({
-            row: entry && entry.row ? entry.row : null,
-            staffMatchStrategy: strategy,
-            emailKey,
-            nameKey,
-            staffIdKey
-          });
-        }
-      });
-      const matchedPatientIds = new Set();
-      staffMatchedLogs.forEach(entry => {
-        const pid = dashboardNormalizePatientId_(entry && entry.patientId);
-        if (pid) matchedPatientIds.add(pid);
-      });
-      return { staffMatchedLogs, matchStats, matchSamples, matchedPatientIds };
-    });
-    const staffMatchedLogs = staffMatchResult.staffMatchedLogs;
-    const matchStats = staffMatchResult.matchStats;
-    const matchSamples = staffMatchResult.matchSamples;
-    const matchedPatientIds = staffMatchResult.matchedPatientIds;
     const patientMaster = patientInfo && patientInfo.patients ? patientInfo.patients : {};
-    const matchedPatientIdsInMaster = Array.from(matchedPatientIds).filter(pid => Object.prototype.hasOwnProperty.call(patientMaster, pid));
-    logContext('getDashboardData:staffMatchStrategy', JSON.stringify({
-      normalizedUser: normalizedUser || 'unknown',
-      normalizedUserName: normalizedUserName || 'unknown',
-      normalizedUserId: normalizedUserId || 'unknown',
-      matchStats,
-      samples: matchSamples
-    }));
-    logContext('getDashboardData:staffMatchedLogs', String(staffMatchedLogs.length));
-    logContext('getDashboardData:matchedPatientIds', JSON.stringify(Array.from(matchedPatientIds)));
-    logContext(
-      'getDashboardData:staffMatchSummary',
-      `normalizedUser=${normalizedUser || 'unknown'} totalLogs=${totalTreatmentLogs} staffMatchedLogs=${staffMatchedLogs.length} matchedPatientIds=${matchedPatientIds.size} matchedPatientIdsInMaster=${matchedPatientIdsInMaster.length}`
-    );
     const responsible = measureStep('assignResponsible', () => (opts.responsible || (typeof assignResponsibleStaff === 'function'
       ? assignResponsibleStaff({ patientInfo, treatmentLogs, now: opts.now, cache: opts.cache, dashboardSpreadsheet })
       : { responsible: {}, warnings: [] })));
@@ -227,16 +124,19 @@ function getDashboardData(options) {
     const responsiblePatientIds = new Set();
     Object.keys(patientMaster || {}).forEach(pid => {
       const patient = patientMaster[pid] || {};
-      const responsibleKeys = getPatientResponsibleKeys_(patient.raw);
-      if (responsibleKeys.has(normalizedUser)
-        || responsibleKeys.has(normalizedUserName)
-        || responsibleKeys.has(normalizedUserId)) {
+      const patientRaw = patient && patient.raw ? patient.raw : {};
+      const responsibleColumn = resolveResponsibleColumn_(patientRaw);
+      const normalizedResponsible = dashboardNormalizeEmail_(patientRaw[responsibleColumn]);
+
+      if (normalizedUser === normalizedResponsible) {
         responsiblePatientIds.add(pid);
       }
     });
     const allPatientIds = Object.keys(patientMaster || {});
     let visiblePatientIds = null;
-    if (isAdmin) {
+    // 可視スコープはロール + 患者マスタ担当割当のみで決定する。
+    // 施術ログ・期間条件・直近○日条件は使用しない。
+    if (role === 'admin') {
       visiblePatientIds = new Set(allPatientIds);
     } else {
       visiblePatientIds = responsiblePatientIds;
@@ -267,7 +167,7 @@ function getDashboardData(options) {
           raw: info && info.raw
         };
         const inVisibleScope = visiblePatientIds.has(pid);
-        const shouldEvaluateConsent = inVisibleScope || matchedPatientIds.has(pid);
+        const shouldEvaluateConsent = inVisibleScope;
 
         if (!shouldEvaluateConsent) return;
 
@@ -449,7 +349,6 @@ function getDashboardData(options) {
       'loadAIReports',
       'loadInvoices',
       'loadTreatmentLogs',
-      'staffMatch処理',
       'assignResponsible',
       'loadUnpaidAlerts',
       'getTodayVisits',
@@ -480,7 +379,6 @@ function getDashboardData(options) {
     logPerf('■ 5秒以内にするための削減候補');
     logPerf('  - 何を: loadTreatmentLogs の対象行数と列数 / どう削るか: 直近期間で先に絞り込み、必要列のみを読み込んで全件走査を削減する。');
     logPerf('  - 何を: loadAIReports・loadInvoices の逐次読み込み / どう削るか: キャッシュ（更新時刻付き）を導入して差分時のみ再計算する。');
-    logPerf('  - 何を: staffMatch処理の全ログループ照合 / どう削るか: 正規化済みキーでインデックスを構築して比較回数を減らす。');
 
     logPerf('■ 副作用リスク');
     logPerf('  - データ欠損: 期間・列の絞り込みを誤ると過去必要データが取り込まれず、患者情報や請求情報が欠ける。');

--- a/src/dashboard/auth/role.js
+++ b/src/dashboard/auth/role.js
@@ -1,0 +1,20 @@
+const ADMIN_EMAILS = [
+  'belltree@belltree1102.com'
+];
+
+function getUserRole_(email) {
+  const normalized = dashboardNormalizeEmail_(email);
+  if (ADMIN_EMAILS.includes(normalized)) return 'admin';
+  return 'staff';
+}
+
+function isAdminUser_(email) {
+  return getUserRole_(email) === 'admin';
+}
+
+if (typeof module !== 'undefined' && module && module.exports) {
+  module.exports = {
+    getUserRole_,
+    isAdminUser_
+  };
+}

--- a/src/dashboard/utils/sheetUtils.js
+++ b/src/dashboard/utils/sheetUtils.js
@@ -238,26 +238,15 @@ function dashboardNormalizeEmail_(email) {
   const normalized = String(raw).normalize('NFKC').trim().toLowerCase();
   return normalized || '';
 }
-
 function dashboardNormalizeStaffKey_(value) {
   const raw = dashboardTrimText_(value);
   if (!raw) return '';
 
   const email = dashboardExtractEmail_(raw);
-  if (email) {
-    const normalizedEmail = dashboardNormalizeEmail_(email)
-      .replace(/\+[^@]+(?=@)/, '');
-    if (normalizedEmail) return normalizedEmail;
-  }
+  if (!email) return '';
 
-  return String(raw)
-    .normalize('NFKC')
-    .toLowerCase()
-    .replace(/[\s\u3000・･]/g, '')
-    .replace(/[ー－ｰ−]/g, '')
-    .replace(/[._]/g, '')
-    .replace(/[^0-9a-z\u3040-\u30ff\u3400-\u9FFF]/g, '')
-    .replace(/-/g, '');
+  return dashboardNormalizeEmail_(email)
+    .replace(/\+[^@]+(?=@)/, '');
 }
 
 function dashboardExtractEmail_(value) {

--- a/tests/dashboardCachingPerf.test.js
+++ b/tests/dashboardCachingPerf.test.js
@@ -5,6 +5,7 @@ const assert = require('assert');
 
 const configCode = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'config.gs'), 'utf8');
 const sheetUtilsCode = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'utils', 'sheetUtils.js'), 'utf8');
+const roleCode = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'auth', 'role.js'), 'utf8');
 const dashboardCode = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'api', 'getDashboardData.js'), 'utf8');
 
 function createContext(overrides = {}) {
@@ -51,8 +52,10 @@ function createContext(overrides = {}) {
     ...overrides
   };
   vm.createContext(ctx);
+  ctx.module = { exports: {} };
   vm.runInContext(configCode, ctx);
   vm.runInContext(sheetUtilsCode, ctx);
+  vm.runInContext(roleCode, ctx);
   vm.runInContext(dashboardCode, ctx);
   return ctx;
 }

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -11,6 +11,10 @@ const configCode = fs.readFileSync(
   path.join(__dirname, '..', 'src', 'dashboard', 'config.gs'),
   'utf8'
 );
+const roleCode = fs.readFileSync(
+  path.join(__dirname, '..', 'src', 'dashboard', 'auth', 'role.js'),
+  'utf8'
+);
 const dashboardCode = fs.readFileSync(
   path.join(__dirname, '..', 'src', 'dashboard', 'api', 'getDashboardData.js'),
   'utf8'
@@ -40,8 +44,10 @@ function createContext(overrides = {}) {
   };
   Object.assign(context, overrides);
   vm.createContext(context);
+  context.module = { exports: {} };
   vm.runInContext(configCode, context);
   vm.runInContext(sheetUtilsCode, context);
+  vm.runInContext(roleCode, context);
   vm.runInContext(dashboardCode, context);
   return context;
 }
@@ -461,62 +467,13 @@ function testConsentDateParseFailureCanBeDebugLogged() {
   assert.ok(parseFailureLogs.some(entry => entry.details.includes('\"raw\":\"invalid-date\"')), 'parse 失敗ログに入力値を含める');
 }
 
-function testStaffMatchingUsesEmailNameAndStaffIdWithLogs() {
-  const logEntries = [];
+function testRoleResolutionIsEmailBasedOnly() {
   const ctx = createContext();
-  ctx.dashboardLogContext_ = (label, details) => {
-    logEntries.push({ label, details: String(details || '') });
-  };
 
-  const resultByEmail = ctx.getDashboardData({
-    user: 'belltree@belltree1102.com',
-    patientInfo: { patients: { '001': { name: '患者A', raw: { '担当者': 'staff@example.com' } }, '002': { name: '患者B', raw: { '担当者': 'other@example.com' } } }, warnings: [] },
-    notes: { notes: {}, warnings: [] },
-    aiReports: { reports: {}, warnings: [] },
-    invoices: { invoices: {}, warnings: [] },
-    treatmentLogs: {
-      logs: [
-        { row: 2, patientId: '001', createdByEmail: 'belltree+billing@belltree1102.com', staffName: '別名', staffId: '', staffKeys: { email: 'belltree+billing@belltree1102.com', name: '別名', staffId: '' } },
-        { row: 3, patientId: '002', createdByEmail: '', staffName: '管理者ID', staffId: 'admin001', staffKeys: { email: '', name: '管理者ID', staffId: 'admin001' } }
-      ],
-      warnings: []
-    },
-    responsible: { responsible: {}, warnings: [] },
-    unpaidAlerts: { alerts: [], warnings: [] },
-    tasksResult: { tasks: [], warnings: [] },
-    visitsResult: { visits: [], warnings: [] }
-  });
-
-  assert.strictEqual(resultByEmail.meta.error, undefined);
-
-  const resultByStaffId = ctx.getDashboardData({
-    user: 'admin001',
-    patientInfo: { patients: { '001': { name: '患者A', raw: { '担当者': 'staff@example.com' } }, '002': { name: '患者B', raw: { '担当者': 'other@example.com' } } }, warnings: [] },
-    notes: { notes: {}, warnings: [] },
-    aiReports: { reports: {}, warnings: [] },
-    invoices: { invoices: {}, warnings: [] },
-    treatmentLogs: {
-      logs: [
-        { row: 2, patientId: '001', createdByEmail: 'other@example.com', staffName: '別名', staffId: '', staffKeys: { email: 'other@example.com', name: '別名', staffId: '' } },
-        { row: 3, patientId: '002', createdByEmail: '', staffName: '管理者ID', staffId: 'admin001', staffKeys: { email: '', name: '管理者ID', staffId: 'admin001' } }
-      ],
-      warnings: []
-    },
-    responsible: { responsible: {}, warnings: [] },
-    unpaidAlerts: { alerts: [], warnings: [] },
-    tasksResult: { tasks: [], warnings: [] },
-    visitsResult: { visits: [], warnings: [] }
-  });
-
-  assert.strictEqual(resultByStaffId.meta.error, undefined);
-
-  const strategyLog = logEntries.find(entry => entry.label === 'getDashboardData:staffMatchStrategy');
-  const matchedCountLog = logEntries.find(entry => entry.label === 'getDashboardData:staffMatchedLogs');
-  const matchedIdsLog = logEntries.find(entry => entry.label === 'getDashboardData:matchedPatientIds');
-  assert.ok(strategyLog, 'staffMatchStrategy ログが出力される');
-  assert.ok(matchedCountLog, 'staffMatchedLogs ログが出力される');
-  assert.ok(matchedIdsLog, 'matchedPatientIds ログが出力される');
-  assert.ok(Number(matchedCountLog.details) >= 1, '少なくとも1件の一致ログがある');
+  assert.strictEqual(ctx.getUserRole_('belltree@belltree1102.com'), 'admin');
+  assert.strictEqual(ctx.getUserRole_('BELLTREE@belltree1102.com'), 'admin', '大文字混在メールも管理者判定される');
+  assert.strictEqual(ctx.getUserRole_('admin001'), 'staff', 'メール以外は管理者判定しない');
+  assert.strictEqual(ctx.isAdminUser_('admin001'), false);
 }
 
 
@@ -561,20 +518,20 @@ function testStaffConsentScopeMetricsAreLogged() {
   assert.ok(scopeMetricsLog, 'consentScopeMetrics ログが出力される');
   const metrics = JSON.parse(scopeMetricsLog.details);
   assert.strictEqual(metrics.totalPatients, 4);
-  assert.strictEqual(metrics.consentEligiblePatients, 2);
+  assert.strictEqual(metrics.consentEligiblePatients, 1);
   assert.strictEqual(metrics.visiblePatientIdsSize, 1);
-  assert.strictEqual(metrics.consentEligibleButOutOfScope, 1);
+  assert.strictEqual(metrics.consentEligibleButOutOfScope, 0);
 
   const outOfScopeLog = logEntries.find(entry => entry.label === 'getDashboardData:consentOutOfScopeByResponsible');
   assert.ok(outOfScopeLog, 'consentOutOfScopeByResponsible ログが出力される');
-  assert.ok(outOfScopeLog.details.indexOf('=1') >= 0, '担当割当スコープ外件数がログに含まれる');
+  assert.ok(outOfScopeLog.details.indexOf('=0') >= 0, '担当割当スコープ外件数がログに含まれる');
 
   assert.ok(logEntries.some(entry => entry.label === 'getDashboardData:visibleScopeRoutes'), 'visibleScopeRoutes ログが出力される');
   assert.ok(logEntries.some(entry => entry.label === 'buildDashboardPatients_:scope'), 'buildDashboardPatients_:scope ログが出力される');
   assert.ok(logEntries.some(entry => entry.label === 'buildOverviewFromConsent_:scope'), 'buildOverviewFromConsent_:scope ログが出力される');
 }
 
-function testStaffConsentEligibilityEvaluatesOnlyVisibleOrMatchedPatients() {
+function testStaffConsentEligibilityEvaluatesOnlyVisiblePatients() {
   const logEntries = [];
   const ctx = createContext();
   ctx.dashboardLogContext_ = (label, details) => {
@@ -922,7 +879,7 @@ function testVisibleScopeForAdminShowsAllPatients() {
   });
 }
 
-function testVisibleScopeForStaffWithin50DaysShowsMatchedPatientsOnly() {
+function testVisibleScopeForStaffShowsResponsiblePatientsOnly() {
   const logEntries = [];
   const ctx = createContext({
     Utilities: {
@@ -992,7 +949,7 @@ function testVisibleScopeForStaffWithin50DaysShowsMatchedPatientsOnly() {
   });
 }
 
-function testVisibleScopeForStaffOnlyOlderThan50DaysShowsNoPatients() {
+function testVisibleScopeForStaffWithoutResponsibleAssignmentShowsNoPatients() {
   const ctx = createContext({
     getTasks: opts => ({ tasks: opts.visiblePatientIds && opts.visiblePatientIds.size ? [{ patientId: '001' }] : [], warnings: [] }),
     getTodayVisits: opts => ({ visits: opts.visiblePatientIds && opts.visiblePatientIds.size ? [{ patientId: '001', dateKey: '2025-02-10', time: '09:00' }] : [], warnings: [] }),
@@ -1107,9 +1064,9 @@ function testWarningsAreDedupedAndSetupFlagged() {
   testConsentDateParsingFormatsAndResolverPriority();
   testParseJapaneseEraDateAndResolveConsentExpiry();
   testConsentDateParseFailureCanBeDebugLogged();
-  testStaffMatchingUsesEmailNameAndStaffIdWithLogs();
+  testRoleResolutionIsEmailBasedOnly();
   testStaffConsentScopeMetricsAreLogged();
-  testStaffConsentEligibilityEvaluatesOnlyVisibleOrMatchedPatients();
+  testStaffConsentEligibilityEvaluatesOnlyVisiblePatients();
   testVisitSummaryWhenTodayIsZeroUsesLatestPastDayCount();
   testVisitSummaryWhenTodayHasTwoUsesTodayCountForBoth();
   testVisitSummaryWhenNoDataReturnsZeroCounts();
@@ -1118,8 +1075,8 @@ function testWarningsAreDedupedAndSetupFlagged() {
   testInvoiceUnconfirmedShouldDetectPatientWithOnlyPreviousMonthTreatment();
   testInvoiceUnconfirmedExcludesMedicalAssistancePatient();
   testVisibleScopeForAdminShowsAllPatients();
-  testVisibleScopeForStaffWithin50DaysShowsMatchedPatientsOnly();
-  testVisibleScopeForStaffOnlyOlderThan50DaysShowsNoPatients();
+  testVisibleScopeForStaffShowsResponsiblePatientsOnly();
+  testVisibleScopeForStaffWithoutResponsibleAssignmentShowsNoPatients();
   testErrorIsCapturedInMeta();
   testSpreadsheetIsOpenedOnceAndPerfCheckIsLogged();
   testWarningsAreDedupedAndSetupFlagged();

--- a/tests/dashboardGetDashboardDataOptions.test.js
+++ b/tests/dashboardGetDashboardDataOptions.test.js
@@ -5,6 +5,7 @@ const assert = require('assert');
 
 const sheetUtilsCode = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'utils', 'sheetUtils.js'), 'utf8');
 const configCode = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'config.gs'), 'utf8');
+const roleCode = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'auth', 'role.js'), 'utf8');
 const dashboardCode = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'api', 'getDashboardData.js'), 'utf8');
 
 function createContext(overrides = {}) {
@@ -23,8 +24,10 @@ function createContext(overrides = {}) {
   };
   Object.assign(context, overrides);
   vm.createContext(context);
+  context.module = { exports: {} };
   vm.runInContext(configCode, context);
   vm.runInContext(sheetUtilsCode, context);
+  vm.runInContext(roleCode, context);
   vm.runInContext(dashboardCode, context);
   return context;
 }


### PR DESCRIPTION
### Motivation

- Finalize dashboard visibility: make scope decisions deterministic and remove ad-hoc log/treatment-log based matching.
- Centralize role resolution so admin/staff checks are uniform and based on normalized email only.
- Restrict "responsible" matching to email equality (no name/staffId/indexOf/ambiguous matching) to end provisional behavior.

### Description

- Added a dedicated role module at `src/dashboard/auth/role.js` providing `getUserRole_` and `isAdminUser_` which normalize emails and treat `belltree@belltree1102.com` as admin. 
- Updated `getDashboardData` to use `const role = getUserRole_(userEmail);` and to derive `isAdmin` from the role, replacing previous in-file role logic and ad-hoc admin checks.
- Removed staff-match / log-dependent scope paths: eliminated name/staffId/index-based matching and the `staffMatch処理` usage; visibility is now decided only by role + patient-master responsible assignment.
- Fixed responsible lookup: added `resolveResponsibleColumn_` and changed responsible matching to compare `dashboardNormalizeEmail_` of `userEmail` against the patient master responsible email only, and added the explicit comment: `// 可視スコープはロール + 患者マスタ担当割当のみで決定する。 // 施術ログ・期間条件・直近○日条件は使用しない.`
- Simplified `dashboardNormalizeStaffKey_` in `src/dashboard/utils/sheetUtils.js` to return only normalized email (empty string when no email), removing fallback normalization from non-email values.
- Updated tests to load the new role module and aligned expectations: tests were renamed/adjusted to assert email-only role resolution and that staff see only responsible patients (consent/overview metrics adjusted accordingly). Files updated: `tests/dashboardGetDashboardData.test.js`, `tests/dashboardGetDashboardDataOptions.test.js`, and `tests/dashboardCachingPerf.test.js`.

### Testing

- Ran `node tests/dashboardGetDashboardData.test.js` and it passed (all dashboard visibility and consent metrics tests updated for the new scope logic). 
- Ran `node tests/dashboardGetDashboardDataOptions.test.js` and it passed (options propagation validated with new role module load). 
- Ran `node tests/dashboardCachingPerf.test.js` and it passed (treatment logs caching behavior unchanged and role module loaded in test context).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992f554c07483219a76ada781960dfd)