### PR TITLE
fix(dashboard): スタッフ可視患者を施術ログ一致+直近50日に限定

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -1,14 +1,3 @@
-const PATIENT_RESPONSIBLE_COLUMN_CANDIDATES = ['担当者', '担当メール', '担当者メール', 'メール', 'email', 'mail', 'responsibleEmail'];
-
-function resolveResponsibleColumn_(patientRaw) {
-  const raw = patientRaw && typeof patientRaw === 'object' ? patientRaw : {};
-  for (let i = 0; i < PATIENT_RESPONSIBLE_COLUMN_CANDIDATES.length; i += 1) {
-    const columnName = PATIENT_RESPONSIBLE_COLUMN_CANDIDATES[i];
-    if (Object.prototype.hasOwnProperty.call(raw, columnName)) return columnName;
-  }
-  return '';
-}
-
 /**
  * ダッシュボードの主要データをまとめて取得し、JSON 形式で返す。
  * エラーが発生した場合は meta.error にメッセージを格納する。
@@ -119,34 +108,44 @@ function getDashboardData(options) {
       : { responsible: {}, warnings: [] })));
     logContext('getDashboardData:assignResponsible', `responsible=${Object.keys(responsible && responsible.responsible ? responsible.responsible : {}).length} warnings=${(responsible && responsible.warnings ? responsible.warnings.length : 0)} setupIncomplete=${!!(responsible && responsible.setupIncomplete)}`);
 
-    const responsiblePatientIds = new Set();
-    Object.keys(patientMaster || {}).forEach(pid => {
-      const patient = patientMaster[pid] || {};
-      const patientRaw = patient && patient.raw ? patient.raw : {};
-      const responsibleColumn = resolveResponsibleColumn_(patientRaw);
-      const normalizedResponsible = dashboardNormalizeEmail_(patientRaw[responsibleColumn]);
-
-      if (normalizedUser === normalizedResponsible) {
-        responsiblePatientIds.add(pid);
-      }
-    });
     const allPatientIds = Object.keys(patientMaster || {});
+    const now = dashboardCoerceDate_(opts.now) || new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const fiftyDaysAgoDate = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 50);
+    const fiftyDaysAgoKey = dashboardFormatDate_(fiftyDaysAgoDate, dashboardResolveTimeZone_(), 'yyyy-MM-dd') || '';
+    const responsiblePatientIds = new Set();
+    let matchedLogsCount = 0;
+    const logs = treatmentLogs && Array.isArray(treatmentLogs.logs) ? treatmentLogs.logs : [];
+    logs.forEach(entry => {
+      const pid = dashboardNormalizePatientId_(entry && entry.patientId);
+      if (!pid || !Object.prototype.hasOwnProperty.call(patientMaster, pid)) return;
+
+      const staffEmail = dashboardNormalizeEmail_(entry && entry.staffKeys ? entry.staffKeys.email : '');
+      if (!staffEmail || staffEmail !== normalizedUser) return;
+
+      const logDate = resolveTreatmentLogDate_(entry);
+      if (!logDate) return;
+      const logDay = new Date(logDate.getFullYear(), logDate.getMonth(), logDate.getDate());
+      if (logDay < fiftyDaysAgoDate) return;
+
+      matchedLogsCount += 1;
+      responsiblePatientIds.add(pid);
+    });
+
     let visiblePatientIds = null;
-    // 可視スコープはロール + 患者マスタ担当割当のみで決定する。
-    // 施術ログ・期間条件・直近○日条件は使用しない。
     if (role === 'admin') {
       visiblePatientIds = new Set(allPatientIds);
     } else {
       visiblePatientIds = responsiblePatientIds;
     }
-    const now = dashboardCoerceDate_(opts.now) || new Date();
     const applyScopeFilter = !isAdmin;
     logContext('getDashboardData:role', JSON.stringify({ role, applyScopeFilter }));
     logContext('getDashboardData:scopeSummary', JSON.stringify({
       role,
       applyScopeFilter,
       visiblePatientIdsSize: visiblePatientIds.size,
-      patientMapSize: allPatientIds.length
+      matchedLogsCount,
+      fiftyDaysAgo: fiftyDaysAgoKey
     }));
 
     if (!isAdmin) {
@@ -359,6 +358,16 @@ function getDashboardData(options) {
     logPerf('  - 権限影響: ユーザー別フィルタを前段キャッシュへ寄せると、権限境界を跨いだデータ混入リスクが上がる。');
     logPerf(`[perf-check] spreadsheetOpenCount=${spreadsheetOpenCount}`);
   }
+}
+
+function resolveTreatmentLogDate_(entry) {
+  if (!entry) return null;
+  const ts = dashboardCoerceDate_(entry.timestamp);
+  if (ts) return ts;
+  const dateKey = entry && entry.dateKey ? String(entry.dateKey).trim() : '';
+  if (!dateKey) return null;
+  const parsed = dashboardCoerceDate_(dateKey);
+  return parsed || null;
 }
 
 function dashboardGetTreatmentLogsFromCache_(cacheKey, monthKey, loader, logCachePerf) {

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -878,7 +878,8 @@ function testVisibleScopeForAdminShowsAllPatients() {
     role: 'admin',
     applyScopeFilter: false,
     visiblePatientIdsSize: 2,
-    patientMapSize: 2
+    matchedLogsCount: 0,
+    fiftyDaysAgo: '2024-12-25'
   });
 }
 
@@ -934,7 +935,7 @@ function testVisibleScopeForStaffShowsResponsiblePatientsOnly() {
     responsible: { responsible: {}, warnings: [] }
   });
 
-  assert.deepStrictEqual(JSON.parse(JSON.stringify(result.patients.map(p => p.patientId))), ['001'], 'スタッフは患者マスタの担当割当患者のみ表示する');
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(result.patients.map(p => p.patientId))), ['001'], 'スタッフは施術ログ一致かつ直近50日患者のみ表示する');
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result.tasks.map(t => t.patientId))), []);
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result.todayVisits.map(v => v.patientId))), ['001']);
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result.unpaidAlerts.map(a => a.patientId))), ['001']);
@@ -948,7 +949,8 @@ function testVisibleScopeForStaffShowsResponsiblePatientsOnly() {
     role: 'staff',
     applyScopeFilter: true,
     visiblePatientIdsSize: 1,
-    patientMapSize: 2
+    matchedLogsCount: 1,
+    fiftyDaysAgo: '2024-12-25'
   });
 }
 
@@ -975,7 +977,7 @@ function testVisibleScopeForStaffWithoutResponsibleAssignmentShowsNoPatients() {
     responsible: { responsible: {}, warnings: [] }
   });
 
-  assert.strictEqual(result.patients.length, 0, '担当割当がなければ患者表示0件');
+  assert.strictEqual(result.patients.length, 0, '直近50日内の施術ログ一致がなければ患者表示0件');
   assert.strictEqual(result.tasks.length, 0);
   assert.strictEqual(result.todayVisits.length, 0);
   assert.strictEqual(result.unpaidAlerts.length, 0);


### PR DESCRIPTION
### Motivation
- スタッフが閲覧できる患者を、患者マスタの担当カラムに依存せず「施術ログの担当メール完全一致（正規化）かつ直近50日以内のログがある患者」のみに限定するため。
- 管理者は従来どおり全患者表示とし、ロール判定・同意計算・患者データ構造は変更しないという仕様を満たすため。 

### Description
- `getDashboardData` の可視スコープ決定ロジックを変更し、患者マスタの担当カラム探索（`PATIENT_RESPONSIBLE_COLUMN_CANDIDATES` / `resolveResponsibleColumn_`）を削除しました。 
- 施術ログ(`treatmentLogs.logs`)を走査して `staffKeys.email` を正規化した値と `normalizedUser` を完全一致で比較し、ログ日付を `timestamp` 優先・`dateKey` フォールバックで解釈して `today - 50日` 以内のログを満たす患者のIDのみ `visiblePatientIds` に含めるようにしました。 
- `fiftyDaysAgo`（今日から50日前）を算出して判定に使用し、`getDashboardData:scopeSummary` ログに `matchedLogsCount` と `fiftyDaysAgo` を追加しました。 
- ログ日付解釈のために `resolveTreatmentLogDate_` を新規追加し、`timestamp` または `dateKey` から日付を返すようにしました。 
- 仕様に合わせて `tests/dashboardGetDashboardData.test.js` の期待値（`scopeSummary` のフォーマットとスタッフ向け説明）を更新しました。 

### Testing
- 自動テストを実行し、`node tests/dashboardGetDashboardData.test.js` が成功しました。 
- 自動テストを実行し、`node tests/dashboardGetDashboardDataOptions.test.js` が成功しました. 
- 上記によりダッシュボード関連のテスト群は通過しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69938a9b6f8483218b78a6d1b758af1c)