### PR TITLE
ダッシュボード同意アラートを期限超過／期限間近で分離表示

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -75,6 +75,8 @@
   .summary-header h3{ margin:0; font-size:1rem; }
   .summary-count{ font-weight:700; font-size:1.1rem; color:#fff; }
   .overview-list{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:8px; }
+  .overview-section{ display:flex; flex-direction:column; gap:8px; }
+  .overview-section-title{ margin:2px 0 0; font-size:0.86rem; color:var(--muted); font-weight:700; }
   .overview-row{ display:flex; flex-direction:column; gap:4px; padding:8px 10px; border-radius:10px; border:1px solid var(--border); background:rgba(255,255,255,0.02); cursor:pointer; transition:background .15s ease, border-color .15s ease, transform .15s ease; }
   .overview-row:hover{ background:rgba(56,189,248,0.12); border-color:rgba(56,189,248,0.4); }
   .overview-row:active{ transform:translateY(1px); }
@@ -319,11 +321,69 @@ function renderConsentSummary() {
   if (!container) return;
   const overview = dashboardState.data && dashboardState.data.overview ? dashboardState.data.overview : {};
   const data = overview && overview.consentRelated ? overview.consentRelated : { count: 0, items: [] };
-  renderOverviewCard_(container, {
-    title: '②同意',
-    items: data.items || [],
-    emptyText: '対象者なし'
+  container.innerHTML = '';
+
+  const header = document.createElement('div');
+  header.className = 'summary-header';
+  const title = document.createElement('h3');
+  title.textContent = '②同意';
+  header.appendChild(title);
+  container.appendChild(header);
+
+  const items = Array.isArray(data.items) ? data.items : [];
+  const sections = classifyConsentSummaryItems_(items);
+  const hasItems = sections.expired.length > 0 || sections.warning.length > 0;
+  if (!hasItems) {
+    const empty = document.createElement('div');
+    empty.className = 'overview-empty';
+    empty.textContent = '対象者なし';
+    container.appendChild(empty);
+    return;
+  }
+
+  if (sections.expired.length > 0) {
+    container.appendChild(renderConsentSummarySection_('期限超過', sections.expired));
+  }
+  if (sections.warning.length > 0) {
+    container.appendChild(renderConsentSummarySection_('期限間近', sections.warning));
+  }
+}
+
+function classifyConsentSummaryItems_(items) {
+  const result = { expired: [], warning: [] };
+  (items || []).forEach(item => {
+    if (!item || !item.patientId) return;
+    const subText = String(item.subText || '').trim();
+    const expiredMatch = subText.match(/(\d+)日超過/);
+    if (expiredMatch && Number(expiredMatch[1]) > 0) {
+      result.expired.push({
+        patientId: item.patientId,
+        name: item.name,
+        subText: `◢ 同意期限超過（${Number(expiredMatch[1])}日超過）`
+      });
+      return;
+    }
+    const remainMatch = subText.match(/残\s*(-?\d+)\s*日/);
+    if (remainMatch && Number(remainMatch[1]) <= 30) {
+      result.warning.push({
+        patientId: item.patientId,
+        name: item.name,
+        subText: `⌛ 同意期限迫る（残${Number(remainMatch[1])}日）`
+      });
+    }
   });
+  return result;
+}
+
+function renderConsentSummarySection_(sectionTitle, items) {
+  const section = document.createElement('div');
+  section.className = 'overview-section';
+  const title = document.createElement('div');
+  title.className = 'overview-section-title';
+  title.textContent = sectionTitle;
+  section.appendChild(title);
+  section.appendChild(renderOverviewList_(items, '', { keepOrder: true }));
+  return section;
 }
 
 function renderVisitSummary() {
@@ -701,7 +761,8 @@ function renderOverviewMetric_(label, value) {
   return row;
 }
 
-function renderOverviewList_(items, emptyText) {
+function renderOverviewList_(items, emptyText, options) {
+  const opts = options || {};
   const filteredItems = (items || []).filter(item => item && item.patientId);
   if (!filteredItems.length) {
     const empty = document.createElement('div');
@@ -712,10 +773,10 @@ function renderOverviewList_(items, emptyText) {
 
   const list = document.createElement('div');
   list.className = 'overview-list';
-  filteredItems
-    .slice()
-    .sort((a, b) => (a.name || '').localeCompare(b.name || '', 'ja'))
-    .forEach(item => {
+  const orderedItems = opts.keepOrder
+    ? filteredItems.slice()
+    : filteredItems.slice().sort((a, b) => (a.name || '').localeCompare(b.name || '', 'ja'));
+  orderedItems.forEach(item => {
       const row = document.createElement('div');
       row.className = 'overview-row';
       const title = document.createElement('div');


### PR DESCRIPTION
### Motivation
- ダッシュボードの同意アラートが期限超過と期限間近が混在して表示されているため、フロントで分類して見やすく2セクションに分離する。 
- バックエンド構造は変更せず、既存ロジックを破壊しない前提でUI側のみ処理を追加する。 

### Description
- `renderConsentSummary()` を専用描画に差し替え、`overview.consentRelated.items` をフロントで分類して描画するようにした。 
- `classifyConsentSummaryItems_()` を追加し、`subText` を解析して以下のルールで振り分ける実装を追加した（フロント分類ロジックのみ）。
  - 期限超過: `XX日超過` の `XX > 0` → 表示文言は `◢ 同意期限超過（XX日超過）`。 
  - 期限間近: `残XX日` の `XX <= 30` → 表示文言は `⌛ 同意期限迫る（残XX日）`。 
- セクション描画用に `renderConsentSummarySection_()` を追加し、見出し（`期限超過` → `期限間近` の順）を生成するようにした。 
- 同一セクション内の既存の並び順を維持するために `renderOverviewList_()` に `keepOrder` オプションを追加し、同意セクションのみ `keepOrder: true` を指定して従来順を保持するようにした。 
- セクション見出し用の軽微な CSS を追加した。 
- 変更は `src/dashboard.html` のみで、バックエンドやデータ生成ロジックには手を入れていない。 

### Testing
- 自動チェックで差分フォーマット問題を確認するために `git diff --check` を実行し、問題なしを確認した（成功）。
- ローカルで簡易サーバを立てて `python3 -m http.server` により HTML を配信し、ブラウザ自動化（Playwright）で `renderConsentSummary()` を実行して表示を確認し、スクリーンショットを取得して期待するセクション表示を確認した（成功）。
- 変更後の UI 表示を手順で確認する自動化スナップショット取得が成功している（Playwright 実行による検証）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994f90d157483219e8dab7885011921)