### PR TITLE
Add visit debug logging to trace previous2 extraction

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -1193,6 +1193,7 @@ function buildOverviewFromTreatmentProgress_(visits, now, tz) {
   const targetNow = dashboardCoerceDate_(now) || new Date();
   const todayKey = dashboardFormatDate_(targetNow, tz, 'yyyy-MM-dd');
   const normalizedVisits = Array.isArray(visits) ? visits : [];
+  const scopedVisits = normalizedVisits;
   const countByDate = {};
 
   normalizedVisits.forEach(visit => {
@@ -1205,6 +1206,28 @@ function buildOverviewFromTreatmentProgress_(visits, now, tz) {
     if (!dateKey || !/^\d{4}-\d{2}-\d{2}$/.test(dateKey)) return;
     countByDate[dateKey] = (countByDate[dateKey] || 0) + 1;
   });
+
+  console.log('===== VISIT DEBUG START =====');
+
+  console.log('[VISIT DEBUG] todayKey =', todayKey);
+  console.log('[VISIT DEBUG] scopedVisits length =', scopedVisits.length);
+
+  const rawDates = scopedVisits.map(v => v.dateKey);
+  console.log('[VISIT DEBUG] raw dateKeys =', rawDates);
+
+  const uniqueSorted = [...new Set(rawDates)].sort();
+  console.log('[VISIT DEBUG] uniqueSorted dateKeys =', uniqueSorted);
+
+  const pastDateKeys = uniqueSorted.filter(d => d < todayKey);
+  console.log('[VISIT DEBUG] pastDateKeys (< todayKey) =', pastDateKeys);
+
+  const sortedDesc = [...pastDateKeys].sort().reverse();
+  console.log('[VISIT DEBUG] sortedDesc =', sortedDesc);
+
+  console.log('[VISIT DEBUG] previous =', sortedDesc[0] || null);
+  console.log('[VISIT DEBUG] previous2 =', sortedDesc[1] || null);
+
+  console.log('===== VISIT DEBUG END =====');
 
   const sortedPastDates = Object.keys(countByDate)
     .filter(dateKey => dateKey < todayKey)


### PR DESCRIPTION
### Motivation
- Add the requested investigation logs to determine at which stage a past visit date (e.g. `2026-02-16`) is dropped when computing `previous2` from visit data.

### Description
- Inserted the provided `VISIT DEBUG` `console.log` statements into `buildOverviewFromTreatmentProgress_` in `src/dashboard/api/getDashboardData.js` to emit `todayKey`, scoped visit count, `raw dateKeys`, `uniqueSorted`, `pastDateKeys`, `sortedDesc`, and the derived `previous` / `previous2` without changing aggregation behavior.
- Added a local alias `scopedVisits = normalizedVisits` so the debug snippet can inspect the same visit array used by the function.

### Testing
- Ran the dashboard unit suite with `node tests/dashboardGetDashboardData.test.js` and it passed (`dashboardGetDashboardData tests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994f8415d208321a7850fcddcc60f12)