### PR TITLE
Migrate todayVisits to timeline format ({today, previous}), remove legacy visits array and update UI/tests

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -39,6 +39,9 @@
   .section-header{ display:flex; align-items:center; gap:10px; }
   .small{ font-size:0.82rem; color:var(--muted); }
   .timeline{ display:flex; flex-direction:column; gap:10px; }
+  .timeline-section{ display:flex; flex-direction:column; gap:8px; }
+  .timeline-section-header{ display:flex; align-items:center; justify-content:space-between; gap:8px; }
+  .timeline-section-title{ font-size:0.92rem; font-weight:700; color:#fff; }
   .visit{ display:grid; grid-template-columns:70px 1fr; gap:10px; align-items:center; padding:10px 12px; border-radius:12px; border:1px solid var(--border); background:var(--panel); }
   .visit-time{ font-variant-numeric:tabular-nums; color:#fff; font-weight:700; }
   .visit-body{ display:flex; flex-direction:column; gap:4px; }
@@ -207,7 +210,7 @@ function fetchDashboardData() {
     setLoading(false);
     const summary = {
       tasks: Array.isArray(data && data.tasks) ? data.tasks.length : 0,
-      visits: Array.isArray(data && data.todayVisits) ? data.todayVisits.length : 0,
+      visits: countTimelineVisits_(data && data.todayVisits),
       patients: Array.isArray(data && data.patients) ? data.patients.length : 0,
       unpaidAlerts: Array.isArray(data && data.unpaidAlerts) ? data.unpaidAlerts.length : 0,
       warnings: Array.isArray(data && data.warnings) ? data.warnings.length : 0,
@@ -500,15 +503,36 @@ function renderVisits() {
   if (!list) return;
   list.innerHTML = '';
 
-  const visits = dashboardState.data && Array.isArray(dashboardState.data.todayVisits)
-    ? dashboardState.data.todayVisits
-    : [];
+  const timeline = normalizeTimelineVisits_(dashboardState.data && dashboardState.data.todayVisits);
+  renderTimelineSection(list, '当日', timeline.today);
+  renderTimelineSection(list, '前日', timeline.previous);
+}
+
+function renderTimelineSection(container, label, sectionData) {
+  const section = document.createElement('section');
+  section.className = 'timeline-section';
+
+  const header = document.createElement('div');
+  header.className = 'timeline-section-header';
+  const title = document.createElement('div');
+  title.className = 'timeline-section-title';
+  title.textContent = `${label}（${formatTimelineDateLabel_(sectionData && sectionData.date)}）`;
+  header.appendChild(title);
+
+  const visits = sectionData && Array.isArray(sectionData.visits) ? sectionData.visits : [];
+  const count = document.createElement('span');
+  count.className = 'small';
+  count.textContent = `${visits.length}件`;
+  header.appendChild(count);
+
+  section.appendChild(header);
 
   if (!visits.length) {
     const empty = document.createElement('div');
     empty.className = 'muted';
-    empty.textContent = '訪問データはありません';
-    list.appendChild(empty);
+    empty.textContent = '0件';
+    section.appendChild(empty);
+    container.appendChild(section);
     return;
   }
 
@@ -549,10 +573,44 @@ function renderVisits() {
     body.appendChild(meta);
     row.appendChild(body);
 
-    list.appendChild(row);
+    section.appendChild(row);
   });
+
+  container.appendChild(section);
 }
 
+function normalizeTimelineVisits_(timeline) {
+  if (!timeline || typeof timeline !== 'object') {
+    return {
+      today: { date: null, visits: [] },
+      previous: { date: null, visits: [] }
+    };
+  }
+  const today = timeline.today && typeof timeline.today === 'object' ? timeline.today : { date: null, visits: [] };
+  const previous = timeline.previous && typeof timeline.previous === 'object' ? timeline.previous : { date: null, visits: [] };
+  return {
+    today: {
+      date: today.date || null,
+      visits: Array.isArray(today.visits) ? today.visits : []
+    },
+    previous: {
+      date: previous.date || null,
+      visits: Array.isArray(previous.visits) ? previous.visits : []
+    }
+  };
+}
+
+function countTimelineVisits_(timeline) {
+  const normalized = normalizeTimelineVisits_(timeline);
+  return normalized.today.visits.length + normalized.previous.visits.length;
+}
+
+function formatTimelineDateLabel_(dateKey) {
+  const key = String(dateKey || '').trim();
+  const match = key.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return '-';
+  return `${match[2]}/${match[3]}`;
+}
 
 function formatVisitPatientLabel_(visit) {
   const patientName = String(visit && visit.patientName ? visit.patientName : '').trim();

--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -2,7 +2,7 @@
  * ダッシュボードの主要データをまとめて取得し、JSON 形式で返す。
  * エラーが発生した場合は meta.error にメッセージを格納する。
  * @param {Object} [options]
- * @return {{tasks: Object[], todayVisits: Object[], patients: Object[], warnings: string[], meta: Object}}
+ * @return {{tasks: Object[], todayVisits: {today: {date: string, visits: Object[]}, previous: {date: (string|null), visits: Object[]}}, patients: Object[], warnings: string[], meta: Object}}
  */
 function getDashboardData(options) {
   const mock = options && options.mock;
@@ -298,23 +298,46 @@ function getDashboardData(options) {
       notes,
       visiblePatientIds,
       now: opts.now
-    }) : { visits: [], warnings: [] })));
+    }) : {
+      today: { date: dashboardFormatDate_(dashboardCoerceDate_(opts.now) || new Date(), dashboardResolveTimeZone_(), 'yyyy-MM-dd'), visits: [] },
+      previous: { date: null, visits: [] },
+      warnings: []
+    })));
 
-    const rawVisits = visitsResult && Array.isArray(visitsResult.visits) ? visitsResult.visits : [];
-    const scopedVisits = visiblePatientIds
-      ? rawVisits.filter(visit => {
+    const timelineTodayKeyRaw = dashboardFormatDate_(dashboardCoerceDate_(opts.now) || new Date(), dashboardResolveTimeZone_(), 'yyyy-MM-dd');
+    const timelineTodayKey = String(timelineTodayKeyRaw || '').slice(0, 10);
+    const rawTodayVisits = visitsResult && visitsResult.today && Array.isArray(visitsResult.today.visits)
+      ? visitsResult.today.visits
+      : [];
+    const rawPreviousVisits = visitsResult && visitsResult.previous && Array.isArray(visitsResult.previous.visits)
+      ? visitsResult.previous.visits
+      : [];
+    const scopeVisits = visits => (visiblePatientIds
+      ? visits.filter(visit => {
         const patientId = dashboardNormalizePatientId_(visit && visit.patientId);
         return !!patientId && visiblePatientIds.has(patientId);
       })
-      : rawVisits;
+      : visits);
+    const scopedVisits = {
+      today: {
+        date: visitsResult && visitsResult.today
+          ? visitsResult.today.date
+          : timelineTodayKey,
+        visits: scopeVisits(rawTodayVisits)
+      },
+      previous: {
+        date: visitsResult && visitsResult.previous ? visitsResult.previous.date : null,
+        visits: scopeVisits(rawPreviousVisits)
+      }
+    };
 
     if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
       Logger.log('[VISIT CALLER] about to call buildOverviewFromTreatmentProgress_');
-      Logger.log('[VISIT CALLER] scopedVisits length=' + scopedVisits.length);
+      Logger.log('[VISIT CALLER] scopedVisits today=' + scopedVisits.today.visits.length + ' previous=' + scopedVisits.previous.visits.length);
       Logger.log('[VISIT CALLER] matchedLogsCount=' + matchedLogsCount);
     }
 
-    logContext('getDashboardData:getTodayVisits', `visits=${rawVisits.length} scopedVisits=${scopedVisits.length} warnings=${(visitsResult && visitsResult.warnings ? visitsResult.warnings.length : 0)} setupIncomplete=${!!(visitsResult && visitsResult.setupIncomplete)}`);
+    logContext('getDashboardData:getTodayVisits', `todayVisits=${rawTodayVisits.length} previousVisits=${rawPreviousVisits.length} scopedToday=${scopedVisits.today.visits.length} scopedPrevious=${scopedVisits.previous.visits.length} warnings=${(visitsResult && visitsResult.warnings ? visitsResult.warnings.length : 0)} setupIncomplete=${!!(visitsResult && visitsResult.setupIncomplete)}`);
     const patients = measureStep('buildPatients', () => buildDashboardPatients_(patientInfo, {
       notes,
       aiReports,
@@ -398,7 +421,7 @@ function getDashboardData(options) {
         metaError: meta.error
       });
     }
-    const result = { tasks: [], todayVisits: [], patients: [], unpaidAlerts: [], warnings: [], overview: null, meta };
+    const result = { tasks: [], todayVisits: { today: { date: null, visits: [] }, previous: { date: null, visits: [] } }, patients: [], unpaidAlerts: [], warnings: [], overview: null, meta };
     logSerializationDiagnostics(result);
     const sanitizedResult = sanitizeDashboardResponse_(result);
     logSerializationDiagnostics(sanitizedResult);
@@ -461,7 +484,13 @@ function sanitizeDashboardResponse_(result) {
   const normalized = result && typeof result === 'object' ? result : {};
   sanitizeDashboardValue_(normalized, new WeakSet(), '$');
   if (!Array.isArray(normalized.tasks)) normalized.tasks = [];
-  if (!Array.isArray(normalized.todayVisits)) normalized.todayVisits = [];
+  if (!normalized.todayVisits || typeof normalized.todayVisits !== 'object' || Array.isArray(normalized.todayVisits)) {
+    normalized.todayVisits = { today: { date: null, visits: [] }, previous: { date: null, visits: [] } };
+  }
+  if (!normalized.todayVisits.today || typeof normalized.todayVisits.today !== 'object') normalized.todayVisits.today = { date: null, visits: [] };
+  if (!normalized.todayVisits.previous || typeof normalized.todayVisits.previous !== 'object') normalized.todayVisits.previous = { date: null, visits: [] };
+  if (!Array.isArray(normalized.todayVisits.today.visits)) normalized.todayVisits.today.visits = [];
+  if (!Array.isArray(normalized.todayVisits.previous.visits)) normalized.todayVisits.previous.visits = [];
   if (!Array.isArray(normalized.patients)) normalized.patients = [];
   if (!Array.isArray(normalized.unpaidAlerts)) normalized.unpaidAlerts = [];
   if (!Array.isArray(normalized.warnings)) normalized.warnings = [];

--- a/src/dashboard/api/getTodayVisits.js
+++ b/src/dashboard/api/getTodayVisits.js
@@ -6,7 +6,7 @@
  * @param {Object} [options.notes] - loadNotes() の戻り値を差し替える際に利用。
  * @param {Date} [options.now] - テスト用に現在日時を差し替え。
  * @param {Set<string>} [options.visiblePatientIds] - 表示対象患者ID。null の場合は全件。
- * @return {{visits: Object[], warnings: string[]}}
+ * @return {{today: {date: string, visits: Object[]}, previous: {date: (string|null), visits: Object[]}, warnings: string[]}}
  */
 function getTodayVisits(options) {
   const opts = options || {};
@@ -37,7 +37,8 @@ function getTodayVisits(options) {
     dashboardWarn_(`[getTodayVisits:setupIncomplete] treatmentLogs=${!!(treatment && treatment.setupIncomplete)} notes=${!!(notesResult && notesResult.setupIncomplete)}`);
   }
 
-  const normalizedVisits = [];
+  const visitsByDate = {};
+  let previousKey = '';
   logs.forEach(entry => {
     if (!entry || !entry.timestamp) return;
     const ts = dashboardCoerceDate_(entry.timestamp);
@@ -55,27 +56,42 @@ function getTodayVisits(options) {
     if (!patientId) return;
     if (visiblePatientIds && !visiblePatientIds.has(patientId)) return;
 
-    normalizedVisits.push({ patientId, patientName, time, dateKey, noteStatus });
+    if (!Object.prototype.hasOwnProperty.call(visitsByDate, dateKey)) visitsByDate[dateKey] = [];
+    visitsByDate[dateKey].push({ patientId, patientName, time, dateKey, noteStatus });
+
+    if (dateKey < todayKey && (!previousKey || dateKey > previousKey)) previousKey = dateKey;
   });
 
-  const latestPastDayKey = normalizedVisits
-    .filter(visit => visit.dateKey < todayKey)
-    .map(visit => visit.dateKey)
-    .sort((a, b) => b.localeCompare(a))[0] || '';
+  const todayVisits = Object.prototype.hasOwnProperty.call(visitsByDate, todayKey)
+    ? visitsByDate[todayKey]
+    : [];
+  const previousVisits = previousKey && Object.prototype.hasOwnProperty.call(visitsByDate, previousKey)
+    ? visitsByDate[previousKey]
+    : [];
+  const sortByTime = (a, b) => a.time.localeCompare(b.time);
+  todayVisits.sort(sortByTime);
+  previousVisits.sort(sortByTime);
 
-  const visits = normalizedVisits.filter(visit => visit.dateKey === todayKey || (latestPastDayKey && visit.dateKey === latestPastDayKey));
-
-  visits.sort((a, b) => {
-    if (a.dateKey === b.dateKey) return a.time.localeCompare(b.time);
-    return a.dateKey.localeCompare(b.dateKey);
-  });
-
-  const result = visits;
+  const result = {
+    today: {
+      date: todayKey,
+      visits: todayVisits
+    },
+    previous: {
+      date: previousKey || null,
+      visits: previousVisits
+    }
+  };
   if (typeof Logger !== 'undefined' && Logger && typeof Logger.log === 'function') {
-    Logger.log('[TODAY VISITS RETURN] result length=' + result.length);
+    Logger.log('[TODAY VISITS RETURN] today=' + result.today.visits.length + ' previous=' + result.previous.visits.length);
   }
 
-  return { visits: result, warnings, setupIncomplete };
+  return {
+    today: result.today,
+    previous: result.previous,
+    warnings,
+    setupIncomplete
+  };
 }
 
 

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -67,7 +67,11 @@ function testAggregatesDashboardData() {
   const treatmentLogs = { logs: [{ patientId: '001', timestamp: new Date('2025-02-01T09:00:00Z'), dateKey: '2025-02-01', createdByEmail: 'user@example.com', staffKeys: { email: 'user@example.com', name: '', staffId: '' } }], warnings: ['t1'] };
   const responsible = { responsible: { '001': 'staff@example.com' }, warnings: ['r1'] };
   const tasksResult = { tasks: [{ type: 'consentWarning', patientId: '001' }], warnings: ['task'] };
-  const visitsResult = { visits: [{ patientId: '001', dateKey: '2025-02-01', time: '10:00' }], warnings: ['visit'] };
+  const visitsResult = {
+    today: { date: '2025-02-01', visits: [{ patientId: '001', dateKey: '2025-02-01', time: '10:00' }] },
+    previous: { date: null, visits: [] },
+    warnings: ['visit']
+  };
   const unpaidAlerts = { alerts: [{ patientId: '001', patientName: '山田太郎', consecutiveMonths: 3, totalAmount: 15000, months: [], followUp: { phone: false, visit: false } }], warnings: ['u1'] };
 
   const ctx = createContext();
@@ -89,7 +93,10 @@ function testAggregatesDashboardData() {
   assert.strictEqual(result.meta.user, 'belltree@belltree1102.com');
   assert.ok(result.meta.generatedAt, 'generatedAt should be present');
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result.tasks)), []);
-  assert.deepStrictEqual(result.todayVisits, visitsResult.visits);
+  const timeline = JSON.parse(JSON.stringify(result.todayVisits));
+  assert.strictEqual(String(timeline.today.date).slice(0, 10), '2025-02-01');
+  assert.deepStrictEqual(timeline.today.visits, [{ patientId: '001', dateKey: '2025-02-01', time: '10:00' }]);
+  assert.deepStrictEqual(timeline.previous, { date: null, visits: [] });
   assert.strictEqual(result.patients.length, 1);
   const normalizedPatient = JSON.parse(JSON.stringify(result.patients[0]));
   assert.deepStrictEqual(normalizedPatient, {
@@ -155,7 +162,7 @@ function testPatientStatusTagsGeneration() {
     responsible: { responsible: {}, warnings: [] },
     unpaidAlerts: { alerts: [], warnings: [] },
     tasksResult: { tasks: [], warnings: [] },
-    visitsResult: { visits: [], warnings: [] }
+    visitsResult: { today: { date: null, visits: [] }, previous: { date: null, visits: [] }, warnings: [] }
   });
 
   const patientsById = {};
@@ -218,7 +225,7 @@ function testConsentOverviewMatchesPatientStatusTags() {
       ],
       warnings: []
     },
-    visitsResult: { visits: [], warnings: [] }
+    visitsResult: { today: { date: null, visits: [] }, previous: { date: null, visits: [] }, warnings: [] }
   });
 
   const overviewItems = JSON.parse(JSON.stringify(result.overview.consentRelated.items));
@@ -280,7 +287,7 @@ function testConsentOver30DaysStillShowsReportTag() {
     responsible: { responsible: {}, warnings: [] },
     unpaidAlerts: { alerts: [], warnings: [] },
     tasksResult: { tasks: [], warnings: [] },
-    visitsResult: { visits: [], warnings: [] }
+    visitsResult: { today: { date: null, visits: [] }, previous: { date: null, visits: [] }, warnings: [] }
   });
 
   const tags = JSON.parse(JSON.stringify(result.patients[0].statusTags));
@@ -323,7 +330,7 @@ function testConsentAcquiredJudgmentHandlesFalseyStringsConsistently() {
     responsible: { responsible: {}, warnings: [] },
     unpaidAlerts: { alerts: [], warnings: [] },
     tasksResult: { tasks: [], warnings: [] },
-    visitsResult: { visits: [], warnings: [] }
+    visitsResult: { today: { date: null, visits: [] }, previous: { date: null, visits: [] }, warnings: [] }
   });
 
   const overviewPatientIds = JSON.parse(JSON.stringify(result.overview.consentRelated.items)).map(item => item.patientId);
@@ -425,7 +432,7 @@ function testConsentDateParsingFormatsAndResolverPriority() {
     responsible: { responsible: {}, warnings: [] },
     unpaidAlerts: { alerts: [], warnings: [] },
     tasksResult: { tasks: [], warnings: [] },
-    visitsResult: { visits: [], warnings: [] }
+    visitsResult: { today: { date: null, visits: [] }, previous: { date: null, visits: [] }, warnings: [] }
   });
 
   const overviewIds = JSON.parse(JSON.stringify(result.overview.consentRelated.items)).map(item => item.patientId);
@@ -470,7 +477,7 @@ function testConsentExpiryResolutionRunsOncePerPatient() {
     responsible: { responsible: {}, warnings: [] },
     unpaidAlerts: { alerts: [], warnings: [] },
     tasksResult: { tasks: [], warnings: [] },
-    visitsResult: { visits: [], warnings: [] }
+    visitsResult: { today: { date: null, visits: [] }, previous: { date: null, visits: [] }, warnings: [] }
   });
 
   assert.strictEqual(result.patients.length, 3);
@@ -519,7 +526,7 @@ function testStaffConsentScopeMetricsAreLogged() {
     },
     responsible: { responsible: {}, warnings: [] },
     unpaidAlerts: { alerts: [], warnings: [] },
-    visitsResult: { visits: [], warnings: [] }
+    visitsResult: { today: { date: null, visits: [] }, previous: { date: null, visits: [] }, warnings: [] }
   });
 
   assert.strictEqual(result.meta.error, undefined);
@@ -571,7 +578,7 @@ function testStaffConsentEligibilityEvaluatesOnlyVisiblePatients() {
     },
     responsible: { responsible: {}, warnings: [] },
     unpaidAlerts: { alerts: [], warnings: [] },
-    visitsResult: { visits: [], warnings: [] }
+    visitsResult: { today: { date: null, visits: [] }, previous: { date: null, visits: [] }, warnings: [] }
   });
 
   assert.strictEqual(result.meta.error, undefined);
@@ -695,11 +702,19 @@ function testVisitSummaryUsesStaffFilteredLogsNotScopedVisits() {
     unpaidAlerts: { alerts: [], warnings: [] },
     tasksResult: { tasks: [], warnings: [] },
     visitsResult: {
-      visits: [
-        { patientId: '001', dateKey: '2025-02-01', time: '09:00' },
-        { patientId: '001', dateKey: '2025-01-31', time: '09:00' },
-        { patientId: '002', dateKey: '2025-01-29', time: '09:00' }
-      ],
+      today: {
+        date: '2025-02-01',
+        visits: [
+          { patientId: '001', dateKey: '2025-02-01', time: '09:00' }
+        ]
+      },
+      previous: {
+        date: '2025-01-31',
+        visits: [
+          { patientId: '001', dateKey: '2025-01-31', time: '09:00' },
+          { patientId: '002', dateKey: '2025-01-31', time: '10:00' }
+        ]
+      },
       warnings: []
     }
   };
@@ -720,10 +735,16 @@ function testVisitSummaryUsesStaffFilteredLogsNotScopedVisits() {
     previous2: { date: '2025-01-30', count: 1 }
   }, 'staff の visitSummary は scopedVisits ではなく staff-filtered treatmentLogs を使う');
 
-  assert.deepStrictEqual(JSON.parse(JSON.stringify(staffResult.todayVisits)), [
-    { patientId: '001', dateKey: '2025-02-01', time: '09:00' },
-    { patientId: '001', dateKey: '2025-01-31', time: '09:00' }
-  ], 'todayVisits は従来どおり visiblePatientIds スコープを使う');
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(staffResult.todayVisits)), {
+    today: {
+      date: '2025-02-01',
+      visits: [{ patientId: '001', dateKey: '2025-02-01', time: '09:00' }]
+    },
+    previous: {
+      date: '2025-01-31',
+      visits: [{ patientId: '001', dateKey: '2025-01-31', time: '09:00' }]
+    }
+  }, 'todayVisits は従来どおり visiblePatientIds スコープを使う');
 }
 
 function testVisitSummaryWorksWhenVisiblePatientIdsBecomesEmpty() {
@@ -752,10 +773,13 @@ function testVisitSummaryWorksWhenVisiblePatientIdsBecomesEmpty() {
     responsible: { responsible: {}, warnings: [] },
     unpaidAlerts: { alerts: [], warnings: [] },
     tasksResult: { tasks: [], warnings: [] },
-    visitsResult: { visits: [], warnings: [] }
+    visitsResult: { today: { date: null, visits: [] }, previous: { date: null, visits: [] }, warnings: [] }
   });
 
-  assert.deepStrictEqual(JSON.parse(JSON.stringify(result.todayVisits)), [], 'visiblePatientIds が空なら todayVisits は空のまま');
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(result.todayVisits)), {
+    today: { date: null, visits: [] },
+    previous: { date: null, visits: [] }
+  }, 'visiblePatientIds が空なら todayVisits は空のまま');
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result.overview.visitSummary)), {
     today: { date: '2025-02-01', count: 0 },
     previous: null,
@@ -790,7 +814,7 @@ function testVisitSummaryStaffScopeLookbackIsFixedTo50Days() {
     responsible: { responsible: {}, warnings: [] },
     unpaidAlerts: { alerts: [], warnings: [] },
     tasksResult: { tasks: [], warnings: [] },
-    visitsResult: { visits: [], warnings: [] }
+    visitsResult: { today: { date: null, visits: [] }, previous: { date: null, visits: [] }, warnings: [] }
   });
 
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result.overview.visitSummary)), {
@@ -879,7 +903,7 @@ function testInvoiceUnconfirmedIgnoresDisplayTargetFilter() {
     responsible: { responsible: {}, warnings: [] },
     unpaidAlerts: { alerts: [], warnings: [] },
     tasksResult: { tasks: [], warnings: [] },
-    visitsResult: { visits: [], warnings: [] }
+    visitsResult: { today: { date: null, visits: [] }, previous: { date: null, visits: [] }, warnings: [] }
   });
 
   assert.strictEqual(result.overview.invoiceUnconfirmed.items.length, 1, 'displayTarget が空でも①請求の対象を保持する');
@@ -922,7 +946,7 @@ function testInvoiceUnconfirmedShouldDetectPatientWithOnlyPreviousMonthTreatment
     responsible: { responsible: {}, warnings: [] },
     unpaidAlerts: { alerts: [], warnings: [] },
     tasksResult: { tasks: [], warnings: [] },
-    visitsResult: { visits: [], warnings: [] }
+    visitsResult: { today: { date: null, visits: [] }, previous: { date: null, visits: [] }, warnings: [] }
   });
 
   assert.strictEqual(result.overview.invoiceUnconfirmed.items.length, 1, '前月のみ施術ログがある患者を未確認として検出する');
@@ -969,7 +993,7 @@ function testInvoiceUnconfirmedExcludesMedicalAssistancePatient() {
     responsible: { responsible: {}, warnings: [] },
     unpaidAlerts: { alerts: [], warnings: [] },
     tasksResult: { tasks: [], warnings: [] },
-    visitsResult: { visits: [], warnings: [] }
+    visitsResult: { today: { date: null, visits: [] }, previous: { date: null, visits: [] }, warnings: [] }
   });
 
   assert.strictEqual(result.overview.invoiceUnconfirmed.items.length, 0, '医療助成患者は請求未確認対象から除外する');
@@ -993,12 +1017,16 @@ function testVisibleScopeForAdminShowsAllPatients() {
         .map(pid => ({ patientId: pid, type: 'consentWarning' })),
       warnings: []
     }),
-    getTodayVisits: opts => ({
-      visits: ['001', '002']
+    getTodayVisits: opts => {
+      const scoped = ['001', '002']
         .filter(pid => !opts.visiblePatientIds || opts.visiblePatientIds.has(pid))
-        .map(pid => ({ patientId: pid, dateKey: '2025-02-10', time: '09:00' })),
-      warnings: []
-    }),
+        .map(pid => ({ patientId: pid, dateKey: '2025-02-10', time: '09:00' }));
+      return {
+        today: { date: '2025-02-10', visits: scoped },
+        previous: { date: null, visits: [] },
+        warnings: []
+      };
+    },
     loadUnpaidAlerts: opts => ({
       alerts: ['001', '002']
         .filter(pid => !opts.visiblePatientIds || opts.visiblePatientIds.has(pid))
@@ -1030,7 +1058,7 @@ function testVisibleScopeForAdminShowsAllPatients() {
 
   assert.strictEqual(result.patients.length, 2, '管理者は全患者表示する');
   assert.strictEqual(result.tasks.length, 0, '上段3ブロックは tasks 非依存とする');
-  assert.strictEqual(result.todayVisits.length, 2, '管理者は訪問全件表示する');
+  assert.strictEqual(result.todayVisits.today.visits.length + result.todayVisits.previous.visits.length, 2, '管理者は訪問全件表示する');
   assert.strictEqual(result.unpaidAlerts.length, 2, '管理者は未回収アラート全件表示する');
   assert.strictEqual(result.overview.invoiceUnconfirmed.items.length, 2, '管理者は請求未確認を全患者分表示する');
   const roleLog = logEntries.find(entry => entry.label === 'getDashboardData:role');
@@ -1065,12 +1093,16 @@ function testVisibleScopeForStaffShowsResponsiblePatientsOnly() {
         .map(pid => ({ patientId: pid, type: 'consentWarning' })),
       warnings: []
     }),
-    getTodayVisits: opts => ({
-      visits: ['001', '002']
+    getTodayVisits: opts => {
+      const scoped = ['001', '002']
         .filter(pid => !opts.visiblePatientIds || opts.visiblePatientIds.has(pid))
-        .map(pid => ({ patientId: pid, dateKey: '2025-02-10', time: '09:00' })),
-      warnings: []
-    }),
+        .map(pid => ({ patientId: pid, dateKey: '2025-02-10', time: '09:00' }));
+      return {
+        today: { date: '2025-02-10', visits: scoped },
+        previous: { date: null, visits: [] },
+        warnings: []
+      };
+    },
     loadUnpaidAlerts: opts => ({
       alerts: ['001', '002']
         .filter(pid => !opts.visiblePatientIds || opts.visiblePatientIds.has(pid))
@@ -1102,7 +1134,8 @@ function testVisibleScopeForStaffShowsResponsiblePatientsOnly() {
 
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result.patients.map(p => p.patientId))), ['001'], 'スタッフは施術ログ一致かつ直近50日患者のみ表示する');
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result.tasks.map(t => t.patientId))), []);
-  assert.deepStrictEqual(JSON.parse(JSON.stringify(result.todayVisits.map(v => v.patientId))), ['001']);
+  const timelinePatientIds = result.todayVisits.today.visits.concat(result.todayVisits.previous.visits).map(v => v.patientId);
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(timelinePatientIds)), ['001']);
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result.unpaidAlerts.map(a => a.patientId))), ['001']);
   assert.deepStrictEqual(JSON.parse(JSON.stringify(result.overview.invoiceUnconfirmed.items.map(item => item.patientId))), ['001'], 'スタッフは請求未確認も担当患者のみ表示する');
   const roleLog = logEntries.find(entry => entry.label === 'getDashboardData:role');
@@ -1123,7 +1156,14 @@ function testVisibleScopeForStaffShowsResponsiblePatientsOnly() {
 function testVisibleScopeForStaffWithoutResponsibleAssignmentShowsNoPatients() {
   const ctx = createContext({
     getTasks: opts => ({ tasks: opts.visiblePatientIds && opts.visiblePatientIds.size ? [{ patientId: '001' }] : [], warnings: [] }),
-    getTodayVisits: opts => ({ visits: opts.visiblePatientIds && opts.visiblePatientIds.size ? [{ patientId: '001', dateKey: '2025-02-10', time: '09:00' }] : [], warnings: [] }),
+    getTodayVisits: opts => ({
+      today: {
+        date: '2025-02-10',
+        visits: opts.visiblePatientIds && opts.visiblePatientIds.size ? [{ patientId: '001', dateKey: '2025-02-10', time: '09:00' }] : []
+      },
+      previous: { date: null, visits: [] },
+      warnings: []
+    }),
     loadUnpaidAlerts: opts => ({ alerts: opts.visiblePatientIds && opts.visiblePatientIds.size ? [{ patientId: '001', patientName: '患者A' }] : [], warnings: [] })
   });
 
@@ -1145,7 +1185,7 @@ function testVisibleScopeForStaffWithoutResponsibleAssignmentShowsNoPatients() {
 
   assert.strictEqual(result.patients.length, 0, '直近50日内の施術ログ一致がなければ患者表示0件');
   assert.strictEqual(result.tasks.length, 0);
-  assert.strictEqual(result.todayVisits.length, 0);
+  assert.strictEqual(result.todayVisits.today.visits.length + result.todayVisits.previous.visits.length, 0);
   assert.strictEqual(result.unpaidAlerts.length, 0);
 }
 
@@ -1156,7 +1196,7 @@ function testErrorIsCapturedInMeta() {
 
   const result = ctx.getDashboardData();
   assert.strictEqual(result.tasks.length, 0);
-  assert.strictEqual(result.todayVisits.length, 0);
+  assert.strictEqual(result.todayVisits.today.visits.length + result.todayVisits.previous.visits.length, 0);
   assert.strictEqual(result.patients.length, 0);
   assert.ok(result.meta.error && result.meta.error.indexOf('boom') >= 0);
 }
@@ -1194,7 +1234,7 @@ function testSpreadsheetIsOpenedOnceAndPerfCheckIsLogged() {
       return { alerts: [], warnings: [] };
     },
     getTasks: () => ({ tasks: [], warnings: [] }),
-    getTodayVisits: () => ({ visits: [], warnings: [] })
+    getTodayVisits: () => ({ today: { date: null, visits: [] }, previous: { date: null, visits: [] }, warnings: [] })
   });
 
   ctx.dashboardGetSpreadsheet_ = () => { openCount += 1; return workbook; };
@@ -1216,7 +1256,7 @@ function testWarningsAreDedupedAndSetupFlagged() {
     treatmentLogs: { logs: [], warnings: [] },
     responsible: { responsible: {}, warnings: [] },
     tasksResult: { tasks: [], warnings: [] },
-    visitsResult: { visits: [], warnings: [] }
+    visitsResult: { today: { date: null, visits: [] }, previous: { date: null, visits: [] }, warnings: [] }
   });
 
   assert.strictEqual(result.warnings.length, 1, '同一警告は一意になる');
@@ -1249,7 +1289,7 @@ function testConsentExpiredOver30DaysAlertsAreRoleFiltered() {
     },
     responsible: { responsible: {}, warnings: [] },
     unpaidAlerts: { alerts: [], warnings: [] },
-    visitsResult: { visits: [], warnings: [] }
+    visitsResult: { today: { date: null, visits: [] }, previous: { date: null, visits: [] }, warnings: [] }
   };
 
   const calcExpiry = value => {

--- a/tests/dashboardTodayVisits.test.js
+++ b/tests/dashboardTodayVisits.test.js
@@ -73,9 +73,7 @@ function createUiContext() {
   const dashboardScript = scriptMatch[1]
     .replace(/const DASHBOARD_TREATMENT_APP_EXEC_URL =[^\n]*\n/, 'var DASHBOARD_TREATMENT_APP_EXEC_URL = "";\n');
 
-  const elements = {
-    visitList: createElement('div')
-  };
+  const elements = { visitList: createElement('div') };
   elements.visitList.innerHTML = '';
 
   const documentStub = {
@@ -103,175 +101,113 @@ function runVisits(context, now, logs, patientInfo, extraOptions) {
     treatmentLogs: { logs, warnings: [] },
     notes: { notes: {}, warnings: [] },
     visiblePatientIds: options.visiblePatientIds || null
-  }).visits;
+  });
 }
 
-(function testVisiblePatientIdsNullShowsAllVisits() {
+(function testTodayAndPreviousBothExist() {
   const context = createApiContext();
-  const visits = runVisits(
+  const result = runVisits(
     context,
     '2025-02-13T10:00:00Z',
     [
       { timestamp: new Date('2025-02-13T09:00:00Z'), dateKey: '2025-02-13', patientId: 'P001' },
-      { timestamp: new Date('2025-02-10T12:00:00Z'), dateKey: '2025-02-10', patientId: 'P002' }
+      { timestamp: new Date('2025-02-12T12:00:00Z'), dateKey: '2025-02-12', patientId: 'P002' },
+      { timestamp: new Date('2025-02-11T12:00:00Z'), dateKey: '2025-02-11', patientId: 'P003' }
+    ],
+    { P001: { name: '患者A' }, P002: { name: '患者B' }, P003: { name: '患者C' } }
+  );
+
+  assert.strictEqual(result.today.date, '2025-02-13');
+  assert.strictEqual(result.today.visits.length, 1);
+  assert.strictEqual(result.previous.date, '2025-02-12');
+  assert.strictEqual(result.previous.visits.length, 1);
+})();
+
+(function testNoTodayButPreviousExists() {
+  const context = createApiContext();
+  const result = runVisits(
+    context,
+    '2025-02-13T10:00:00Z',
+    [
+      { timestamp: new Date('2025-02-12T09:00:00Z'), dateKey: '2025-02-12', patientId: 'P001' },
+      { timestamp: new Date('2025-02-10T09:00:00Z'), dateKey: '2025-02-10', patientId: 'P002' }
     ],
     { P001: { name: '患者A' }, P002: { name: '患者B' } }
   );
 
-  assert.strictEqual(visits.length, 2, 'visiblePatientIds=null では全件表示する');
+  assert.strictEqual(result.today.visits.length, 0);
+  assert.strictEqual(result.previous.date, '2025-02-12');
+  assert.strictEqual(result.previous.visits.length, 1);
 })();
 
-(function testVisiblePatientIdsShowsOnlyTargetPatients() {
+(function testTodayExistsButNoPrevious() {
   const context = createApiContext();
-  const visits = runVisits(
+  const result = runVisits(
+    context,
+    '2025-02-13T10:00:00Z',
+    [{ timestamp: new Date('2025-02-13T09:00:00Z'), dateKey: '2025-02-13', patientId: 'P001' }],
+    { P001: { name: '患者A' } }
+  );
+
+  assert.strictEqual(result.today.visits.length, 1);
+  assert.strictEqual(result.previous.date, null);
+  assert.strictEqual(result.previous.visits.length, 0);
+})();
+
+(function testBothTodayAndPreviousAreEmpty() {
+  const context = createApiContext();
+  const result = runVisits(context, '2025-02-13T10:00:00Z', [], {});
+
+  assert.strictEqual(result.today.date, '2025-02-13');
+  assert.strictEqual(result.today.visits.length, 0);
+  assert.strictEqual(result.previous.date, null);
+  assert.strictEqual(result.previous.visits.length, 0);
+})();
+
+(function testStaffScopeDifferenceViaVisiblePatientIds() {
+  const context = createApiContext();
+  const adminLike = runVisits(
     context,
     '2025-02-13T10:00:00Z',
     [
       { timestamp: new Date('2025-02-13T09:00:00Z'), dateKey: '2025-02-13', patientId: 'P001' },
       { timestamp: new Date('2025-02-13T10:00:00Z'), dateKey: '2025-02-13', patientId: 'P002' },
-      { timestamp: new Date('2025-02-10T12:00:00Z'), dateKey: '2025-02-10', patientId: 'P003' }
+      { timestamp: new Date('2025-02-12T09:00:00Z'), dateKey: '2025-02-12', patientId: 'P003' }
+    ],
+    { P001: { name: '患者A' }, P002: { name: '患者B' }, P003: { name: '患者C' } },
+    { visiblePatientIds: null }
+  );
+  const staffLike = runVisits(
+    context,
+    '2025-02-13T10:00:00Z',
+    [
+      { timestamp: new Date('2025-02-13T09:00:00Z'), dateKey: '2025-02-13', patientId: 'P001' },
+      { timestamp: new Date('2025-02-13T10:00:00Z'), dateKey: '2025-02-13', patientId: 'P002' },
+      { timestamp: new Date('2025-02-12T09:00:00Z'), dateKey: '2025-02-12', patientId: 'P003' }
     ],
     { P001: { name: '患者A' }, P002: { name: '患者B' }, P003: { name: '患者C' } },
     { visiblePatientIds: new Set(['P001']) }
   );
 
-  assert.strictEqual(visits.length, 1, '可視患者のみ表示する');
-  assert.strictEqual(visits[0].patientId, 'P001');
+  assert.strictEqual(adminLike.today.visits.length, 2);
+  assert.strictEqual(staffLike.today.visits.length, 1);
+  assert.strictEqual(staffLike.today.visits[0].patientId, 'P001');
 })();
 
-(function testVisiblePatientIdsCanResultInZeroVisits() {
-  const context = createApiContext();
-  const visits = runVisits(
-    context,
-    '2025-02-13T10:00:00Z',
-    [
-      { timestamp: new Date('2025-02-13T09:00:00Z'), dateKey: '2025-02-13', patientId: 'P001' },
-      { timestamp: new Date('2024-12-20T09:00:00Z'), dateKey: '2024-12-20', patientId: 'P001' }
-    ],
-    { P001: { name: '患者A' } },
-    { visiblePatientIds: new Set() }
-  );
-
-  assert.strictEqual(visits.length, 0, '可視患者が空なら表示0件になる');
-})();
-
-(function testVisiblePatientFilterKeepsTodayAndLatestPastDayLogic() {
-  const context = createApiContext();
-  const visits = runVisits(
-    context,
-    '2025-02-13T10:00:00Z',
-    [
-      { timestamp: new Date('2025-02-13T09:00:00Z'), dateKey: '2025-02-13', patientId: 'P001' },
-      { timestamp: new Date('2025-02-10T12:00:00Z'), dateKey: '2025-02-10', patientId: 'P001' },
-      { timestamp: new Date('2025-02-07T12:00:00Z'), dateKey: '2025-02-07', patientId: 'P001' }
-    ],
-    { P001: { name: '患者A' } },
-    { visiblePatientIds: new Set(['P001']) }
-  );
-
-  const keys = JSON.parse(JSON.stringify(visits.map(v => v.dateKey)));
-  assert.deepStrictEqual(keys, ['2025-02-10', '2025-02-13'], '可視患者フィルタ適用後も今日+最新過去1日のロジックを維持する');
-})();
-
-(function testWeekendGapShowsFridayOnMonday() {
-  const context = createApiContext();
-  const visits = runVisits(
-    context,
-    '2025-02-10T10:00:00Z',
-    [
-      { timestamp: new Date('2025-02-10T09:00:00Z'), dateKey: '2025-02-10', patientId: 'P001' },
-      { timestamp: new Date('2025-02-07T16:00:00Z'), dateKey: '2025-02-07', patientId: 'P002' },
-      { timestamp: new Date('2025-02-06T11:00:00Z'), dateKey: '2025-02-06', patientId: 'P003' }
-    ],
-    { P001: { name: '患者A' }, P002: { name: '患者B' } }
-  );
-
-  assert.strictEqual(visits.length, 2, '月曜表示では今日+直近営業日(金曜)のみ表示する');
-  const keys = JSON.parse(JSON.stringify(visits.map(v => v.dateKey)));
-  assert.deepStrictEqual(keys, ['2025-02-07', '2025-02-10']);
-})();
-
-(function testAfterLeavePicksLatestPastDayOnly() {
-  const context = createApiContext();
-  const visits = runVisits(
-    context,
-    '2025-02-13T10:00:00Z',
-    [
-      { timestamp: new Date('2025-02-13T09:00:00Z'), dateKey: '2025-02-13', patientId: 'P001' },
-      { timestamp: new Date('2025-02-10T12:00:00Z'), dateKey: '2025-02-10', patientId: 'P002' },
-      { timestamp: new Date('2025-02-07T12:00:00Z'), dateKey: '2025-02-07', patientId: 'P003' }
-    ],
-    { P001: { name: '患者A' }, P002: { name: '患者B' }, P003: { name: '患者C' } }
-  );
-
-  const keys = JSON.parse(JSON.stringify(visits.map(v => v.dateKey)));
-  assert.deepStrictEqual(keys, ['2025-02-10', '2025-02-13'], '有給明けでも過去は最新1日だけ');
-})();
-
-
-(function testMissingDateKeyIsDerivedFromTimestamp() {
-  const context = createApiContext();
-  const visits = runVisits(
-    context,
-    '2025-02-01T10:00:00Z',
-    [
-      { timestamp: new Date('2025-02-01T09:30:00Z'), patientId: 'P001' },
-      { timestamp: new Date('2025-01-31T23:00:00Z'), patientId: 'P002' }
-    ],
-    { P001: { name: '田中 花子' }, P002: { name: '山田 太郎' } }
-  );
-
-  assert.strictEqual(visits.length, 2, 'dateKey未設定でもtimestampから補完して2日分を返す');
-  const keys = JSON.parse(JSON.stringify(visits.map(v => v.dateKey)));
-  assert.deepStrictEqual(keys, ['2025-01-31', '2025-02-01']);
-})();
-
-(function testTodayOnly() {
-  const context = createApiContext();
-  const visits = runVisits(
-    context,
-    '2025-02-01T10:00:00Z',
-    [
-      { timestamp: new Date('2025-02-01T09:30:00Z'), dateKey: '2025-02-01', patientId: 'P001' }
-    ],
-    { P001: { name: '田中 花子' } }
-  );
-
-  assert.strictEqual(visits.length, 1, '今日のみの場合は今日の訪問のみ返す');
-  assert.strictEqual(visits[0].dateKey, '2025-02-01');
-  assert.strictEqual(visits[0].patientName, '田中 花子', 'patientInfoのnameを引き当てる');
-})();
-
-(function testTodayAndPreviousDay() {
-  const context = createApiContext();
-  const visits = runVisits(
-    context,
-    '2025-02-01T10:00:00Z',
-    [
-      { timestamp: new Date('2025-02-01T09:30:00Z'), dateKey: '2025-02-01', patientId: 'P001' },
-      { timestamp: new Date('2025-01-31T23:00:00Z'), dateKey: '2025-01-31', patientId: 'P002' },
-      { timestamp: new Date('2025-01-30T23:00:00Z'), dateKey: '2025-01-30', patientId: 'P003' }
-    ],
-    { P001: { name: '田中 花子' }, P002: { name: '山田 太郎' } }
-  );
-
-  assert.strictEqual(visits.length, 2, '今日＋前日が存在する場合はその2日を返す');
-  const keys = JSON.parse(JSON.stringify(visits.map(v => v.dateKey)));
-  assert.deepStrictEqual(keys, ['2025-01-31', '2025-02-01']);
-  assert.strictEqual(visits[0].patientName, '山田 太郎', '患者名を表示できる');
-})();
-
-(function testRenderVisitsUsesPatientNameWithPatientId() {
+(function testRenderVisitsAsTodayAndPreviousSections() {
   const { context, elements } = createUiContext();
   vm.runInContext(
-    `dashboardState.data = { todayVisits: [{ time: '09:30', patientId: 'P001', patientName: '田中 花子', noteStatus: '◎' }] };`,
+    `dashboardState.data = { todayVisits: { today: { date: '2025-02-13', visits: [{ time: '09:30', patientId: 'P001', patientName: '田中 花子', noteStatus: '◎' }] }, previous: { date: null, visits: [] } } };`,
     context
   );
 
   context.renderVisits();
 
   const renderedText = flattenText(elements.visitList);
+  assert.ok(renderedText.includes('当日（02/13）'), '当日見出しは MM/DD 形式で描画する');
+  assert.ok(renderedText.includes('前日（-）'), '前日の日付 null は - で描画する');
   assert.ok(renderedText.includes('田中 花子（P001）'), '患者名（患者ID）形式で描画する');
+  assert.ok(renderedText.includes('0件'), '前日0件を表示する');
 })();
 
 console.log('dashboard today visits tests passed');


### PR DESCRIPTION
### Motivation
- 統一されたタイムライン形式（当日 / 前日）で訪問データを扱い、API と表示ロジックを分離して見やすくするため。 
- 旧 `visits` 単一配列の互換パスが残っており混乱や二重走査の原因になっていたため移行を完了するため。 
- フロントエンド表示を新 API 仕様に合わせ、テスト群も新仕様で検証できるようにするため。

### Description
- `getTodayVisits` を単一 `visits` 配列返却から `{ today: { date, visits }, previous: { date|null, visits } }` 返却へ変更し、日付バケット (`visitsByDate`) を使った単一走査で `previousKey` を決定するロジックに最適化した。 
- `getDashboardData` の `visitsResult` 受け取りを新フォーマット前提に変更し、legacy `visits` 配列互換パスを削除して `scopedVisits` の構築を更新した。 
- UI (`src/dashboard.html`) の訪問表示を単一リストからタイムライン2セクション描画へ移行し、`normalizeTimelineVisits_` / `countTimelineVisits_` / `formatTimelineDateLabel_` を追加して `MM/DD` 日付見出し、`null` → `-`、空セクションは `0件` 表示にした。 
- テストを更新して全体を新ペイロード形に合わせ、管理者／スタッフのスコープ差分・visitSummary 整合性を検証するように修正した（テスト内のモック/フィクスチャも新形に揃えた）。

### Testing
- Ran `node tests/dashboardTodayVisits.test.js` and it passed (today/previous extraction, UI rendering stub assertions). 
- Ran `node tests/dashboardGetDashboardData.test.js` and it passed (aggregation, scope filtering and admin/staff behaviour). 
- Ran `node tests/dashboardDoGet.test.js` which still fails in the current harness with `doGet is defined` (unchanged by this PR and unrelated to the todayVisits migration).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699544b5468c83219dc04134fff1af41)