### PR TITLE
Add diagnostic [STRUCTURE] logs to dashboard fetch flow

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -184,8 +184,16 @@ function fetchDashboardData() {
     console.log('[dashboard requestId] fetchDashboardData:onSuccess', requestId);
     console.log('[dashboard-ui] requestId:success', requestId, 'patients=', data?.patients?.length);
     console.log('[dashboard debug] patients.length (api response)', Array.isArray(data && data.patients) ? data.patients.length : 0);
+    console.log('[STRUCTURE] typeof data =', typeof data);
+    console.log('[STRUCTURE] keys =', Object.keys(data || {}));
+    console.log('[STRUCTURE] raw data =', data);
+    console.log('[STRUCTURE] data.patients typeof =', typeof data?.patients);
+    console.log('[STRUCTURE] data.patients isArray =', Array.isArray(data?.patients));
     dashboardState.data = data || {};
     console.log('[dashboard debug] patients.length (after dashboardState.data assignment)', Array.isArray(dashboardState.data && dashboardState.data.patients) ? dashboardState.data.patients.length : 0);
+    console.log('[STRUCTURE] dashboardState.data keys =', Object.keys(dashboardState.data || {}));
+    console.log('[STRUCTURE] dashboardState.data.patients typeof =', typeof dashboardState.data?.patients);
+    console.log('[STRUCTURE] dashboardState.data.patients isArray =', Array.isArray(dashboardState.data?.patients));
     setLoading(false);
     const summary = {
       tasks: Array.isArray(data && data.tasks) ? data.tasks.length : 0,
@@ -197,6 +205,8 @@ function fetchDashboardData() {
     };
     logDashboardUi_('fetchDashboardData:success', summary);
     console.log('[dashboard-ui] requestId:beforeRender', requestId, 'patients=', dashboardState.data?.patients?.length);
+    console.log('[STRUCTURE] before render patients typeof =', typeof dashboardState.data?.patients);
+    console.log('[STRUCTURE] before render isArray =', Array.isArray(dashboardState.data?.patients));
     renderAll();
   };
   const onFailure = (err) => {


### PR DESCRIPTION
### Motivation
- Capture and diagnose inconsistencies in the dashboard API response and the in-memory `dashboardState.data` shape during fetch and render steps by adding runtime diagnostic logs.

### Description
- Inserted `console.log` statements in `src/dashboard.html` inside `fetchDashboardData` success callback to log `typeof data`, `Object.keys(data || {})`, raw payload, and `data.patients` type/array checks before assignment.
- Added `console.log` statements immediately after `dashboardState.data = data || {}` to log `Object.keys(dashboardState.data || {})` and `dashboardState.data.patients` type/array checks.
- Added `console.log` statements immediately before calling `renderAll()` to inspect `typeof dashboardState.data?.patients` and whether it is an array.
- Did not change existing logic, return values, conditions, or remove existing logs; only added diagnostic logs.

### Testing
- Verified the new log lines are present with `rg -n "\[STRUCTURE\]" src/dashboard.html` and inspected the modified region with `nl -ba src/dashboard.html | sed -n '176,216p'`, both showing the inserted logs.
- Confirmed no runtime control-flow changes were introduced and behavior is limited to additional console logging; no automated unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993c423ad84832199517a8414e0ed4b)