### PR TITLE
Ensure visitSummary uses scoped visits and add edge-case tests

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -332,11 +332,11 @@ function renderVisitSummary() {
   const overview = dashboardState.data && dashboardState.data.overview ? dashboardState.data.overview : {};
   const data = overview && overview.visitSummary
     ? overview.visitSummary
-    : { todayCount: 0, previousDayCount: 0, previousDayDate: null };
-  const todayCount = Number(data.todayCount || 0);
-  const previousDayCount = Number(data.previousDayCount || 0);
-  const previousDayDate = data.previousDayDate ? String(data.previousDayDate).trim() : '';
-  const previousDayLabel = `前回施術（${formatPreviousVisitDate_(previousDayDate)}）`;
+    : { today: { date: '-', count: 0 }, previous: null, previous2: null };
+
+  const today = data.today || { date: '-', count: 0 };
+  const previous = data.previous || null;
+  const previous2 = data.previous2 || null;
 
   container.innerHTML = '';
 
@@ -350,13 +350,20 @@ function renderVisitSummary() {
   const metrics = document.createElement('div');
   metrics.className = 'overview-metrics';
 
-  metrics.appendChild(renderOverviewMetric_('今日', `${todayCount}件`));
-  metrics.appendChild(renderOverviewMetric_(previousDayLabel, `${previousDayCount}件`));
+  metrics.appendChild(renderOverviewMetric_(`今日（${formatVisitDateForOverview_(today && today.date)}）`, `${Number(today && today.count || 0)}件`));
+  metrics.appendChild(renderOverviewMetric_(
+    `前回施術（${formatVisitDateForOverview_(previous && previous.date)}）`,
+    `${Number(previous && previous.count || 0)}件`
+  ));
+  metrics.appendChild(renderOverviewMetric_(
+    `前々回施術（${formatVisitDateForOverview_(previous2 && previous2.date)}）`,
+    `${Number(previous2 && previous2.count || 0)}件`
+  ));
 
   container.appendChild(metrics);
 }
 
-function formatPreviousVisitDate_(dateKey) {
+function formatVisitDateForOverview_(dateKey) {
   if (!dateKey) return '-';
   const matched = String(dateKey).match(/^(\d{4})-(\d{2})-(\d{2})$/);
   if (!matched) return '-';

--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -293,7 +293,16 @@ function getDashboardData(options) {
       visiblePatientIds,
       now: opts.now
     }) : { visits: [], warnings: [] })));
-    logContext('getDashboardData:getTodayVisits', `visits=${(visitsResult && visitsResult.visits ? visitsResult.visits.length : 0)} warnings=${(visitsResult && visitsResult.warnings ? visitsResult.warnings.length : 0)} setupIncomplete=${!!(visitsResult && visitsResult.setupIncomplete)}`);
+
+    const rawVisits = visitsResult && Array.isArray(visitsResult.visits) ? visitsResult.visits : [];
+    const scopedVisits = visiblePatientIds
+      ? rawVisits.filter(visit => {
+        const patientId = dashboardNormalizePatientId_(visit && visit.patientId);
+        return !!patientId && visiblePatientIds.has(patientId);
+      })
+      : rawVisits;
+
+    logContext('getDashboardData:getTodayVisits', `visits=${rawVisits.length} scopedVisits=${scopedVisits.length} warnings=${(visitsResult && visitsResult.warnings ? visitsResult.warnings.length : 0)} setupIncomplete=${!!(visitsResult && visitsResult.setupIncomplete)}`);
     const patients = measureStep('buildPatients', () => buildDashboardPatients_(patientInfo, {
       notes,
       aiReports,
@@ -324,7 +333,7 @@ function getDashboardData(options) {
     logContext('getDashboardData:setupIncomplete', `result=${meta.setupIncomplete} warnings=${warningState.warnings.length}`);
 
     const overview = buildDashboardOverview_({
-      visits: visitsResult && visitsResult.visits ? visitsResult.visits : [],
+      visits: scopedVisits,
       patients,
       patientInfo,
       treatmentLogs,
@@ -348,7 +357,7 @@ function getDashboardData(options) {
     }
     const result = {
       tasks: [],
-      todayVisits: visitsResult && visitsResult.visits ? visitsResult.visits : [],
+      todayVisits: scopedVisits,
       patients,
       unpaidAlerts: unpaidAlertsResult && unpaidAlertsResult.alerts ? unpaidAlertsResult.alerts : [],
       warnings: warningState.warnings,
@@ -1187,23 +1196,36 @@ function buildOverviewFromTreatmentProgress_(visits, now, tz) {
   const countByDate = {};
 
   normalizedVisits.forEach(visit => {
-    const dateKey = visit && visit.dateKey ? String(visit.dateKey).trim() : '';
-    if (!dateKey) return;
+    const rawDateKey = visit && visit.dateKey ? String(visit.dateKey).trim() : '';
+    let dateKey = rawDateKey;
+    if (!dateKey || !/^\d{4}-\d{2}-\d{2}$/.test(dateKey)) {
+      const ts = dashboardCoerceDate_(visit && visit.timestamp ? visit.timestamp : null);
+      dateKey = ts ? dashboardFormatDate_(ts, tz, 'yyyy-MM-dd') : '';
+    }
+    if (!dateKey || !/^\d{4}-\d{2}-\d{2}$/.test(dateKey)) return;
     countByDate[dateKey] = (countByDate[dateKey] || 0) + 1;
   });
 
-  const todayCount = countByDate[todayKey] || 0;
-  const previousDayDate = Object.keys(countByDate)
+  const sortedPastDates = Object.keys(countByDate)
     .filter(dateKey => dateKey < todayKey)
-    .sort((a, b) => b.localeCompare(a))[0] || null;
-  const previousDayCount = previousDayDate ? countByDate[previousDayDate] || 0 : 0;
+    .sort((a, b) => b.localeCompare(a));
+  const previousDate = sortedPastDates[0] || null;
+  const previous2Date = sortedPastDates[1] || null;
 
   return {
-    todayCount,
-    previousDayCount,
-    previousDayDate
+    today: {
+      date: todayKey,
+      count: countByDate[todayKey] || 0
+    },
+    previous: previousDate
+      ? { date: previousDate, count: countByDate[previousDate] || 0 }
+      : null,
+    previous2: previous2Date
+      ? { date: previous2Date, count: countByDate[previous2Date] || 0 }
+      : null
   };
 }
+
 
 function collectDashboardWarnings_(results) {
   const warnings = [];

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -145,7 +145,13 @@ function testPatientStatusTagsGeneration() {
       warnings: []
     },
     invoices: { invoices: {}, warnings: [] },
-    treatmentLogs: { logs: [], warnings: [] },
+    treatmentLogs: {
+      logs: [
+        { patientId: '001', timestamp: new Date('2025-01-25T09:00:00Z'), staffKeys: { email: 'staff@example.com', name: '', staffId: '' } },
+        { patientId: '002', timestamp: new Date('2025-01-25T09:00:00Z'), staffKeys: { email: 'other@example.com', name: '', staffId: '' } }
+      ],
+      warnings: []
+    },
     responsible: { responsible: {}, warnings: [] },
     unpaidAlerts: { alerts: [], warnings: [] },
     tasksResult: { tasks: [], warnings: [] },
@@ -583,80 +589,151 @@ function testStaffConsentEligibilityEvaluatesOnlyVisiblePatients() {
   assert.deepStrictEqual(consentDebugLogs, ['001'], '可視範囲外の患者は一致していても同意デバッグログを出力しない');
 }
 
-function testVisitSummaryWhenTodayIsZeroUsesPreviousDayCount() {
-  const ctx = createContext({
+function createVisitSummaryTestContext() {
+  return createContext({
     Utilities: {
       formatDate: (date, _tz, fmt) => {
         if (fmt === 'yyyy-MM-dd') return new Date(date).toISOString().slice(0, 10);
         return new Date(date).toISOString();
       }
     }
-  });
-
-  const result = ctx.buildOverviewFromTreatmentProgress_(
-    [
-      { patientId: '001', dateKey: '2025-01-31', time: '09:00' }
-    ],
-    new Date('2025-02-01T00:00:00Z'),
-    'Asia/Tokyo'
-  );
-
-  assert.deepStrictEqual(JSON.parse(JSON.stringify(result)), {
-    todayCount: 0,
-    previousDayCount: 1,
-    previousDayDate: '2025-01-31'
   });
 }
 
-function testVisitSummaryWhenTodayHasTwoStillUsesPreviousDayAsPastDate() {
-  const ctx = createContext({
-    Utilities: {
-      formatDate: (date, _tz, fmt) => {
-        if (fmt === 'yyyy-MM-dd') return new Date(date).toISOString().slice(0, 10);
-        return new Date(date).toISOString();
-      }
-    }
-  });
+function testVisitSummaryWithTodayVisits() {
+  const ctx = createVisitSummaryTestContext();
 
   const result = ctx.buildOverviewFromTreatmentProgress_(
     [
       { patientId: '001', dateKey: '2025-02-01', time: '09:00' },
       { patientId: '002', dateKey: '2025-02-01', time: '10:00' },
-      { patientId: '003', dateKey: '2025-01-31', time: '11:00' }
+      { patientId: '003', dateKey: '2025-01-31', time: '11:00' },
+      { patientId: '004', dateKey: '2025-01-25', time: '12:00' }
     ],
     new Date('2025-02-01T00:00:00Z'),
     'Asia/Tokyo'
   );
 
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result)), {
-    todayCount: 2,
-    previousDayCount: 1,
-    previousDayDate: '2025-01-31'
+    today: { date: '2025-02-01', count: 2 },
+    previous: { date: '2025-01-31', count: 1 },
+    previous2: { date: '2025-01-25', count: 1 }
   });
-  assert.notStrictEqual(result.previousDayDate, '2025-02-01', 'today に施術があっても previousDayDate は今日より前を指す');
 }
 
-function testVisitSummaryWhenNoDataReturnsZeroCounts() {
-  const ctx = createContext({
+function testVisitSummaryWithoutTodayVisits() {
+  const ctx = createVisitSummaryTestContext();
+
+  const result = ctx.buildOverviewFromTreatmentProgress_(
+    [
+      { patientId: '001', dateKey: '2025-01-31', time: '09:00' },
+      { patientId: '002', dateKey: '2025-01-31', time: '10:00' },
+      { patientId: '003', dateKey: '2025-01-20', time: '11:00' }
+    ],
+    new Date('2025-02-01T00:00:00Z'),
+    'Asia/Tokyo'
+  );
+
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(result)), {
+    today: { date: '2025-02-01', count: 0 },
+    previous: { date: '2025-01-31', count: 2 },
+    previous2: { date: '2025-01-20', count: 1 }
+  });
+}
+
+function testVisitSummaryWithOnlyOneTreatmentDay() {
+  const ctx = createVisitSummaryTestContext();
+
+  const result = ctx.buildOverviewFromTreatmentProgress_(
+    [
+      { patientId: '001', dateKey: '2025-02-01', time: '09:00' }
+    ],
+    new Date('2025-02-01T00:00:00Z'),
+    'Asia/Tokyo'
+  );
+
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(result)), {
+    today: { date: '2025-02-01', count: 1 },
+    previous: null,
+    previous2: null
+  });
+}
+
+function testVisitSummaryRespectsStaffAdminScopeDifference() {
+  const summaryCtxOptions = {
     Utilities: {
       formatDate: (date, _tz, fmt) => {
         if (fmt === 'yyyy-MM-dd') return new Date(date).toISOString().slice(0, 10);
         return new Date(date).toISOString();
       }
     }
-  });
+  };
 
+  const baseOptions = {
+    now: new Date('2025-02-01T00:00:00Z'),
+    patientInfo: {
+      patients: {
+        '001': { name: '患者1', raw: {} },
+        '002': { name: '患者2', raw: {} }
+      },
+      warnings: []
+    },
+    notes: { notes: {}, warnings: [] },
+    aiReports: { reports: {}, warnings: [] },
+    invoices: { invoices: {}, warnings: [] },
+    treatmentLogs: {
+      logs: [
+        { patientId: '001', timestamp: new Date('2025-01-25T09:00:00Z'), staffKeys: { email: 'staff@example.com', name: '', staffId: '' } },
+        { patientId: '002', timestamp: new Date('2025-01-25T09:00:00Z'), staffKeys: { email: 'other@example.com', name: '', staffId: '' } }
+      ],
+      warnings: []
+    },
+    responsible: { responsible: { '001': 'staff@example.com' }, warnings: [] },
+    unpaidAlerts: { alerts: [], warnings: [] },
+    tasksResult: { tasks: [], warnings: [] },
+    visitsResult: {
+      visits: [
+        { patientId: '001', dateKey: '2025-02-01', time: '09:00' },
+        { patientId: '001', dateKey: '2025-01-31', time: '09:00' },
+        { patientId: '002', dateKey: '2025-01-30', time: '09:00' }
+      ],
+      warnings: []
+    }
+  };
+
+  const adminCtx = createContext(summaryCtxOptions);
+  const adminResult = adminCtx.getDashboardData(Object.assign({}, baseOptions, { user: { email: 'belltree@belltree1102.com', role: 'admin' } }));
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(adminResult.overview.visitSummary)), {
+    today: { date: '2025-02-01', count: 1 },
+    previous: { date: '2025-01-31', count: 1 },
+    previous2: { date: '2025-01-30', count: 1 }
+  }, 'admin は全可視患者の visitSummary になる');
+
+  const staffCtx = createContext(summaryCtxOptions);
+  const staffResult = staffCtx.getDashboardData(Object.assign({}, baseOptions, { user: { email: 'staff@example.com', role: 'staff' } }));
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(staffResult.overview.visitSummary)), {
+    today: { date: '2025-02-01', count: 1 },
+    previous: { date: '2025-01-31', count: 1 },
+    previous2: null
+  }, 'staff は visiblePatientIds 適用後の visitSummary になる');
+}
+
+function testVisitSummaryHasOnlyThreeKeysAndPastSlotsAreBeforeToday() {
+  const ctx = createVisitSummaryTestContext();
   const result = ctx.buildOverviewFromTreatmentProgress_(
-    [],
+    [
+      { patientId: '001', dateKey: '2025-02-01', time: '09:00' },
+      { patientId: '001', dateKey: '2025-01-31', time: '09:00' },
+      { patientId: '002', dateKey: '2025-01-30', time: '09:00' }
+    ],
     new Date('2025-02-01T00:00:00Z'),
     'Asia/Tokyo'
   );
 
-  assert.deepStrictEqual(JSON.parse(JSON.stringify(result)), {
-    todayCount: 0,
-    previousDayCount: 0,
-    previousDayDate: null
-  });
+  const keys = Object.keys(JSON.parse(JSON.stringify(result))).sort();
+  assert.deepStrictEqual(keys, ['previous', 'previous2', 'today']);
+  assert.ok(!result.previous || result.previous.date < result.today.date, 'previous は today より前のみ');
+  assert.ok(!result.previous2 || result.previous2.date < result.today.date, 'previous2 は today より前のみ');
 }
 
 
@@ -1137,9 +1214,11 @@ function testConsentExpiredOver30DaysAlertsAreRoleFiltered() {
   testRoleResolutionIsEmailBasedOnly();
   testStaffConsentScopeMetricsAreLogged();
   testStaffConsentEligibilityEvaluatesOnlyVisiblePatients();
-  testVisitSummaryWhenTodayIsZeroUsesPreviousDayCount();
-  testVisitSummaryWhenTodayHasTwoStillUsesPreviousDayAsPastDate();
-  testVisitSummaryWhenNoDataReturnsZeroCounts();
+  testVisitSummaryWithTodayVisits();
+  testVisitSummaryWithoutTodayVisits();
+  testVisitSummaryWithOnlyOneTreatmentDay();
+  testVisitSummaryRespectsStaffAdminScopeDifference();
+  testVisitSummaryHasOnlyThreeKeysAndPastSlotsAreBeforeToday();
   testInvoiceUnconfirmedUsesPositiveConfirmationEvidence();
   testInvoiceUnconfirmedIgnoresDisplayTargetFilter();
   testInvoiceUnconfirmedShouldDetectPatientWithOnlyPreviousMonthTreatment();


### PR DESCRIPTION
### Motivation
- Prevent `visitSummary` from counting visits outside the current user scope so `staff` users see only `visiblePatientIds`-filtered counts. 
- Enforce a single strict shape for `visitSummary` as `{ today: { date, count }, previous: { date, count } | null, previous2: { date, count } | null }` and avoid mixing old keys. 
- Make UI and tests rely on the new 3-row overview (today / previous / previous2) and guard edge cases (single treatment day, today=0 with past days, shape invariants).

### Description
- In `src/dashboard/api/getDashboardData.js` compute `rawVisits` and `scopedVisits` (filtered by `visiblePatientIds`) and use `scopedVisits` for both `overview.visitSummary` and `todayVisits`, with updated logging for `scopedVisits`. 
- Replace the old `buildOverviewFromTreatmentProgress_` behavior with a hardened implementation that aggregates only valid `YYYY-MM-DD` day keys (fallback from `timestamp`) and returns the strict `today/previous/previous2` structure. 
- Update `src/dashboard.html` to consume the new `visitSummary` shape and render three metrics (today / previous / previous2) with `MM/DD` formatting and safe fallbacks. 
- Tighten tests in `tests/dashboardGetDashboardData.test.js` by adding a `createVisitSummaryTestContext()` helper and new/adjusted tests that cover today-present, today-empty, single-treatment-day, staff/admin scope difference (via `getDashboardData`), and a shape guard asserting only `today/previous/previous2` keys are present.

### Testing
- Ran `node tests/dashboardGetDashboardData.test.js` and the suite passed. 
- Ran `node tests/dashboardTodayVisits.test.js` and the suite passed. 
- Verified old keys are removed with `! rg "todayCount|previousDayCount|previousDayDate" -n src tests`, which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994f13da04483219513a4506bf36df0)