### PR TITLE
Format patients[].consentExpiry as YYYY/MM/DD in dashboard data

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -668,7 +668,7 @@ function buildDashboardPatients_(patientInfo, sources, allowedPatientIds) {
     const entry = {
       patientId,
       name: base.name || base.patientName || '',
-      consentExpiry: consentExpiryResolved.value == null ? '' : consentExpiryResolved.value,
+      consentExpiry: formatDateOnlyInternal_(consentExpiryDate),
       responsible: Object.prototype.hasOwnProperty.call(responsible, patientId) ? responsible[patientId] : null,
       invoiceUrl: Object.prototype.hasOwnProperty.call(invoices, patientId) ? invoices[patientId] : null,
       aiReportAt: Object.prototype.hasOwnProperty.call(aiReports, patientId) ? aiReports[patientId] : null,

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -102,7 +102,7 @@ function testAggregatesDashboardData() {
   assert.deepStrictEqual(normalizedPatient, {
     patientId: '001',
     name: '山田太郎',
-    consentExpiry: '2025-01-31T00:00:00.000Z',
+    consentExpiry: '2025/01/31',
     responsible: 'staff@example.com',
     invoiceUrl: 'https://example.com/invoice.pdf',
     aiReportAt: '2025-01-15 10:00',
@@ -124,6 +124,37 @@ function testAggregatesDashboardData() {
   assert.strictEqual(result.unpaidAlerts[0].patientId, '001');
   const warnings = JSON.parse(JSON.stringify(result.warnings)).sort();
   assert.deepStrictEqual(warnings, ['a1', 'i1', 'n1', 'p1', 'r1', 't1', 'u1', 'visit'].sort());
+}
+
+function testPatientConsentExpiryUsesSlashDateWithoutIso() {
+  const ctx = createContext();
+  const result = ctx.getDashboardData({
+    user: { email: 'belltree@belltree1102.com', role: 'admin' },
+    now: new Date('2025-02-01T00:00:00Z'),
+    patientInfo: {
+      patients: {
+        '001': { name: 'ISO形式患者', consentExpiry: '2026-05-30T15:00:00.000Z', raw: {} },
+        '002': { name: '同意日患者', raw: { '同意年月日': '2024-08-16' } }
+      },
+      warnings: []
+    },
+    notes: { notes: {}, warnings: [] },
+    aiReports: { reports: {}, warnings: [] },
+    invoices: { invoices: {}, warnings: [] },
+    treatmentLogs: { logs: [], warnings: [] },
+    responsible: { responsible: {}, warnings: [] },
+    unpaidAlerts: { alerts: [], warnings: [] },
+    tasksResult: { tasks: [], warnings: [] },
+    visitsResult: { today: { date: null, visits: [] }, previous: { date: null, visits: [] }, warnings: [] }
+  });
+
+  const expiries = (result.patients || []).map(patient => String(patient && patient.consentExpiry || ''));
+  assert.ok(expiries.length >= 2, '患者一覧に複数患者が含まれる');
+  expiries.forEach(expiry => {
+    if (!expiry) return;
+    assert.ok(/^\d{4}\/\d{2}\/\d{2}$/.test(expiry), `consentExpiry は YYYY/MM/DD 形式: ${expiry}`);
+    assert.ok(!/\d{4}-\d{2}-\d{2}T/.test(expiry), `consentExpiry に ISO 形式を含めない: ${expiry}`);
+  });
 }
 
 
@@ -1422,6 +1453,7 @@ function testConsentOverviewSubTextUsesSlashDateWithoutIso() {
 
 (function run() {
   testAggregatesDashboardData();
+  testPatientConsentExpiryUsesSlashDateWithoutIso();
   testPatientStatusTagsGeneration();
   testConsentOverviewMatchesPatientStatusTags();
   testEvaluateConsentStatusBoundaries();


### PR DESCRIPTION
### Motivation
- The patients list was emitting `consentExpiry` as ISO timestamps (e.g. `2026-05-30T15:00:00.000Z`) while the overview already displayed `YYYY/MM/DD`, causing inconsistent UI output.
- The change is intended to be minimal and only affect display formatting without altering consent-status or parsing logic.

### Description
- Use the existing helper `formatDateOnlyInternal_` when populating `patients[].consentExpiry` inside `buildDashboardPatients_` so the value becomes `YYYY/MM/DD` instead of raw ISO strings (`src/dashboard/api/getDashboardData.js`).
- Keep internal date parsing/logic unchanged by continuing to compute and pass `consentExpiryDate` for status evaluation and other calculations.
- Update an existing expectation in `tests/dashboardGetDashboardData.test.js` from an ISO string to the new slash-date string and add a new regression test `testPatientConsentExpiryUsesSlashDateWithoutIso` that asserts `patients[].consentExpiry` is `YYYY/MM/DD` and contains no ISO `T...Z` patterns.

### Testing
- Ran `node tests/dashboardGetDashboardData.test.js` which includes the new regression test, and the test suite passed.
- Verified that `overview` formatting and the internal consent-status/date-parsing logic remain unchanged by the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69955609651c832188ea6d052059137c)