### PR TITLE
Role-filter >30-day consent_expired alerts; keep overview shape and add alertsSample logging

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -87,8 +87,9 @@ function getDashboardData(options) {
   meta.user = userIdentity || '';
   const userEmail = userIdentity || '';
   const normalizedUser = dashboardNormalizeEmail_(userEmail);
-  const role = getUserRole_(userEmail);
-  const isAdmin = role === 'admin';
+  const currentUserRole = getUserRole_(userEmail);
+  const role = currentUserRole;
+  const isAdmin = currentUserRole === 'admin';
   logContext('getDashboardData:start', `user=${userIdentity || 'unknown'} normalizedUser=${normalizedUser || 'unknown'} isAdmin=${isAdmin ? 'true' : 'false'} mock=${opts.mock ? 'true' : 'false'}`);
 
   try {
@@ -331,6 +332,7 @@ function getDashboardData(options) {
       notes,
       user: userIdentity,
       now: opts.now,
+      currentUserRole,
       allowedPatientIds: visiblePatientIds
     });
     const invoiceUnconfirmed = overview && overview.invoiceUnconfirmed ? overview.invoiceUnconfirmed : { items: [] };
@@ -747,6 +749,7 @@ function buildDashboardOverview_(params) {
   const now = dashboardCoerceDate_(payload.now) || new Date();
   const tz = dashboardResolveTimeZone_();
   const user = payload.user || '';
+  const currentUserRole = payload.currentUserRole || 'staff';
   const allowedPatientIds = payload.allowedPatientIds && typeof payload.allowedPatientIds.has === 'function' ? payload.allowedPatientIds : null;
   const scope = { patientIds: allowedPatientIds, applyFilter: !!allowedPatientIds };
   const invoiceScope = scope;
@@ -773,7 +776,7 @@ function buildDashboardOverview_(params) {
     tz,
     patientInfo
   );
-  const consentRelated = buildOverviewFromConsent_(patients, scope, patientNameMap, now);
+  const consentRelated = buildOverviewFromConsent_(patients, scope, patientNameMap, now, currentUserRole);
   const visitSummary = buildOverviewFromTreatmentProgress_(payload.visits, now, tz);
   return {
     invoiceUnconfirmed,
@@ -908,8 +911,8 @@ function buildDashboardInvoiceSearchText_(entry) {
     .join('\n');
 }
 
-function buildOverviewFromConsent_(patients, scope, patientNameMap, now) {
-  const items = [];
+function buildOverviewFromConsent_(patients, scope, patientNameMap, now, currentUserRole) {
+  const alerts = [];
   const allowedPatientIds = scope ? scope.patientIds : null;
   const applyFilter = scope ? scope.applyFilter : false;
   const targetNow = dashboardCoerceDate_(now) || new Date();
@@ -930,6 +933,8 @@ function buildOverviewFromConsent_(patients, scope, patientNameMap, now) {
 
     const consentStatus = evaluateConsentStatus_(consentExpiryDate, targetNow, pid);
     if (!consentStatus) return;
+    const expiredDays = consentStatus.type === 'expired' ? Math.abs(consentStatus.days) : 0;
+    if (consentStatus.type === 'expired' && expiredDays > 30 && currentUserRole !== 'admin') return;
     let label = `同意期限（残${consentStatus.days}日）`;
     if (consentStatus.type === 'expired') {
       label = `⚠ 同意期限超過（${Math.abs(consentStatus.days)}日超過）`;
@@ -937,20 +942,28 @@ function buildOverviewFromConsent_(patients, scope, patientNameMap, now) {
       label = `⏳ 同意期限迫る（残${consentStatus.days}日）`;
     }
     const name = (patient && patient.name) || patientNameMap[pid] || '';
-    items.push({
+    const alert = {
+      type: consentStatus.type === 'expired' ? 'consent_expired' : 'consent_warning',
       patientId: pid,
       name,
       subText: label
-    });
+    };
+    if (consentStatus.type === 'expired') {
+      alert.expiredDays = expiredDays;
+    }
+    alerts.push(alert);
   });
 
-  items.sort((a, b) => (a.name || '').localeCompare(b.name || '', 'ja'));
+  alerts.sort((a, b) => (a.name || '').localeCompare(b.name || '', 'ja'));
+  const items = alerts.map(alert => ({ patientId: alert.patientId, name: alert.name, subText: alert.subText }));
   if (typeof dashboardLogContext_ === 'function') {
     dashboardLogContext_('buildOverviewFromConsent_:scope', JSON.stringify({
       applyFilter,
       totalPatients: Array.isArray(patients) ? patients.length : 0,
       filteredByScope,
-      resultItems: items.length
+      resultItems: items.length,
+      currentUserRole,
+      alertsSample: alerts.slice(0, 10)
     }));
   }
   return { items };

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -27,7 +27,8 @@ function createContext(overrides = {}) {
     Date,
     Set,
     Utilities: {
-      formatDate: (date, _tz, _fmt) => date.toISOString()
+      formatDate: (date, _tz, _fmt) => date.toISOString(),
+      getUuid: () => 'test-uuid'
     },
     Session: {
       getScriptTimeZone: () => 'Asia/Tokyo',
@@ -1058,6 +1059,66 @@ function testWarningsAreDedupedAndSetupFlagged() {
   assert.strictEqual(result.meta.setupIncomplete, true, 'セットアップ未完了フラグが伝搬する');
 }
 
+
+function testConsentExpiredOver30DaysAlertsAreRoleFiltered() {
+  const baseOptions = {
+    now: new Date('2025-02-01T00:00:00Z'),
+    patientInfo: {
+      patients: {
+        '001': { name: '超過29日', raw: { '同意年月日': '2024-01-01' } },
+        '002': { name: '超過30日', raw: { '同意年月日': '2024-01-02' } },
+        '003': { name: '超過31日', raw: { '同意年月日': '2024-01-03' } }
+      },
+      warnings: []
+    },
+    notes: { notes: {}, warnings: [] },
+    aiReports: { reports: {}, warnings: [] },
+    invoices: { invoices: {}, warnings: [] },
+    treatmentLogs: {
+      logs: [
+        { patientId: '001', timestamp: new Date('2025-01-20T00:00:00Z'), staffKeys: { email: 'staff@example.com' } },
+        { patientId: '002', timestamp: new Date('2025-01-20T00:00:00Z'), staffKeys: { email: 'staff@example.com' } },
+        { patientId: '003', timestamp: new Date('2025-01-20T00:00:00Z'), staffKeys: { email: 'staff@example.com' } }
+      ],
+      warnings: []
+    },
+    responsible: { responsible: {}, warnings: [] },
+    unpaidAlerts: { alerts: [], warnings: [] },
+    visitsResult: { visits: [], warnings: [] }
+  };
+
+  const calcExpiry = value => {
+    const key = value instanceof Date ? value.toISOString().slice(0, 10) : String(value);
+    if (key === '2024-01-01') return '2025-01-03';
+    if (key === '2024-01-02') return '2025-01-02';
+    if (key === '2024-01-03') return '2025-01-01';
+    return '';
+  };
+
+  const adminCtx = createContext({ calculateConsentExpiry_: calcExpiry });
+  const adminResult = adminCtx.getDashboardData(Object.assign({}, baseOptions, { user: { email: 'belltree@belltree1102.com' } }));
+  const adminItems = JSON.parse(JSON.stringify(adminResult.overview.consentRelated.items || []));
+  const adminIds = adminItems.map(item => item.patientId);
+  assert.strictEqual(adminItems.length, 3, 'admin では 29/30/31 日超過をすべて表示する');
+  assert.deepStrictEqual(adminIds.sort(), ['001', '002', '003']);
+  const adminExpiredDays = Object.fromEntries(adminItems.map(item => [item.patientId, Number((item.subText.match(/（(\d+)日超過）/) || [])[1]) ]));
+  assert.strictEqual(adminExpiredDays['001'], 29);
+  assert.strictEqual(adminExpiredDays['002'], 30);
+  assert.strictEqual(adminExpiredDays['003'], 31);
+
+  const staffCtx = createContext({ calculateConsentExpiry_: calcExpiry });
+  const staffResult = staffCtx.getDashboardData(Object.assign({}, baseOptions, { user: { email: 'staff@example.com' } }));
+  const staffItems = JSON.parse(JSON.stringify(staffResult.overview.consentRelated.items || []));
+  const staffIds = staffItems.map(item => item.patientId);
+  assert.strictEqual(staffItems.length, 2, 'staff では 31 日超過を除外する');
+  assert.deepStrictEqual(staffIds.sort(), ['001', '002']);
+  assert.ok(!staffItems.some(item => item.patientId === '003'), 'staff では 31 日超過は完全非表示');
+  const staffExpiredDays = Object.fromEntries(staffItems.map(item => [item.patientId, Number((item.subText.match(/（(\d+)日超過）/) || [])[1]) ]));
+  assert.strictEqual(staffExpiredDays['001'], 29);
+  assert.strictEqual(staffExpiredDays['002'], 30);
+}
+
+
 (function run() {
   testAggregatesDashboardData();
   testPatientStatusTagsGeneration();
@@ -1085,5 +1146,6 @@ function testWarningsAreDedupedAndSetupFlagged() {
   testErrorIsCapturedInMeta();
   testSpreadsheetIsOpenedOnceAndPerfCheckIsLogged();
   testWarningsAreDedupedAndSetupFlagged();
+  testConsentExpiredOver30DaysAlertsAreRoleFiltered();
   console.log('dashboardGetDashboardData tests passed');
 })();


### PR DESCRIPTION
### Motivation
- Prevent staff from seeing `consent_expired` alerts older than 30 days while allowing admins to see them, and enable Cloud-log verification of the computed `expiredDays` without changing the public overview shape.

### Description
- Propagate current user role into overview creation by adding `currentUserRole` to `buildDashboardOverview_` and using it in `buildOverviewFromConsent_` (file: `src/dashboard/api/getDashboardData.js`).
- Compute `expiredDays` for `consent_expired` entries and skip adding alerts where `expiredDays > 30` unless `currentUserRole === 'admin'`, while preserving the public return shape `overview.consentRelated.items` (only `items` are returned).
- Internally keep `alerts` with `expiredDays` for filtering and add `alertsSample` (up to 10) to the `buildOverviewFromConsent_:scope` Cloud log to assist verification of `expiredDays` and role-based inclusion.
- Add/modify test `testConsentExpiredOver30DaysAlertsAreRoleFiltered` in `tests/dashboardGetDashboardData.test.js` to deterministically cover 29/30/31-day boundaries by stubbing `calculateConsentExpiry_` and assert admin sees all three while staff excludes the >30-day case.

### Testing
- Ran the dashboard unit suite with `node tests/dashboardGetDashboardData.test.js` and it passed (message: `dashboardGetDashboardData tests passed`).
- Executed a Node runtime check that loads the updated modules and prints `overview` for admin and staff; it confirmed admin includes 29/30/31-day expired patients and staff excludes the 31-day one, and `patients` lengths match.
- Attempted an automated Playwright run to open `src/dashboard.html` for a browser/Cloud-log validation, but the Chromium process crashed (`SIGSEGV`) in this environment so in-browser verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994e92669cc83219cdc46d1d137aeec)