### PR TITLE
請求書受渡確認の判定を句点有無の2パターンに限定

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -838,7 +838,7 @@ function buildOverviewFromInvoiceUnconfirmed_(invoices, treatmentLogs, notes, sc
   const targetNow = dashboardCoerceDate_(now) || new Date();
   const previousMonthKey = dashboardFormatDate_(new Date(targetNow.getFullYear(), targetNow.getMonth() - 1, 1), tz, 'yyyy-MM');
   const currentMonthKey = dashboardFormatDate_(targetNow, tz, 'yyyy-MM');
-  const confirmationPhrase = '請求書・領収書を受け渡し済み';
+  const confirmationPhrases = ['請求書・領収書を受け渡し済み', '請求書・領収書を受け渡し済み。'];
   const logBillingDebug = (message, details) => {
     const payload = details ? ` ${details}` : '';
     const line = `[billing-debug] ${message}${payload}`;
@@ -875,7 +875,7 @@ function buildOverviewFromInvoiceUnconfirmed_(invoices, treatmentLogs, notes, sc
     if (!isDashboardInvoiceConfirmationInWindow_(entry, currentMonthKey, tz)) return;
     inBillingWindowPatients.add(pid);
     const searchable = buildDashboardInvoiceSearchText_(entry);
-    if (searchable.indexOf(confirmationPhrase) >= 0) confirmedPatients.add(pid);
+    if (confirmationPhrases.some(phrase => searchable.indexOf(phrase) >= 0)) confirmedPatients.add(pid);
   });
 
   const noteEntries = notes && notes.notes ? notes.notes : {};
@@ -886,7 +886,7 @@ function buildOverviewFromInvoiceUnconfirmed_(invoices, treatmentLogs, notes, sc
     if (!isDashboardInvoiceConfirmationInWindow_(note, currentMonthKey, tz)) return;
     inBillingWindowPatients.add(pid);
     const searchable = buildDashboardInvoiceSearchText_(note);
-    if (searchable.indexOf(confirmationPhrase) >= 0) confirmedPatients.add(pid);
+    if (confirmationPhrases.some(phrase => searchable.indexOf(phrase) >= 0)) confirmedPatients.add(pid);
   });
 
   logBillingDebug(`inBillingWindow count=${inBillingWindowPatients.size}`);

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -942,7 +942,7 @@ function testVisitSummaryHasOnlyThreeKeysAndPastSlotsAreBeforeToday() {
 }
 
 
-function testInvoiceUnconfirmedUsesPositiveConfirmationEvidence() {
+function testInvoiceUnconfirmedAcceptsConfirmationWithoutPeriod() {
   const ctx = createContext({
     Utilities: {
       formatDate: (date, _tz, fmt) => {
@@ -958,19 +958,73 @@ function testInvoiceUnconfirmedUsesPositiveConfirmationEvidence() {
     {},
     [
       { patientId: '001', dateKey: '2025-01-10', searchText: '前月施術あり' },
-      { patientId: '001', dateKey: '2025-02-05', searchText: '請求書・領収書を受け渡し済み（家族へ）' },
-      { patientId: '002', dateKey: '2025-01-08', searchText: '前月施術あり' },
-      { patientId: '003', dateKey: '2025-02-01', searchText: '当月のみ' }
+      { patientId: '001', dateKey: '2025-02-05', searchText: '請求書・領収書を受け渡し済み' }
     ],
     { notes: {} },
-    { patientIds: new Set(['001', '002', '003']), applyFilter: true },
-    { '001': '患者A', '002': '患者B', '003': '患者C' },
+    { patientIds: new Set(['001']), applyFilter: true },
+    { '001': '患者A' },
     new Date('2025-02-10T00:00:00Z'),
     'Asia/Tokyo'
   );
 
-  assert.strictEqual(result.items.length, 1, '20日以前の証跡は従来どおり確認済み扱いになる');
-  assert.strictEqual(result.items[0].patientId, '002');
+  assert.strictEqual(result.items.length, 0, '句点なし文言は確認済み扱いになる');
+}
+
+function testInvoiceUnconfirmedAcceptsConfirmationWithPeriod() {
+  const ctx = createContext({
+    Utilities: {
+      formatDate: (date, _tz, fmt) => {
+        const iso = new Date(date).toISOString();
+        if (fmt === 'yyyy-MM') return iso.slice(0, 7);
+        if (fmt === 'yyyy-MM-dd') return iso.slice(0, 10);
+        return iso;
+      }
+    }
+  });
+
+  const result = ctx.buildOverviewFromInvoiceUnconfirmed_(
+    {},
+    [
+      { patientId: '001', dateKey: '2025-01-10', searchText: '前月施術あり' },
+      { patientId: '001', dateKey: '2025-02-05', searchText: '請求書・領収書を受け渡し済み。' }
+    ],
+    { notes: {} },
+    { patientIds: new Set(['001']), applyFilter: true },
+    { '001': '患者A' },
+    new Date('2025-02-10T00:00:00Z'),
+    'Asia/Tokyo'
+  );
+
+  assert.strictEqual(result.items.length, 0, '句点あり文言は確認済み扱いになる');
+}
+
+function testInvoiceUnconfirmedIgnoresConsentHandoutRecord() {
+  const ctx = createContext({
+    Utilities: {
+      formatDate: (date, _tz, fmt) => {
+        const iso = new Date(date).toISOString();
+        if (fmt === 'yyyy-MM') return iso.slice(0, 7);
+        if (fmt === 'yyyy-MM-dd') return iso.slice(0, 10);
+        return iso;
+      }
+    }
+  });
+
+  const result = ctx.buildOverviewFromInvoiceUnconfirmed_(
+    {},
+    [
+      { patientId: '001', dateKey: '2025-01-10', searchText: '前月施術あり' },
+      { patientId: '001', dateKey: '2025-02-05', searchText: '同意書受渡。' }
+    ],
+    { notes: {} },
+    { patientIds: new Set(['001']), applyFilter: true },
+    { '001': '患者A' },
+    new Date('2025-02-10T00:00:00Z'),
+    'Asia/Tokyo'
+  );
+
+  assert.strictEqual(result.items.length, 1, '同意書受渡記録は請求書受渡確認として扱わない');
+  assert.strictEqual(result.items[0].patientId, '001');
 }
 
 function testInvoiceUnconfirmedTreatsConfirmationAfter21stAsInWindow() {
@@ -1501,7 +1555,9 @@ function testConsentOverviewSubTextUsesSlashDateWithoutIso() {
   testVisitSummaryWorksWhenVisiblePatientIdsBecomesEmpty();
   testVisitSummaryStaffScopeLookbackIsFixedTo50Days();
   testVisitSummaryHasOnlyThreeKeysAndPastSlotsAreBeforeToday();
-  testInvoiceUnconfirmedUsesPositiveConfirmationEvidence();
+  testInvoiceUnconfirmedAcceptsConfirmationWithoutPeriod();
+  testInvoiceUnconfirmedAcceptsConfirmationWithPeriod();
+  testInvoiceUnconfirmedIgnoresConsentHandoutRecord();
   testInvoiceUnconfirmedTreatsConfirmationAfter21stAsInWindow();
   testInvoiceUnconfirmedIgnoresDisplayTargetFilter();
   testInvoiceUnconfirmedShouldDetectPatientWithOnlyPreviousMonthTreatment();


### PR DESCRIPTION
### Motivation
- 請求書受渡の確認判定が単一の文字列に依存しており、句点あり/なしの表記差で誤判定が起きるため、句点の有無両方を明示的に判定する必要があった。

### Description
- `src/dashboard/api/getDashboardData.js` の `confirmationPhrase` を `confirmationPhrases`（`['請求書・領収書を受け渡し済み', '請求書・領収書を受け渡し済み。']`）に置換し、`some()` でいずれかに一致する場合に確認済み扱いとするよう変更しました。
- 判定は treatment logs 側と notes 側の両方に同一条件で適用しています（判定ロジック自体は変更していません）。
- `tests/dashboardGetDashboardData.test.js` に以下のテストを追加・更新しました: `testInvoiceUnconfirmedAcceptsConfirmationWithoutPeriod`, `testInvoiceUnconfirmedAcceptsConfirmationWithPeriod`, `testInvoiceUnconfirmedIgnoresConsentHandoutRecord` およびテスト呼び出しの順序調整。
- 変更対象ファイルは `src/dashboard/api/getDashboardData.js` と `tests/dashboardGetDashboardData.test.js` です。

### Testing
- 実行コマンド `node tests/dashboardGetDashboardData.test.js` による自動テストを実行した結果、テストスイートは成功し `dashboardGetDashboardData tests passed` が出力されました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995642596ac83218b5868483c8db787)