### PR TITLE
Add diagnostic logs for getDashboardData call/return flow

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -181,6 +181,7 @@ function fetchDashboardData() {
   logDashboardUi_('fetchDashboardData:start', { mock: resolveDashboardMockParam_() || null });
 
   const onSuccess = (data) => {
+    console.log('[CALL CHECK] success handler triggered');
     console.log('[dashboard requestId] fetchDashboardData:onSuccess', requestId);
     console.log('[dashboard-ui] requestId:success', requestId, 'patients=', data?.patients?.length);
     console.log('[dashboard debug] patients.length (api response)', Array.isArray(data && data.patients) ? data.patients.length : 0);
@@ -222,6 +223,7 @@ function fetchDashboardData() {
     const mockFlag = resolveDashboardMockParam_();
     const args = mockFlag ? { mock: mockFlag } : {};
     logDashboardUi_('fetchDashboardData:appsScript', { mock: mockFlag || null });
+    console.log('[CALL CHECK] invoking getDashboardData');
     runner.withSuccessHandler(onSuccess).withFailureHandler(onFailure).getDashboardData(args);
     return;
   }

--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -5,6 +5,9 @@
  * @return {{tasks: Object[], todayVisits: Object[], patients: Object[], warnings: string[], meta: Object}}
  */
 function getDashboardData(options) {
+  if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+    Logger.log('[ENTRY CHECK] getDashboardData called');
+  }
   const opts = options || {};
   let spreadsheetOpenCount = 0;
   const perfStartedAt = Date.now();
@@ -320,7 +323,7 @@ function getDashboardData(options) {
         metaError: meta.error
       });
     }
-    return {
+    const result = {
       tasks: [],
       todayVisits: visitsResult && visitsResult.visits ? visitsResult.visits : [],
       patients,
@@ -329,6 +332,10 @@ function getDashboardData(options) {
       overview,
       meta
     };
+    if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+      Logger.log('[EXIT CHECK] returning patients=' + (result?.patients?.length || 'N/A'));
+    }
+    return result;
   } catch (err) {
     meta.error = err && err.message ? err.message : String(err);
     logContext('getDashboardData:error', meta.error);
@@ -342,7 +349,11 @@ function getDashboardData(options) {
         metaError: meta.error
       });
     }
-    return { tasks: [], todayVisits: [], patients: [], unpaidAlerts: [], warnings: [], overview: null, meta };
+    const result = { tasks: [], todayVisits: [], patients: [], unpaidAlerts: [], warnings: [], overview: null, meta };
+    if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+      Logger.log('[EXIT CHECK] returning patients=' + (result?.patients?.length || 'N/A'));
+    }
+    return result;
   } finally {
     const totalDuration = Date.now() - perfStartedAt;
     logPerf(`[perf] total=${totalDuration}ms`);


### PR DESCRIPTION
### Motivation
- Investigate a mismatch where the UI success handler sometimes receives `null` despite `getDashboardData` returning data by tracing the call/return path and patient counts.
- Introduce lightweight, non-invasive diagnostics to observe invocation and returned patient count without changing behavior.
- Restrict changes to logging points in the Apps Script backend and the dashboard UI call path.

### Description
- Inserted an entry log in `src/dashboard/api/getDashboardData.js`: `Logger.log('[ENTRY CHECK] getDashboardData called')` with a `Logger` availability guard.
- Added exit logs that report `result?.patients?.length` immediately before returning in both the successful return path and the catch return, constructing a local `result` object and returning it unchanged.
- Added `console.log('[CALL CHECK] invoking getDashboardData')` before `google.script.run.getDashboardData(args)` and `console.log('[CALL CHECK] success handler triggered')` at the start of the success handler in `src/dashboard.html`.
- Preserved all existing logs, return payload shapes, and business logic; changes are strictly diagnostic.

### Testing
- Inspected and validated the code changes with `git diff` to ensure logs are present and limited to the intended locations.
- Confirmed the working tree is clean with `git status --short` after committing the changes.
- No automated unit test suite was executed because none were applicable/available for this diagnostic-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993c51b7e7c8321ab1cd216ba658997)