### PR TITLE
同意期限 overview の日付表示を YYYY/MM/DD に統一

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -981,11 +981,15 @@ function buildOverviewFromConsent_(patients, scope, patientNameMap, now, current
     if (!consentStatus) return;
     const expiredDays = consentStatus.type === 'expired' ? Math.abs(consentStatus.days) : 0;
     if (consentStatus.type === 'expired' && expiredDays > 30 && currentUserRole !== 'admin') return;
+    const formattedConsentExpiry = formatDateOnlyInternal_(consentExpiryDate);
     let label = `同意期限（残${consentStatus.days}日）`;
     if (consentStatus.type === 'expired') {
       label = `⚠ 同意期限超過（${Math.abs(consentStatus.days)}日超過）`;
     } else if (consentStatus.type === 'warning') {
       label = `⏳ 同意期限迫る（残${consentStatus.days}日）`;
+    }
+    if (formattedConsentExpiry) {
+      label = `${label} ${formattedConsentExpiry}`;
     }
     const name = (patient && patient.name) || patientNameMap[pid] || '';
     const alert = {
@@ -1013,6 +1017,16 @@ function buildOverviewFromConsent_(patients, scope, patientNameMap, now, current
     }));
   }
   return { items };
+}
+
+function formatDateOnlyInternal_(value) {
+  const parsed = parseConsentDateInternal_(value);
+  if (!parsed) return '';
+  return [
+    String(parsed.getFullYear()).padStart(4, '0'),
+    String(parsed.getMonth() + 1).padStart(2, '0'),
+    String(parsed.getDate()).padStart(2, '0')
+  ].join('/');
 }
 
 function dashboardDebugLogLimited_(counterKey, label, payload) {

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -230,9 +230,9 @@ function testConsentOverviewMatchesPatientStatusTags() {
 
   const overviewItems = JSON.parse(JSON.stringify(result.overview.consentRelated.items));
   assert.deepStrictEqual(overviewItems, [
-    { patientId: '002', name: '期限超過未取得', subText: '⚠ 同意期限超過（1日超過）' },
-    { patientId: '001', name: '期限内未取得', subText: '同意期限（残27日）' },
-    { patientId: '005', name: '期限迫る未取得', subText: '同意期限（残27日）' }
+    { patientId: '002', name: '期限超過未取得', subText: '⚠ 同意期限超過（1日超過） 2025/01/31' },
+    { patientId: '001', name: '期限内未取得', subText: '同意期限（残27日） 2025/02/28' },
+    { patientId: '005', name: '期限迫る未取得', subText: '同意期限（残27日） 2025/02/28' }
   ], '上段同意ブロックは同意年月日から算出した期限と同意書取得確認で表示する');
 
   const patientsById = {};
@@ -1391,6 +1391,35 @@ function testConsentExpiredOver30DaysAlertsAreRoleFiltered() {
 }
 
 
+
+function testConsentOverviewSubTextUsesSlashDateWithoutIso() {
+  const ctx = createContext();
+  const result = ctx.getDashboardData({
+    user: { email: 'belltree@belltree1102.com', role: 'admin' },
+    now: new Date('2025-02-01T00:00:00Z'),
+    patientInfo: {
+      patients: {
+        '001': { name: 'ISO入力患者', raw: { '同意年月日': '2024-08-16' } }
+      },
+      warnings: []
+    },
+    notes: { notes: {}, warnings: [] },
+    aiReports: { reports: {}, warnings: [] },
+    invoices: { invoices: {}, warnings: [] },
+    treatmentLogs: { logs: [{ patientId: '001', timestamp: new Date('2025-01-20T00:00:00Z'), staffKeys: { email: 'staff@example.com' } }], warnings: [] },
+    responsible: { responsible: {}, warnings: [] },
+    unpaidAlerts: { alerts: [], warnings: [] },
+    tasksResult: { tasks: [], warnings: [] },
+    visitsResult: { today: { date: null, visits: [] }, previous: { date: null, visits: [] }, warnings: [] }
+  });
+
+  const item = JSON.parse(JSON.stringify((result.overview.consentRelated.items || [])[0] || null));
+  assert.ok(item, '同意 overview アイテムが1件作成される');
+  assert.ok(/\d{4}\/\d{2}\/\d{2}$/.test(item.subText), 'subText 末尾は YYYY/MM/DD 形式');
+  assert.ok(!/\d{4}-\d{2}-\d{2}T/.test(item.subText), 'subText に ISO 文字列を含めない');
+}
+
+
 (function run() {
   testAggregatesDashboardData();
   testPatientStatusTagsGeneration();
@@ -1424,5 +1453,6 @@ function testConsentExpiredOver30DaysAlertsAreRoleFiltered() {
   testSpreadsheetIsOpenedOnceAndPerfCheckIsLogged();
   testWarningsAreDedupedAndSetupFlagged();
   testConsentExpiredOver30DaysAlertsAreRoleFiltered();
+  testConsentOverviewSubTextUsesSlashDateWithoutIso();
   console.log('dashboardGetDashboardData tests passed');
 })();


### PR DESCRIPTION
### Motivation
- overview に ISO 形式の日時文字列を直接含めないようにし、バックエンドで `YYYY/MM/DD` 形式に統一して返すことで表示の一貫性を持たせる。
- フロントエンドのロジックは変更せず、同意判定や `diffDays` 判定など既存の同意ロジックには手を加えないようにする。

### Description
- `buildOverviewFromConsent_` の `subText` 生成で同意期限を `formatDateOnlyInternal_` を使って整形し、既存ラベルに `YYYY/MM/DD` を付与するように変更しました (`src/dashboard/api/getDashboardData.js`)。
- 日付整形用のヘルパー `formatDateOnlyInternal_` を追加して、内部で `parseConsentDateInternal_` を使って日付をパースし `YYYY/MM/DD` を返す実装を追加しました。
- 既存のテスト期待値を新仕様に合わせて更新し、`testConsentOverviewSubTextUsesSlashDateWithoutIso` テストを追加して `subText` が `YYYY/MM/DD` で終わることと ISO 文字列を含まないことを保証しました (`tests/dashboardGetDashboardData.test.js`)。
- 日付表示部分以外の同意ロジックや表示順序などには変更を加えていません。

### Testing
- 実行コマンド `node tests/dashboardGetDashboardData.test.js` を実行し、テストスイートは成功しました（出力: `dashboardGetDashboardData tests passed`）。
- 追加したテスト `testConsentOverviewSubTextUsesSlashDateWithoutIso` は `subText` の末尾が `YYYY/MM/DD` 形式であることと `ISO` 文字列が含まれないことを検証しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699551c588d48321b73760c5b02c2de6)