### PR TITLE
fix: 請求書・領収書の受渡確認ウィンドウを当月末まで拡張

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -936,8 +936,7 @@ function isDashboardInvoiceConfirmationInWindow_(entry, currentMonthKey, tz) {
     dayKey = dashboardFormatDate_(ts, tz, 'yyyy-MM-dd');
   }
   if (dayKey.slice(0, 7) !== currentMonthKey) return false;
-  const day = Number(dayKey.slice(8, 10));
-  return day >= 1 && day <= 20;
+  return true;
 }
 
 function buildDashboardInvoiceSearchText_(entry) {

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -960,7 +960,6 @@ function testInvoiceUnconfirmedUsesPositiveConfirmationEvidence() {
       { patientId: '001', dateKey: '2025-01-10', searchText: '前月施術あり' },
       { patientId: '001', dateKey: '2025-02-05', searchText: '請求書・領収書を受け渡し済み（家族へ）' },
       { patientId: '002', dateKey: '2025-01-08', searchText: '前月施術あり' },
-      { patientId: '002', dateKey: '2025-02-22', searchText: '請求書・領収書を受け渡し済み' },
       { patientId: '003', dateKey: '2025-02-01', searchText: '当月のみ' }
     ],
     { notes: {} },
@@ -970,8 +969,36 @@ function testInvoiceUnconfirmedUsesPositiveConfirmationEvidence() {
     'Asia/Tokyo'
   );
 
-  assert.strictEqual(result.items.length, 1, '前月施術があり証跡がない患者のみ未対応になる');
+  assert.strictEqual(result.items.length, 1, '20日以前の証跡は従来どおり確認済み扱いになる');
   assert.strictEqual(result.items[0].patientId, '002');
+}
+
+function testInvoiceUnconfirmedTreatsConfirmationAfter21stAsInWindow() {
+  const ctx = createContext({
+    Utilities: {
+      formatDate: (date, _tz, fmt) => {
+        const iso = new Date(date).toISOString();
+        if (fmt === 'yyyy-MM') return iso.slice(0, 7);
+        if (fmt === 'yyyy-MM-dd') return iso.slice(0, 10);
+        return iso;
+      }
+    }
+  });
+
+  const result = ctx.buildOverviewFromInvoiceUnconfirmed_(
+    {},
+    [
+      { patientId: '001', dateKey: '2025-01-10', searchText: '前月施術あり' },
+      { patientId: '001', dateKey: '2025-02-22', searchText: '請求書・領収書を受け渡し済み' }
+    ],
+    { notes: {} },
+    { patientIds: new Set(['001']), applyFilter: true },
+    { '001': '患者A' },
+    new Date('2025-02-10T00:00:00Z'),
+    'Asia/Tokyo'
+  );
+
+  assert.strictEqual(result.items.length, 0, '21日以降の受渡記録も当月であれば確認済み扱いにする');
 }
 
 function testInvoiceUnconfirmedIgnoresDisplayTargetFilter() {
@@ -1475,6 +1502,7 @@ function testConsentOverviewSubTextUsesSlashDateWithoutIso() {
   testVisitSummaryStaffScopeLookbackIsFixedTo50Days();
   testVisitSummaryHasOnlyThreeKeysAndPastSlotsAreBeforeToday();
   testInvoiceUnconfirmedUsesPositiveConfirmationEvidence();
+  testInvoiceUnconfirmedTreatsConfirmationAfter21stAsInWindow();
   testInvoiceUnconfirmedIgnoresDisplayTargetFilter();
   testInvoiceUnconfirmedShouldDetectPatientWithOnlyPreviousMonthTreatment();
   testInvoiceUnconfirmedExcludesMedicalAssistancePatient();


### PR DESCRIPTION
### Motivation
- 受渡確認ウィンドウを「当月1日〜20日」から「当月1日〜末日」に拡張して、当月中の21日以降の受渡記録も確認済み扱いにする必要がありました。 

### Description
- `src/dashboard/api/getDashboardData.js` の `isDashboardInvoiceConfirmationInWindow_` を変更し、日付の上限判定 (`day <= 20`) を削除して当月一致のみで判定するようにしました。 
- `tests/dashboardGetDashboardData.test.js` を更新し、既存の 20 日以前の挙動を検証するテストを維持しつつ、21 日以降（例: `2025-02-22`）の受渡記録が当月であれば確認済み扱いになることを検証する新規テスト `testInvoiceUnconfirmedTreatsConfirmationAfter21stAsInWindow` を追加しました。 
- 本変更はロールスコープ（50日制限）や母集団作成ロジック、完全一致文字列検索ロジックには手を加えていません。 

### Testing
- `node tests/dashboardGetDashboardData.test.js` を実行してテストスイートを走らせ、該当テストを含めて全体が実行され `dashboardGetDashboardData tests passed` と表示されて成功しました。 
- 変更対象のユニットテスト（既存の確認済みケースと新規の21日以降ケース）は両方とも成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995602f1c748321960b53801b290cb4)