### PR TITLE
Issue #1656: Add getDashboardData call/response tracing logs

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -183,6 +183,7 @@ function fetchDashboardData() {
   logDashboardUi_('fetchDashboardData:start', { mock: resolveDashboardMockParam_() || null });
 
   const onSuccess = (data) => {
+    console.log('[SUCCESS DATA RAW]', data);
     console.log('[DUP CHECK] success handler entered');
     console.log('[CALL CHECK] success handler triggered');
     console.log('[dashboard requestId] fetchDashboardData:onSuccess', requestId);

--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -5,7 +5,10 @@
  * @return {{tasks: Object[], todayVisits: Object[], patients: Object[], warnings: string[], meta: Object}}
  */
 function getDashboardData(options) {
+  const mock = options && options.mock;
   if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+    Logger.log('[CALL ID] ' + Utilities.getUuid());
+    Logger.log('[CALL PARAM mock] ' + mock);
     Logger.log('[ENTRY CHECK] getDashboardData called');
   }
   const opts = options || {};
@@ -333,6 +336,7 @@ function getDashboardData(options) {
       meta
     };
     if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+      Logger.log('[CALL END] returning patients=' + (result?.patients?.length || 'N/A'));
       Logger.log('[EXIT CHECK] returning patients=' + (result?.patients?.length || 'N/A'));
     }
     return result;
@@ -351,6 +355,7 @@ function getDashboardData(options) {
     }
     const result = { tasks: [], todayVisits: [], patients: [], unpaidAlerts: [], warnings: [], overview: null, meta };
     if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+      Logger.log('[CALL END] returning patients=' + (result?.patients?.length || 'N/A'));
       Logger.log('[EXIT CHECK] returning patients=' + (result?.patients?.length || 'N/A'));
     }
     return result;


### PR DESCRIPTION
### Motivation
- Add non-invasive tracing to determine whether duplicate server responses are being produced by `getDashboardData` without changing business logic or return behavior.

### Description
- Emit a per-call UUID and the incoming `mock` parameter at the top of `getDashboardData` via `Logger.log('[CALL ID] ' + Utilities.getUuid())` and `Logger.log('[CALL PARAM mock] ' + mock)`, and emit `[CALL END] returning patients=...` immediately before returning in both success and catch return paths in `src/dashboard/api/getDashboardData.js`.
- Log the raw payload on the client success handler with `console.log('[SUCCESS DATA RAW]', data);` in `src/dashboard.html` to correlate client receives with server call IDs.

### Testing
- Ran repository checks and file-diff inspections (including `git diff --check`) to verify the changes applied cleanly and no unexpected whitespace or diff issues were introduced, and those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993c70479448321a2bbbb5cea523e0e)