### PR TITLE
Optimize consent expiry evaluation to run once per patient

### DIFF
--- a/docs/consent-expiry-investigation.md
+++ b/docs/consent-expiry-investigation.md
@@ -1,43 +1,26 @@
-# Consent Expiry Data-Layer Investigation
+# Consent Expiry Investigation (Issue: resolveConsentExpiry_ 呼び出し最適化)
 
-## 1) resolveConsentExpiry_ 実装確認
-- 参照キー（優先順）
-  1. `info.consentExpiry`
-  2. `raw['同意期限']`
-  3. `raw['同意有効期限']`
-  4. `raw['同意期限日']`
-- `raw['consentExpiry']` は参照していない。
-- `patientInfo` の `patients[pid]` オブジェクトを受け取り、`patient.raw` を読む。
-- `null` 扱い条件:
-  - 値が `null/undefined`
-  - 文字列かつ trim 後に空文字
+## 調査結果
 
-## 2) loadPatientInfo のカラムマッピング確認
-- ヘッダは `getDisplayValues()` で取得。
-- 同意期限列の候補: `['同意期限', '同意書期限', '同意有効期限', '同意期限日']`。
-- マッチ方式:
-  - ヘッダは trim + lowercase で正規化
-  - 候補側も trim + lowercase で正規化
-  - 完全一致比較
-- index は 1-origin（見つからない場合は 0）。
-- `raw` オブジェクト生成:
-  - 全ヘッダを走査し、`raw[String(header).trim()] = row[idx]` を格納。
+### 1. `resolveConsentExpiry_` の呼び出し回数（改修前）
+- `getDashboardData` 実行時（管理者表示）
+  - `buildDashboardPatients_` 内: **1回/患者**
+  - `buildDashboardPatientStatusTags_` 内: **1回/患者**
+  - `buildOverviewFromConsent_` 内: **1回/患者**
+- 合計: **3回/患者**（表示用途の重複計算あり）
 
-## 3) 実シート構造確認
-- ローカルリポジトリ環境では Google Apps Script 実行コンテキスト・実スプレッドシートへの接続がないため未実施。
+### 2. `getDashboardData` 内での評価回数
+- `resolveConsentExpiry_` は患者配列の構築・タグ表示・上段概要の3箇所で評価され、同一患者に対して重複していた。
+- `parseConsentDate_`（旧名称）は `resolveConsentExpiry_` の結果を各表示処理で再パースしていた。
 
-## 4) PID単体検証
-- 実シートデータにアクセスできないため未実施。
+### 3. 患者1件あたりの実測（改修後）
+- テスト `testConsentExpiryResolutionRunsOncePerPatient` で `resolveConsentExpiry_` をフックし、
+  - 患者3件で `resolveConsentExpiry_` 呼び出し数 **3回**
+  - すなわち **1回/患者** を確認。
 
-## 5) parseConsentDate_ の挙動
-- 受理フォーマット:
-  - `Date` オブジェクト（有効日付）
-  - `yyyy-M-d` / `yyyy-MM-dd`
-  - `yyyy/M/d` / `yyyy/MM/dd`
-  - `yyyy年M月d日`
-  - ISO日時（例: `2025-02-01T00:00:00Z`）
-- `null` になる主な条件:
-  - `null/undefined`
-  - 空文字
-  - 上記いずれのフォーマットにも一致しない
-  - 数値として不正な日付（例: 2025-02-30）
+## 改修方針への反映
+
+- 同意期限は患者整形時（`buildDashboardPatients_`）に1回だけ計算。
+- 表示ロジック（ステータスタグ、概要表示）では `patient.consentExpiry` を利用し、同意期限の再解決を行わない。
+- `parseConsentDate_` は `parseConsentDateInternal_` に改名し、内部利用へ限定。
+- 同意期限解析関連のデバッグ/失敗ログを削除。

--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -1,5 +1,3 @@
-const DEBUG_CONSENT_PID = '513';
-
 const PATIENT_RESPONSIBLE_COLUMN_CANDIDATES = ['担当者', '担当メール', '担当者メール', 'メール', 'email', 'mail', 'responsibleEmail'];
 
 function resolveResponsibleColumn_(patientRaw) {
@@ -171,22 +169,8 @@ function getDashboardData(options) {
 
         if (!shouldEvaluateConsent) return;
 
-        if (patient.pid === DEBUG_CONSENT_PID) {
-          console.log(JSON.stringify({
-            label: '[CONSENT_TRACE]',
-            pid: patient.pid,
-            rawConsent: patient.raw && patient.raw['同意年月日'],
-            rawConsentType: typeof (patient.raw && patient.raw['同意年月日']),
-            resolved: resolveConsentExpiry_(patient),
-            parsed: parseConsentDate_(resolveConsentExpiry_(patient).value),
-            consentAcquired: dashboardIsConsentAcquired_(patient.raw),
-            visibleScope: visiblePatientIds && typeof visiblePatientIds.has === 'function' ? visiblePatientIds.has(patient.pid) : null,
-            today: new Date().toISOString()
-          }));
-        }
-
         const consentExpiryResolved = resolveConsentExpiry_(patient);
-        const consentExpiryDate = parseConsentDate_(consentExpiryResolved.value);
+        const consentExpiryDate = parseConsentDateInternal_(consentExpiryResolved.value);
         const consentAcquired = dashboardIsConsentAcquired_(info.raw);
         const hasConsentExpiry = consentExpiryResolved.value != null && String(consentExpiryResolved.value).trim() !== '';
 
@@ -215,17 +199,6 @@ function getDashboardData(options) {
           && diffDays != null
           && diffDays >= 0
           && diffDays <= threshold;
-        if (patient.pid === DEBUG_CONSENT_PID) {
-          console.log(JSON.stringify({
-            label: '[CONSENT_TRACE:diff]',
-            expiryISO: parsedConsentExpiry && typeof parsedConsentExpiry.toISOString === 'function' ? parsedConsentExpiry.toISOString() : null,
-            todayISO: today.toISOString(),
-            diffMs,
-            diffDays,
-            threshold,
-            finalCondition: finalCondition
-          }));
-        }
         if (inVisibleScope) {
           logContext('consent-eligible-debug', JSON.stringify({
             pid,
@@ -248,7 +221,7 @@ function getDashboardData(options) {
         if (!inVisibleScope) consentEligibleButOutOfScope += 1;
       });
 
-      logContext('getDashboardData:consentEligibleFormula', 'consentEligiblePatients = count(pid where parseConsentDate_(resolveConsentExpiry_(patient).value) != null && dashboardIsConsentAcquired_(patient.raw) === false)');
+      logContext('getDashboardData:consentEligibleFormula', 'consentEligiblePatients = count(pid where parseConsentDateInternal_(resolveConsentExpiry_(patient).value) != null && dashboardIsConsentAcquired_(patient.raw) === false)');
       logContext('getDashboardData:consentScopeMetrics', JSON.stringify({
         totalPatients: patientMasterIds.length,
         consentEligiblePatients,
@@ -487,6 +460,9 @@ function buildDashboardPatients_(patientInfo, sources, allowedPatientIds) {
 
     const base = payload || {};
     const consentExpiryResolved = resolveConsentExpiry_(base);
+    const consentExpiryDate = parseConsentDateInternal_(consentExpiryResolved.value);
+    const raw = base && base.raw ? base.raw : null;
+    const consentAcquired = dashboardIsConsentAcquired_(raw);
     const entry = {
       patientId,
       name: base.name || base.patientName || '',
@@ -499,7 +475,9 @@ function buildDashboardPatients_(patientInfo, sources, allowedPatientIds) {
         aiReportAt: Object.prototype.hasOwnProperty.call(aiReports, patientId) ? aiReports[patientId] : null,
         note: normalizeDashboardNote_(notes[patientId], patientId),
         responsible: Object.prototype.hasOwnProperty.call(responsible, patientId) ? responsible[patientId] : null,
-        now
+        now,
+        consentExpiryDate,
+        consentAcquired
       })
     };
     patients.push(entry);
@@ -526,19 +504,12 @@ function buildDashboardPatientStatusTags_(patient, params, maybeNow) {
     : { aiReportAt: params, now: maybeNow };
   const targetNow = dashboardCoerceDate_(options.now) || new Date();
   const aiReportAt = options.aiReportAt;
-  const consentExpiryResolved = resolveConsentExpiry_(patient);
-  const consentExpiryDate = parseConsentDate_(consentExpiryResolved.value);
-  const raw = patient && patient.raw ? patient.raw : null;
-  const consentAcquired = dashboardIsConsentAcquired_(raw);
-
-  if (shouldDebugConsent_() && consentExpiryResolved.value != null && !consentExpiryDate) {
-    dashboardLogContext_('consent-date-parse-failed', JSON.stringify({
-      phase: 'tag',
-      patientId: patient && patient.patientId ? patient.patientId : '',
-      source: consentExpiryResolved.source,
-      raw: consentExpiryResolved.value
-    }));
-  }
+  const consentExpiryDate = Object.prototype.hasOwnProperty.call(options, 'consentExpiryDate')
+    ? options.consentExpiryDate
+    : parseConsentDateInternal_(patient && patient.consentExpiry);
+  const consentAcquired = Object.prototype.hasOwnProperty.call(options, 'consentAcquired')
+    ? !!options.consentAcquired
+    : dashboardIsConsentAcquired_(patient && patient.raw ? patient.raw : null);
 
   const consentStatus = !consentAcquired
     ? evaluateConsentStatus_(consentExpiryDate, targetNow, patient && patient.patientId ? patient.patientId : '')
@@ -572,7 +543,7 @@ function dashboardDaysBetween_(from, to, futurePositive) {
 }
 
 function evaluateConsentStatus_(consentExpiryDate, today, pid) {
-  const expiry = parseConsentDate_(consentExpiryDate);
+  const expiry = parseConsentDateInternal_(consentExpiryDate);
   if (!expiry) return null;
   const threshold = 30;
   const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
@@ -648,7 +619,7 @@ function buildDashboardOverview_(params) {
     tz,
     patientInfo
   );
-  const consentRelated = buildOverviewFromConsent_(patientInfo, scope, patientNameMap, now);
+  const consentRelated = buildOverviewFromConsent_(patients, scope, patientNameMap, now);
   const visitSummary = buildOverviewFromTreatmentProgress_(payload.visits, now, tz);
   return {
     invoiceUnconfirmed,
@@ -783,32 +754,25 @@ function buildDashboardInvoiceSearchText_(entry) {
     .join('\n');
 }
 
-function buildOverviewFromConsent_(patientInfo, scope, patientNameMap, now) {
+function buildOverviewFromConsent_(patients, scope, patientNameMap, now) {
   const items = [];
   const allowedPatientIds = scope ? scope.patientIds : null;
   const applyFilter = scope ? scope.applyFilter : false;
   const targetNow = dashboardCoerceDate_(now) || new Date();
   let filteredByScope = 0;
 
-  Object.keys(patientInfo || {}).forEach(pid => {
+  (patients || []).forEach(patient => {
+    const pid = dashboardNormalizePatientId_(patient && patient.patientId);
     if (!pid) return;
     if (applyFilter && allowedPatientIds && !allowedPatientIds.has(pid)) {
       filteredByScope += 1;
       return;
     }
-    const info = patientInfo[pid] || {};
-    const consentExpiryResolved = resolveConsentExpiry_(info);
-    const consentExpiryDate = parseConsentDate_(consentExpiryResolved.value);
-    const consentAcquired = dashboardIsConsentAcquired_(info.raw);
-    if (shouldDebugConsent_() && consentExpiryResolved.value != null && !consentExpiryDate) {
-      dashboardLogContext_('consent-date-parse-failed', JSON.stringify({
-        phase: 'overview',
-        patientId: pid,
-        source: consentExpiryResolved.source,
-        raw: consentExpiryResolved.value
-      }));
-    }
-    if (consentAcquired || !consentExpiryDate) return;
+    const consentExpiryDate = parseConsentDateInternal_(patient && patient.consentExpiry);
+    if (!consentExpiryDate) return;
+    const statusTags = patient && Array.isArray(patient.statusTags) ? patient.statusTags : [];
+    const hasConsentTag = statusTags.some(tag => tag && tag.type === 'consent');
+    if (!hasConsentTag) return;
 
     const consentStatus = evaluateConsentStatus_(consentExpiryDate, targetNow, pid);
     if (!consentStatus) return;
@@ -818,7 +782,7 @@ function buildOverviewFromConsent_(patientInfo, scope, patientNameMap, now) {
     } else if (consentStatus.type === 'warning') {
       label = `⏳ 同意期限迫る（残${consentStatus.days}日）`;
     }
-    const name = info.name || patientNameMap[pid] || '';
+    const name = (patient && patient.name) || patientNameMap[pid] || '';
     items.push({
       patientId: pid,
       name,
@@ -830,7 +794,7 @@ function buildOverviewFromConsent_(patientInfo, scope, patientNameMap, now) {
   if (typeof dashboardLogContext_ === 'function') {
     dashboardLogContext_('buildOverviewFromConsent_:scope', JSON.stringify({
       applyFilter,
-      totalPatients: Object.keys(patientInfo || {}).length,
+      totalPatients: Array.isArray(patients) ? patients.length : 0,
       filteredByScope,
       resultItems: items.length
     }));
@@ -848,48 +812,23 @@ function dashboardDebugLogLimited_(counterKey, label, payload) {
 }
 
 function resolveConsentExpiry_(patient) {
-  if (patient && patient.pid === DEBUG_CONSENT_PID) {
-    console.log(JSON.stringify({
-      label: '[CONSENT_TRACE:resolve]',
-      pid: patient.pid,
-      rawConsent: patient.raw && patient.raw['同意年月日'],
-      rawKeys: Object.keys((patient && patient.raw) || {})
-    }));
-  }
-
-  dashboardDebugLogLimited_('resolveConsentExpiry_:debug', '[resolveConsentExpiry_:debug]', {
-    pid: patient && patient.patientId,
-    hasRaw: Boolean(patient && patient.raw),
-    rawKeys: patient && patient.raw ? Object.keys(patient.raw) : [],
-    rawConsent: patient && patient.raw ? patient.raw['同意年月日'] : undefined,
-    rawConsentType: typeof (patient && patient.raw ? patient.raw['同意年月日'] : undefined)
-  });
-
   const info = patient && typeof patient === 'object' ? patient : {};
+  if (Object.prototype.hasOwnProperty.call(info, '__dashboardConsentExpiryResolved')) {
+    return info.__dashboardConsentExpiryResolved;
+  }
   const raw = info.raw && typeof info.raw === 'object' ? info.raw : null;
   const consentDateRaw = raw ? raw['同意年月日'] : null;
 
   if (consentDateRaw != null && String(consentDateRaw).trim()) {
     const expiryDate = calculateConsentExpiryDateFromConsentDate_(consentDateRaw, patient && patient.pid);
     if (expiryDate) {
-      if (typeof dashboardLogContext_ === 'function') {
-        dashboardLogContext_('resolveConsentExpiry_:result', JSON.stringify({
-          source: "raw['同意年月日']",
-          resolvedValue: expiryDate
-        }));
-      }
-      return { value: expiryDate, source: "raw['同意年月日']" };
+      info.__dashboardConsentExpiryResolved = { value: expiryDate, source: "raw['同意年月日']" };
+      return info.__dashboardConsentExpiryResolved;
     }
   }
 
-  if (typeof dashboardLogContext_ === 'function') {
-    dashboardLogContext_('resolveConsentExpiry_:result', JSON.stringify({
-      source: '',
-      resolvedValue: null
-    }));
-  }
-
-  return { value: null, source: '' };
+  info.__dashboardConsentExpiryResolved = { value: null, source: '' };
+  return info.__dashboardConsentExpiryResolved;
 }
 
 function calculateConsentExpiryDateFromConsentDate_(consentDateRaw, debugPid) {
@@ -902,7 +841,7 @@ function calculateConsentExpiryDateFromConsentDate_(consentDateRaw, debugPid) {
 
   if (typeof calculateConsentExpiry_ === 'function') {
     const calculated = calculateConsentExpiry_(parsedConsentDate);
-    return parseConsentDate_(calculated);
+    return parseConsentDateInternal_(calculated);
   }
 
   const monthsToAdd = parsedConsentDate.getDate() <= 15 ? 5 : 6;
@@ -931,33 +870,25 @@ function parseDateFlexible_(value) {
     const eraYear = japaneseEra[2] === '元' ? 1 : Number(japaneseEra[2]);
     const yearBase = era === '令和' ? 2018 : era === '平成' ? 1988 : 1925;
     const parsed = createDateFromYmd_(yearBase + eraYear, japaneseEra[3], japaneseEra[4]);
-    if (parsed) return parsed;
-    logConsentDateParseFailed_(raw);
-    return null;
+    return parsed || null;
   }
 
   const ymdHyphen = raw.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
   if (ymdHyphen) {
     const parsed = createDateFromYmd_(ymdHyphen[1], ymdHyphen[2], ymdHyphen[3]);
-    if (parsed) return parsed;
-    logConsentDateParseFailed_(raw);
-    return null;
+    return parsed || null;
   }
 
   const ymdSlash = raw.match(/^(\d{4})\/(\d{1,2})\/(\d{1,2})$/);
   if (ymdSlash) {
     const parsed = createDateFromYmd_(ymdSlash[1], ymdSlash[2], ymdSlash[3]);
-    if (parsed) return parsed;
-    logConsentDateParseFailed_(raw);
-    return null;
+    return parsed || null;
   }
 
   const ymdJapanese = raw.match(/^(\d{4})年\s*(\d{1,2})月\s*(\d{1,2})日$/);
   if (ymdJapanese) {
     const parsed = createDateFromYmd_(ymdJapanese[1], ymdJapanese[2], ymdJapanese[3]);
-    if (parsed) return parsed;
-    logConsentDateParseFailed_(raw);
-    return null;
+    return parsed || null;
   }
 
   const iso = Date.parse(raw);
@@ -965,19 +896,7 @@ function parseDateFlexible_(value) {
     return new Date(iso);
   }
 
-  logConsentDateParseFailed_(raw);
   return null;
-}
-
-function logConsentDateParseFailed_(raw) {
-  const message = `[consent-date-parse-failed] ${JSON.stringify({ raw: String(raw) })}`;
-  if (typeof dashboardLogContext_ === 'function') {
-    dashboardLogContext_('consent-date-parse-failed', message);
-    return;
-  }
-  if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
-    Logger.log(message);
-  }
 }
 
 function parseJapaneseEraDate_(value) {
@@ -1011,63 +930,37 @@ function parseJapaneseEraDate_(value) {
   ].join('-');
 }
 
-function parseConsentDate_(value) {
-  const logParseResult = result => {
-    if (typeof dashboardLogContext_ !== 'function') return;
-    dashboardLogContext_('parseConsentDate_:result', JSON.stringify({
-      input: value,
-      result: result ? result.toISOString() : null
-    }));
-  };
-
+function parseConsentDateInternal_(value) {
   if (value instanceof Date) {
-    const parsedDate = Number.isNaN(value.getTime()) ? null : value;
-    logParseResult(parsedDate);
-    return parsedDate;
+    return Number.isNaN(value.getTime()) ? null : value;
   }
-  if (value == null) {
-    logParseResult(null);
-    return null;
-  }
+  if (value == null) return null;
 
   const str = String(value).trim();
-  if (!str) {
-    logParseResult(null);
-    return null;
-  }
+  if (!str) return null;
 
   const ymdHyphen = str.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
   if (ymdHyphen) {
-    const parsedDate = createDateFromYmd_(ymdHyphen[1], ymdHyphen[2], ymdHyphen[3]);
-    logParseResult(parsedDate);
-    return parsedDate;
+    return createDateFromYmd_(ymdHyphen[1], ymdHyphen[2], ymdHyphen[3]);
   }
 
   const ymdSlash = str.match(/^(\d{4})\/(\d{1,2})\/(\d{1,2})$/);
   if (ymdSlash) {
-    const parsedDate = createDateFromYmd_(ymdSlash[1], ymdSlash[2], ymdSlash[3]);
-    logParseResult(parsedDate);
-    return parsedDate;
+    return createDateFromYmd_(ymdSlash[1], ymdSlash[2], ymdSlash[3]);
   }
 
   const ymdJapanese = str.match(/^(\d{4})年(\d{1,2})月(\d{1,2})日$/);
   if (ymdJapanese) {
-    const parsedDate = createDateFromYmd_(ymdJapanese[1], ymdJapanese[2], ymdJapanese[3]);
-    logParseResult(parsedDate);
-    return parsedDate;
+    return createDateFromYmd_(ymdJapanese[1], ymdJapanese[2], ymdJapanese[3]);
   }
 
   const isoPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})?$/;
   if (isoPattern.test(str)) {
     const timestamp = Date.parse(str);
     if (Number.isFinite(timestamp)) {
-      const parsedDate = new Date(timestamp);
-      logParseResult(parsedDate);
-      return parsedDate;
+      return new Date(timestamp);
     }
   }
-
-  logParseResult(null);
   return null;
 }
 

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -436,19 +436,23 @@ function testConsentDateParsingFormatsAndResolverPriority() {
   assert.deepStrictEqual((patientsById['008'] || []).filter(tag => tag.type === 'consent'), [], '同意年月日なしでは同意タグを表示しない');
 }
 
-function testConsentDateParseFailureCanBeDebugLogged() {
-  const logs = [];
-  const ctx = createContext({ DASHBOARD_DEBUG_CONSENT: true });
-  ctx.dashboardLogContext_ = (label, details) => {
-    logs.push({ label, details: String(details || '') });
+function testConsentExpiryResolutionRunsOncePerPatient() {
+  const ctx = createContext();
+  const originalResolve = ctx.resolveConsentExpiry_;
+  let resolveCount = 0;
+  ctx.resolveConsentExpiry_ = patient => {
+    resolveCount += 1;
+    return originalResolve(patient);
   };
 
-  ctx.getDashboardData({
+  const result = ctx.getDashboardData({
     user: { email: 'belltree@belltree1102.com', role: 'admin' },
     now: new Date('2025-02-01T00:00:00Z'),
     patientInfo: {
       patients: {
-        '001': { name: 'invalid-overview', raw: { '同意年月日': 'invalid-date' } }
+        '001': { name: 'A', raw: { '同意年月日': '2024-08-16' } },
+        '002': { name: 'B', raw: { '同意年月日': '2024-08-20' } },
+        '003': { name: 'C', raw: {} }
       },
       warnings: []
     },
@@ -462,9 +466,8 @@ function testConsentDateParseFailureCanBeDebugLogged() {
     visitsResult: { visits: [], warnings: [] }
   });
 
-  const parseFailureLogs = logs.filter(entry => entry.label === 'consent-date-parse-failed');
-  assert.ok(parseFailureLogs.length >= 1, '同意年月日の形式不正時は parse 失敗ログを出す');
-  assert.ok(parseFailureLogs.some(entry => entry.details.includes('\"raw\":\"invalid-date\"')), 'parse 失敗ログに入力値を含める');
+  assert.strictEqual(result.patients.length, 3);
+  assert.strictEqual(resolveCount, 3, 'resolveConsentExpiry_ は患者整形時に1回/患者だけ実行する');
 }
 
 function testRoleResolutionIsEmailBasedOnly() {
@@ -1063,7 +1066,7 @@ function testWarningsAreDedupedAndSetupFlagged() {
   testConsentAcquiredJudgmentHandlesFalseyStringsConsistently();
   testConsentDateParsingFormatsAndResolverPriority();
   testParseJapaneseEraDateAndResolveConsentExpiry();
-  testConsentDateParseFailureCanBeDebugLogged();
+  testConsentExpiryResolutionRunsOncePerPatient();
   testRoleResolutionIsEmailBasedOnly();
   testStaffConsentScopeMetricsAreLogged();
   testStaffConsentEligibilityEvaluatesOnlyVisiblePatients();


### PR DESCRIPTION
### Motivation
- Reduce duplicated work: `resolveConsentExpiry_` was being computed multiple times per patient (patient shaping, tag generation, overview) causing extra parsing and logging. 
- Ensure consistent display: avoid recalculating consent expiry in UI rendering paths so tags and overview use the same precomputed value. 
- Simplify internals: make the consent date parser internal-only and remove noisy parse-failure debug/log outputs.

### Description
- Compute consent expiry once during patient shaping in `buildDashboardPatients_` and attach `consentExpiry` (and pre-parsed `consentExpiryDate` / `consentAcquired`) to the shaped patient objects, then pass those into `buildDashboardPatientStatusTags_` via `params` instead of re-resolving from raw rows. 
- Change `buildDashboardOverview_`/`buildOverviewFromConsent_` to consume the shaped `patients` array and rely on `patient.statusTags`/`patient.consentExpiry` so overview generation does not re-resolve expiry. 
- Add in-object memoization for `resolveConsentExpiry_` (`__dashboardConsentExpiryResolved`) and rename `parseConsentDate_` to `parseConsentDateInternal_` for internal-only parsing, and remove parse-failure/dashboard debug logging paths. 
- Update tests and docs: replace the previous parse-failure logging test with `testConsentExpiryResolutionRunsOncePerPatient`, update `tests/dashboardGetDashboardData.test.js`, and refresh `docs/consent-expiry-investigation.md` with before/after call-count findings.

### Testing
- Ran `node tests/dashboardGetDashboardData.test.js` and the suite passed (including the new `testConsentExpiryResolutionRunsOncePerPatient`).
- Ran `node tests/calculateConsentExpiry.test.js` and it passed.
- Verified that `resolveConsentExpiry_` is invoked once per patient in the new test asserting call-count equals patient count.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699387f5cf188321a57755049555ec99)