### PR TITLE
Add requestId logging for dashboard API request tracing

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -150,8 +150,13 @@ const dashboardState = {
   loading: true,
   data: null,
   error: '',
-  marking: new Set()
+  marking: new Set(),
+  requestId: ''
 };
+
+function createDashboardRequestId_() {
+  return `dashboard-${Date.now()}-${Math.floor(Math.random() * 1000000)}`;
+}
 
 function logDashboardUi_(label, details) {
   if (typeof console === 'undefined') return;
@@ -166,11 +171,15 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 function fetchDashboardData() {
+  const requestId = createDashboardRequestId_();
+  dashboardState.requestId = requestId;
   setLoading(true);
   dashboardState.error = '';
+  console.log('[dashboard requestId] fetchDashboardData', requestId);
   logDashboardUi_('fetchDashboardData:start', { mock: resolveDashboardMockParam_() || null });
 
   const onSuccess = (payload) => {
+    console.log('[dashboard requestId] fetchDashboardData:onSuccess', requestId);
     console.log('[dashboard debug] patients.length (api response)', Array.isArray(payload && payload.patients) ? payload.patients.length : 0);
     dashboardState.data = payload || {};
     console.log('[dashboard debug] patients.length (after dashboardState.data assignment)', Array.isArray(dashboardState.data && dashboardState.data.patients) ? dashboardState.data.patients.length : 0);
@@ -187,6 +196,7 @@ function fetchDashboardData() {
     renderAll();
   };
   const onFailure = (err) => {
+    console.log('[dashboard requestId] fetchDashboardData:onFailure', requestId);
     dashboardState.error = err && err.message ? err.message : String(err || '不明なエラー');
     setLoading(false);
     logDashboardUi_('fetchDashboardData:failure', dashboardState.error);
@@ -222,6 +232,7 @@ function setLoading(flag) {
 }
 
 function renderAll() {
+  console.log('[dashboard requestId] renderAll', dashboardState.requestId || '');
   renderMeta();
   renderOverview();
   renderUnpaidAlerts();


### PR DESCRIPTION
### Motivation
- ダッシュボードAPI呼び出し（`getDashboardData`）ごとのログを相関して二重リクエストの有無を調査するため、各リクエストに一意の `requestId` を付与して画面側で出力する。 

### Description
- `src/dashboard.html` に `dashboardState.requestId` と `createDashboardRequestId_()` を追加し、`fetchDashboardData()` 開始時に `requestId` を生成・保持して開始/成功/失敗時に `console.log` 出力し、`renderAll()` 実行時にも同じ `requestId` を出力する診断用ログを追加した（非同期制御や既存処理の変更は行っていない）。

### Testing
- 自動テストを実行して `node --test tests/dashboardGetDashboardData.test.js` が成功（pass）することを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993c03e569483218286ebf15b56009b)