### PR TITLE
タイムライン訪問の患者番号バッジ重複表示を削除

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -564,12 +564,6 @@ function renderTimelineSection(container, label, sectionData) {
       badge.textContent = hasNote ? '報告書作成ヒントあり' : '報告書作成ヒント未入力';
       meta.appendChild(badge);
     }
-    if (v.patientId) {
-      const idBadge = document.createElement('span');
-      idBadge.className = 'badge';
-      idBadge.textContent = v.patientId;
-      meta.appendChild(idBadge);
-    }
     body.appendChild(meta);
     row.appendChild(body);
 


### PR DESCRIPTION
### Motivation
- タイムライン（当日・前日）の各訪問行で患者番号が名前横の `氏名（患者番号）` と下段のバッジで二重に表示されており、下段バッジを削除して表示を一箇所にしたい。これにより UI の重複表示を解消する。 

### Description
- UI テンプレートの描画のみを変更し、`src/dashboard.html` の `renderTimelineSection` 内で訪問メタ行に追加していた患者番号バッジ生成ブロック（`if (v.patientId) { const idBadge = document.createElement('span'); ... }`）を削除しました。 
- `formatVisitPatientLabel_` による `氏名（患者番号）` 表示はそのまま維持しています。 
- データ取得や ID 生成、スコープ関連のロジック（例: `getTodayVisits` / `getDashboardData` 等）には一切変更を加えていません。 

### Testing
- `node tests/dashboardNavigationLinks.test.js` を実行して成功しました。 
- Playwright を使ったローカル HTML スクリーンショット取得を試みましたが `file://` 経由の参照で `ERR_FILE_NOT_FOUND` となり取得できなかったためその検証は失敗しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995757547f883219ca961078665f52a)