### PR TITLE
Fix consent expiry date display format in dashboard patient list

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -688,7 +688,7 @@ function renderPatients() {
 
     const meta = document.createElement('div');
     meta.className = 'meta-row';
-    if (p.consentExpiry) meta.appendChild(makeBadge('同意期限: ' + p.consentExpiry));
+    meta.appendChild(makeBadge('同意期限: ' + formatDateOnly(p.consentExpiry)));
     if (p.invoiceUrl) meta.appendChild(makeBadge('請求書リンクあり'));
     summary.appendChild(meta);
 
@@ -982,6 +982,16 @@ function formatCurrency(amount) {
   } catch (_err) {
     return `¥${num.toFixed(0)}`;
   }
+}
+
+function formatDateOnly(dateString) {
+  if (!dateString) return '-';
+  const d = new Date(dateString);
+  if (Number.isNaN(d.getTime())) return '-';
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}/${mm}/${dd}`;
 }
 
 function formatDateLabel(key) {


### PR DESCRIPTION
### Motivation
- Prevent raw ISO timestamps from appearing in the dashboard patient list and show a user-friendly `YYYY/MM/DD` or `-` for null/invalid values while keeping backend data shape and existing date logic unchanged.

### Description
- Added a `formatDateOnly(dateString)` helper to `src/dashboard.html` that returns `YYYY/MM/DD` for valid dates and `-` for null/invalid inputs and replaced the consent expiry badge rendering to use `formatDateOnly(p.consentExpiry)`.

### Testing
- Ran the dashboard rendering test with `node tests/dashboardPatientStatusTagsRendering.test.js` which passed. 
- Executed a focused VM check via Node to assert `formatDateOnly('2026-05-30T15:00:00.000Z') === '2026/05/30'`, `formatDateOnly(null) === '-'`, and `formatDateOnly('invalid') === '-'`, which all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69954c446e2c8321afc0a8ef88a1e8f0)