### PR TITLE
Detect invoice handoff from treatment observation (所見)

### DIFF
--- a/src/dashboard/api/getDashboardData.js
+++ b/src/dashboard/api/getDashboardData.js
@@ -959,6 +959,7 @@ function buildDashboardInvoiceSearchText_(entry) {
     entry.body,
     entry.content,
     entry.summary,
+    entry.observation,
     entry.searchText
   ];
   return candidates

--- a/src/dashboard/data/loadTreatmentLogs.js
+++ b/src/dashboard/data/loadTreatmentLogs.js
@@ -73,6 +73,7 @@ function loadTreatmentLogsUncached_(options) {
   const colStaffName = dashboardResolveColumn_(headers, ['施術者', '担当者', '担当', 'スタッフ名', 'staffName', 'staff'], 0);
   const colStaffEmail = dashboardResolveColumn_(headers, ['メール', '担当メール', 'email', 'mail', 'createdbyemail'], 0);
   const colStaffId = dashboardResolveColumn_(headers, ['担当者ID', 'スタッフID', 'staffId', 'staffid'], 0);
+  const colObservation = dashboardResolveColumn_(headers, ['所見', '観察', 'observation'], 0);
   const searchableColumns = [
     dashboardResolveColumn_(headers, ['施術内容', '内容', '記録', 'メモ', 'ノート', '備考', 'コメント', '対応内容', '申し送り', '自由記述', 'text', 'note', 'memo', 'comment', 'body', 'content'], 0),
     dashboardResolveColumn_(headers, ['SOAP', 'S', 'O', 'A', 'P'], 0)
@@ -202,7 +203,8 @@ function loadTreatmentLogsUncached_(options) {
     colCreatedBy,
     colStaffName,
     colStaffEmail,
-    colStaffId
+    colStaffId,
+    colObservation
   ].concat(searchableColumns)
     .filter(function(col, index, arr) { return !!col && arr.indexOf(col) === index; });
 
@@ -279,6 +281,7 @@ function loadTreatmentLogsUncached_(options) {
     const staffEmailRaw = colStaffEmail ? String(readDisplay(colStaffEmail) || readValue(colStaffEmail) || '').trim() : '';
     const staffIdRaw = colStaffId ? String(readDisplay(colStaffId) || readValue(colStaffId) || '').trim() : '';
     const dateKey = dashboardFormatDate_(timestamp, tz, 'yyyy-MM-dd');
+    const observation = colObservation ? String(readDisplay(colObservation) || readValue(colObservation) || '').trim() : '';
     const searchText = searchableColumns
       .map(function(col) {
         return String(readDisplay(col) || readValue(col) || '').trim();
@@ -310,6 +313,7 @@ function loadTreatmentLogsUncached_(options) {
       },
       timestamp,
       dateKey,
+      observation,
       searchText
     };
 

--- a/tests/dashboardGetDashboardData.test.js
+++ b/tests/dashboardGetDashboardData.test.js
@@ -996,6 +996,64 @@ function testInvoiceUnconfirmedAcceptsConfirmationWithPeriod() {
   assert.strictEqual(result.items.length, 0, '句点あり文言は確認済み扱いになる');
 }
 
+
+function testInvoiceUnconfirmedAcceptsConfirmationFromObservationField() {
+  const ctx = createContext({
+    Utilities: {
+      formatDate: (date, _tz, fmt) => {
+        const iso = new Date(date).toISOString();
+        if (fmt === 'yyyy-MM') return iso.slice(0, 7);
+        if (fmt === 'yyyy-MM-dd') return iso.slice(0, 10);
+        return iso;
+      }
+    }
+  });
+
+  const result = ctx.buildOverviewFromInvoiceUnconfirmed_(
+    {},
+    [
+      { patientId: '001', dateKey: '2025-01-10', searchText: '前月施術あり' },
+      { patientId: '001', dateKey: '2025-02-05', observation: '請求書・領収書を受け渡し済み。' }
+    ],
+    { notes: {} },
+    { patientIds: new Set(['001']), applyFilter: true },
+    { '001': '患者A' },
+    new Date('2025-02-10T00:00:00Z'),
+    'Asia/Tokyo'
+  );
+
+  assert.strictEqual(result.items.length, 0, '所見の請求書受渡記録は確認済み扱いになる');
+}
+
+function testInvoiceUnconfirmedIgnoresConsentHandoutRecordInObservationField() {
+  const ctx = createContext({
+    Utilities: {
+      formatDate: (date, _tz, fmt) => {
+        const iso = new Date(date).toISOString();
+        if (fmt === 'yyyy-MM') return iso.slice(0, 7);
+        if (fmt === 'yyyy-MM-dd') return iso.slice(0, 10);
+        return iso;
+      }
+    }
+  });
+
+  const result = ctx.buildOverviewFromInvoiceUnconfirmed_(
+    {},
+    [
+      { patientId: '001', dateKey: '2025-01-10', searchText: '前月施術あり' },
+      { patientId: '001', dateKey: '2025-02-05', observation: '同意書を受け渡し済み。' }
+    ],
+    { notes: {} },
+    { patientIds: new Set(['001']), applyFilter: true },
+    { '001': '患者A' },
+    new Date('2025-02-10T00:00:00Z'),
+    'Asia/Tokyo'
+  );
+
+  assert.strictEqual(result.items.length, 1, '所見が同意書受渡のみの場合は請求書確認済み扱いにしない');
+  assert.strictEqual(result.items[0].patientId, '001');
+}
+
 function testInvoiceUnconfirmedIgnoresConsentHandoutRecord() {
   const ctx = createContext({
     Utilities: {
@@ -1555,7 +1613,9 @@ function testConsentOverviewSubTextUsesSlashDateWithoutIso() {
   testVisitSummaryHasOnlyThreeKeysAndPastSlotsAreBeforeToday();
   testInvoiceUnconfirmedAcceptsConfirmationWithoutPeriod();
   testInvoiceUnconfirmedAcceptsConfirmationWithPeriod();
+  testInvoiceUnconfirmedAcceptsConfirmationFromObservationField();
   testInvoiceUnconfirmedIgnoresConsentHandoutRecord();
+  testInvoiceUnconfirmedIgnoresConsentHandoutRecordInObservationField();
   testInvoiceUnconfirmedTreatsConfirmationAfter21stAsInWindow();
   testInvoiceUnconfirmedIgnoresDisplayTargetFilter();
   testInvoiceUnconfirmedShouldDetectPatientWithOnlyPreviousMonthTreatment();


### PR DESCRIPTION
### Motivation
- Invoice handoff confirmations recorded in the treatment "所見" (observation) column were not being detected, causing `completedByText count=0` and patients to remain in the billing target list despite the note.

### Description
- Resolve and read the 所見 column in `loadTreatmentLogsUncached_` and attach it to each treatment log as `observation` so the field is available on `entry` objects (`src/dashboard/data/loadTreatmentLogs.js`).
- Add `entry.observation` to the searchable candidates in `buildDashboardInvoiceSearchText_` so confirmation phrase matching scans the observation text as well (`src/dashboard/api/getDashboardData.js`).
- Add two regression tests covering observation-based detection: one where observation contains `請求書・領収書を受け渡し済み。` (should mark completed) and one where observation contains only `同意書を受け渡し済み。` (should not mark completed) (`tests/dashboardGetDashboardData.test.js`).
- Kept all non-search logic unchanged (month detection, 50-day scope, `prevMonthPatientIds`, `inBillingWindow`, cache logic and `buildOverviewFromInvoiceUnconfirmed_` structure) — change limited to expanding searchable text inputs.

### Testing
- Ran `node tests/dashboardGetDashboardData.test.js` and the test suite passed successfully.
- Ran `node tests/dashboardLoadTreatmentLogsScanOptimization.test.js` and `node tests/dashboardGetDashboardDataOptions.test.js` and both suites passed successfully.
- Verified debug logs show `completedByText` increases when observation contains the invoice handoff phrase and that patients are excluded from the unconfirmed invoice list accordingly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69956f881cc48321b1ba3efaadaebb7f)