### PR TITLE
Add investigation logs for visit summary execution path

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -302,6 +302,12 @@ function getDashboardData(options) {
       })
       : rawVisits;
 
+    if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+      Logger.log('[VISIT CALLER] about to call buildOverviewFromTreatmentProgress_');
+      Logger.log('[VISIT CALLER] scopedVisits length=' + scopedVisits.length);
+      Logger.log('[VISIT CALLER] matchedLogsCount=' + matchedLogsCount);
+    }
+
     logContext('getDashboardData:getTodayVisits', `visits=${rawVisits.length} scopedVisits=${scopedVisits.length} warnings=${(visitsResult && visitsResult.warnings ? visitsResult.warnings.length : 0)} setupIncomplete=${!!(visitsResult && visitsResult.setupIncomplete)}`);
     const patients = measureStep('buildPatients', () => buildDashboardPatients_(patientInfo, {
       notes,
@@ -1190,6 +1196,12 @@ function dashboardIsConsentAcquired_(raw) {
 }
 
 function buildOverviewFromTreatmentProgress_(visits, now, tz) {
+  if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+    Logger.log('[VISIT ENTRY] called buildOverviewFromTreatmentProgress_');
+    Logger.log('[VISIT ENTRY] visits typeof=' + typeof visits);
+    Logger.log('[VISIT ENTRY] visits length=' + (visits ? visits.length : 'null'));
+    Logger.log('[VISIT ENTRY] sample=' + JSON.stringify((visits || []).slice(0, 3)));
+  }
   const targetNow = dashboardCoerceDate_(now) || new Date();
   const todayKey = dashboardFormatDate_(targetNow, tz, 'yyyy-MM-dd');
   const normalizedVisits = Array.isArray(visits) ? visits : [];

--- a/src/dashboard/api/getTodayVisits.js
+++ b/src/dashboard/api/getTodayVisits.js
@@ -21,6 +21,11 @@ function getTodayVisits(options) {
   const notesResult = opts.notes || (typeof loadNotes === 'function' ? loadNotes() : null);
   const notes = notesResult && notesResult.notes ? notesResult.notes : {};
 
+  if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+    Logger.log('[TODAY VISITS ENTRY] logs length=' + (logs ? logs.length : 'null'));
+    Logger.log('[TODAY VISITS ENTRY] visiblePatientIds size=' + (visiblePatientIds ? visiblePatientIds.size : 'null'));
+  }
+
   const warnings = [];
   if (treatment && Array.isArray(treatment.warnings)) warnings.push.apply(warnings, treatment.warnings);
   if (notesResult && Array.isArray(notesResult.warnings)) warnings.push.apply(warnings, notesResult.warnings);
@@ -65,7 +70,12 @@ function getTodayVisits(options) {
     return a.dateKey.localeCompare(b.dateKey);
   });
 
-  return { visits, warnings, setupIncomplete };
+  const result = visits;
+  if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
+    Logger.log('[TODAY VISITS RETURN] result length=' + result.length);
+  }
+
+  return { visits: result, warnings, setupIncomplete };
 }
 
 


### PR DESCRIPTION
### Motivation
- 確実に `buildOverviewFromTreatmentProgress_` が呼ばれているか、その呼び出し元と入力データを Cloud ログで特定するための調査用ログを挿入しました。
- `getTodayVisits` の入力／出力件数と `getDashboardData` に渡されるスコープを可視化して、どの visits 配列が参照されているかを確定する狙いです。
- ロジック変更やリファクタは行わず、実行経路の特定に必要な最小限のログ出力にとどめています。

### Description
- `src/dashboard/api/getDashboardData.js` に `buildOverviewFromTreatmentProgress_` 呼び出し直前の `[VISIT CALLER]` ログを追加し、`scopedVisits.length` と `matchedLogsCount` を出力するようにしました。
- 同ファイルの `buildOverviewFromTreatmentProgress_` 冒頭に `[VISIT ENTRY]` ログを追加し、呼び出し有無・`visits` の型・長さ・先頭3件サンプルを出力するようにしました。
- `src/dashboard/api/getTodayVisits.js` に `[TODAY VISITS ENTRY]` を冒頭へ、返却直前に `[TODAY VISITS RETURN]` を追加して、ソースログ数・visible スコープ・返却件数を出力するようにしました。
- すべてログ出力のみの追加で、既存ロジック・戻り値の挙動は変更していません。

### Testing
- ローカルのターゲットテストを実行して動作確認を行いました: `node tests/dashboardTodayVisits.test.js` と `node tests/dashboardGetDashboardData.test.js` が成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994fa8e0878832188d95144b3414aeb)