### PR TITLE
visitSummaryを今日と前回施術日の2指標へ整理

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -330,9 +330,13 @@ function renderVisitSummary() {
   const container = document.getElementById('visitSummary');
   if (!container) return;
   const overview = dashboardState.data && dashboardState.data.overview ? dashboardState.data.overview : {};
-  const data = overview && overview.visitSummary ? overview.visitSummary : { todayCount: 0, latestDayCount: 0 };
+  const data = overview && overview.visitSummary
+    ? overview.visitSummary
+    : { todayCount: 0, previousDayCount: 0, previousDayDate: null };
   const todayCount = Number(data.todayCount || 0);
-  const latestDayCount = Number(data.latestDayCount || 0);
+  const previousDayCount = Number(data.previousDayCount || 0);
+  const previousDayDate = data.previousDayDate ? String(data.previousDayDate).trim() : '';
+  const previousDayLabel = `前回施術（${formatPreviousVisitDate_(previousDayDate)}）`;
 
   container.innerHTML = '';
 
@@ -347,9 +351,18 @@ function renderVisitSummary() {
   metrics.className = 'overview-metrics';
 
   metrics.appendChild(renderOverviewMetric_('今日', `${todayCount}件`));
-  metrics.appendChild(renderOverviewMetric_('直近1日施術', `${latestDayCount}件`));
+  metrics.appendChild(renderOverviewMetric_(previousDayLabel, `${previousDayCount}件`));
 
   container.appendChild(metrics);
+}
+
+function formatPreviousVisitDate_(dateKey) {
+  if (!dateKey) return '-';
+  const matched = String(dateKey).match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!matched) return '-';
+  const month = String(Number(matched[2]));
+  const day = String(Number(matched[3]));
+  return `${month}/${day}`;
 }
 
 function renderUnpaidAlerts() {

--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -1192,16 +1192,16 @@ function buildOverviewFromTreatmentProgress_(visits, now, tz) {
     countByDate[dateKey] = (countByDate[dateKey] || 0) + 1;
   });
 
-
   const todayCount = countByDate[todayKey] || 0;
-  const latestPastDate = Object.keys(countByDate)
+  const previousDayDate = Object.keys(countByDate)
     .filter(dateKey => dateKey < todayKey)
-    .sort((a, b) => b.localeCompare(a))[0] || '';
-  const latestDayCount = todayCount > 0 ? todayCount : (latestPastDate ? countByDate[latestPastDate] || 0 : 0);
+    .sort((a, b) => b.localeCompare(a))[0] || null;
+  const previousDayCount = previousDayDate ? countByDate[previousDayDate] || 0 : 0;
 
   return {
     todayCount,
-    latestDayCount
+    previousDayCount,
+    previousDayDate
   };
 }
 

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -583,7 +583,7 @@ function testStaffConsentEligibilityEvaluatesOnlyVisiblePatients() {
   assert.deepStrictEqual(consentDebugLogs, ['001'], '可視範囲外の患者は一致していても同意デバッグログを出力しない');
 }
 
-function testVisitSummaryWhenTodayIsZeroUsesLatestPastDayCount() {
+function testVisitSummaryWhenTodayIsZeroUsesPreviousDayCount() {
   const ctx = createContext({
     Utilities: {
       formatDate: (date, _tz, fmt) => {
@@ -603,11 +603,12 @@ function testVisitSummaryWhenTodayIsZeroUsesLatestPastDayCount() {
 
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result)), {
     todayCount: 0,
-    latestDayCount: 1
+    previousDayCount: 1,
+    previousDayDate: '2025-01-31'
   });
 }
 
-function testVisitSummaryWhenTodayHasTwoUsesTodayCountForBoth() {
+function testVisitSummaryWhenTodayHasTwoStillUsesPreviousDayAsPastDate() {
   const ctx = createContext({
     Utilities: {
       formatDate: (date, _tz, fmt) => {
@@ -629,8 +630,10 @@ function testVisitSummaryWhenTodayHasTwoUsesTodayCountForBoth() {
 
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result)), {
     todayCount: 2,
-    latestDayCount: 2
+    previousDayCount: 1,
+    previousDayDate: '2025-01-31'
   });
+  assert.notStrictEqual(result.previousDayDate, '2025-02-01', 'today に施術があっても previousDayDate は今日より前を指す');
 }
 
 function testVisitSummaryWhenNoDataReturnsZeroCounts() {
@@ -651,7 +654,8 @@ function testVisitSummaryWhenNoDataReturnsZeroCounts() {
 
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result)), {
     todayCount: 0,
-    latestDayCount: 0
+    previousDayCount: 0,
+    previousDayDate: null
   });
 }
 
@@ -1133,8 +1137,8 @@ function testConsentExpiredOver30DaysAlertsAreRoleFiltered() {
   testRoleResolutionIsEmailBasedOnly();
   testStaffConsentScopeMetricsAreLogged();
   testStaffConsentEligibilityEvaluatesOnlyVisiblePatients();
-  testVisitSummaryWhenTodayIsZeroUsesLatestPastDayCount();
-  testVisitSummaryWhenTodayHasTwoUsesTodayCountForBoth();
+  testVisitSummaryWhenTodayIsZeroUsesPreviousDayCount();
+  testVisitSummaryWhenTodayHasTwoStillUsesPreviousDayAsPastDate();
   testVisitSummaryWhenNoDataReturnsZeroCounts();
   testInvoiceUnconfirmedUsesPositiveConfirmationEvidence();
   testInvoiceUnconfirmedIgnoresDisplayTargetFilter();


### PR DESCRIPTION
### Motivation
- ダッシュボードの実績表示を整理して同時に3指標が出ないようにし、意味の明確な2指標（今日・前回施術日）に統一するため。 
- 前回施術日は「今日より前の最大の`dateKey`」を採用して件数と日付を返す要件に合わせるため。 

### Description
- `buildOverviewFromTreatmentProgress_` を修正して返却を `todayCount` / `previousDayCount` / `previousDayDate` （`YYYY-MM-DD` または `null`）に統一し、`latestDayCount` と `lastWorkingDayVisits` を削除しました。 
- 日付ロジックは `previousDayDate = max(dateKey where dateKey < todayKey)` として算出し、`previousDayCount` はその日の件数（該当なしなら `0`）にしています。 
- フロントの `src/dashboard.html` を更新して実績カードを2指標にし、`previousDayDate` を `MM/DD` で表示するための `formatPreviousVisitDate_` を追加し、`前回施術（-）` 表示を実装しました。 
- テスト `tests/dashboardGetDashboardData.test.js` を修正して `visitSummary.previousDayCount` / `visitSummary.previousDayDate` を検証するようにし、今日に施術があっても `previousDayDate` は今日より前であることを追加で検証するアサートを入れました。 

### Testing
- `node tests/dashboardGetDashboardData.test.js` を実行してテスト群はパスしました。 
- `node tests/dashboardNavigationLinks.test.js` を実行してパスしました。 
- Playwright を使って UI スクリーンショット取得を試みましたが、テスト環境でのワーキングディレクトリ不一致によりスクリプトが失敗したためスクリーンショットは取得できませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994ec5f00f8832199360953f912e2bd)